### PR TITLE
Fix safety_attributes merging issue

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_utils.py
@@ -152,4 +152,12 @@ def get_generation_info(
     if stream:
         # Remove non-streamable types, like bools.
         info.pop("is_blocked")
+
+    # NOTE:
+    # "safety_attributes" can contain different values for the same keys
+    # for each generation. Put it in a list, so it can be merged later by merge_dicts().
+    #
+    safety_attributes = info.get("safety_attributes") or {}
+    info["safety_attributes"] = [safety_attributes]
+
     return info


### PR DESCRIPTION
- **Description:** `VertexAI` can generate different safety attributes for each chunk, and `merge_dicts()` in the `ChatGenerationChunk.__add__()` can't merge that. This PR converts `generation_info.safety_attributes` to a list so `merge_dicts()` can merge the generation.
- **Issue:** [#17376](https://github.com/langchain-ai/langchain/issues/17376)

How to reproduce:
```python
    from langchain_core.prompts import PromptTemplate
    from langchain_core.output_parsers import StrOutputParser
    from langchain_google_vertexai import ChatVertexAI

    prompt = PromptTemplate.from_template("Tell me a short, funny health story in 100 words.")
    chain = prompt | ChatVertexAI() | StrOutputParser()

    for c in chain.stream({}):
        print(">", c)
```
`health` keyword should trigger `safety_attributes` generating.