### PR TITLE
Add Model garden class to handle Llama2 interactions

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/llms.py
+++ b/libs/vertexai/langchain_google_vertexai/llms.py
@@ -609,3 +609,39 @@ class VertexAIModelGarden(_VertexAIBase, BaseLLM):
             endpoint=self.endpoint_path, instances=instances
         )
         return self._parse_response(response)
+
+
+class VertexAIModelGardenLlama2(VertexAIModelGarden):
+    """Llama2-7b models served from Vertex AI Model Garden."""
+
+    allowed_model_args: Optional[List[str]] = [
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+    ]
+    max_tokens: Optional[int]
+    temperature: Optional[float]
+    top_p: Optional[float]
+    top_k: Optional[int]
+
+    def _prepare_request(self, *args, **kwargs):
+        if self.allowed_model_args:
+            for possible_kwarg in self.allowed_model_args:
+                if hasattr(self, possible_kwarg):
+                    if (val := getattr(self, possible_kwarg)) is not None:
+                        kwargs[possible_kwarg] = val
+
+        res = super()._prepare_request(*args, **kwargs)
+        return res
+
+    def _parse_response(self, predictions) -> LLMResult:
+        generations: List[List[Generation]] = []
+        for result in predictions.predictions:
+            if isinstance(result, str) and "Output:" in result:
+                _, output = result.split("Output:", 1)
+                generations.append([Generation(text=self._parse_prediction(output))])
+            else:
+                ValueError(f"Model did not produce expected Llama2 response: {result=}")
+
+        return LLMResult(generations=generations)


### PR DESCRIPTION
Llama2 models hosted on VertexAI return a response object that is parsed incorrectly by the generic VertexAIModelGarden class. Each character of the response is treated as a "prediction", and as such the full response text is not correctly extracted.

The model response also includes the original prompt which needs to be stripped, along with the keywords "Prompt:" and "Output:".

This Llama2 specific model introduces the following behaviors:

- Process full text returned by the model

- Extract only the newly generated text from the response

- Support passing in model parameter values by setting corresponding props on the object, this is a behavior that the core VertexAI objects support, so this adds consistency and good dev. "ergonomics"

![Screenshot 2024-02-27 at 11 43 50 AM](https://github.com/langchain-ai/langchain-google/assets/53634432/7e452fa0-690b-452e-b295-aafaf0d60342)

![Screenshot 2024-02-27 at 11 44 35 AM](https://github.com/langchain-ai/langchain-google/assets/53634432/9954e426-9343-43f1-93c5-0f152a8089a0)

![Screenshot 2024-02-27 at 11 45 07 AM](https://github.com/langchain-ai/langchain-google/assets/53634432/68c746f3-0d0c-4ce1-a749-57c156303a42)
