### PR TITLE
feat: add support for multimodal model and add embed_image

### DIFF
--- a/libs/vertexai/.gitignore
+++ b/libs/vertexai/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.mypy_cache_test

--- a/libs/vertexai/langchain_google_vertexai/embeddings.py
+++ b/libs/vertexai/langchain_google_vertexai/embeddings.py
@@ -53,7 +53,8 @@ class VertexAIEmbeddings(_VertexAICommon, Embeddings):
             values["model_name"] = "textembedding-gecko@001"
         if cls._is_multimodal_model(values["model_name"]):
             values["client"] = MultiModalEmbeddingModel.from_pretrained(
-                values["model_name"])
+                values["model_name"]
+            )
         else:
             values["client"] = TextEmbeddingModel.from_pretrained(values["model_name"])
         return values

--- a/libs/vertexai/tests/integration_tests/conftest.py
+++ b/libs/vertexai/tests/integration_tests/conftest.py
@@ -2,7 +2,7 @@ import base64
 
 import pytest
 from _pytest.tmpdir import TempPathFactory
-from vertexai.vision_models import Image
+from vertexai.vision_models import Image  # type: ignore
 
 
 @pytest.fixture

--- a/libs/vertexai/tests/integration_tests/conftest.py
+++ b/libs/vertexai/tests/integration_tests/conftest.py
@@ -32,7 +32,7 @@ def base64_image() -> str:
 
 @pytest.fixture
 def tmp_image(tmp_path_factory: TempPathFactory, base64_image) -> str:
-    img_data = base64.b64decode(base64_image.split(',')[1])
+    img_data = base64.b64decode(base64_image.split(",")[1])
     image = Image(image_bytes=img_data)
     fn = tmp_path_factory.mktemp("data") / "img.png"
     image.save(str(fn))

--- a/libs/vertexai/tests/integration_tests/conftest.py
+++ b/libs/vertexai/tests/integration_tests/conftest.py
@@ -1,0 +1,39 @@
+import base64
+
+import pytest
+from _pytest.tmpdir import TempPathFactory
+from vertexai.vision_models import Image
+
+
+@pytest.fixture
+def base64_image() -> str:
+    return (
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAA"
+        "BHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3"
+        "d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBap"
+        "ySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnx"
+        "BwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXr"
+        "CDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD"
+        "1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQD"
+        "ry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPs"
+        "gxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96Cu"
+        "tRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOM"
+        "OVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWqua"
+        "ZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYS"
+        "Ub3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6E"
+        "hOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oW"
+        "VeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmH"
+        "rwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz"
+        "8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66Pf"
+        "yuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UN"
+        "z8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+    )
+
+
+@pytest.fixture
+def tmp_image(tmp_path_factory: TempPathFactory, base64_image) -> str:
+    img_data = base64.b64decode(base64_image.split(',')[1])
+    image = Image(image_bytes=img_data)
+    fn = tmp_path_factory.mktemp("data") / "img.png"
+    image.save(str(fn))
+    return str(fn)

--- a/libs/vertexai/tests/integration_tests/test_embeddings.py
+++ b/libs/vertexai/tests/integration_tests/test_embeddings.py
@@ -81,18 +81,21 @@ def test_warning(caplog: pytest.LogCaptureFixture) -> None:
     assert record.message == expected_message
 
 
+@pytest.mark.release
 def test_langchain_google_vertexai_image_embeddings(tmp_image) -> None:
     model = VertexAIEmbeddings(model_name="multimodalembedding")
     output = model.embed_image(tmp_image)
     assert len(output) == 1408
 
 
+@pytest.mark.release
 def test_langchain_google_vertexai_text_model() -> None:
     embeddings_model = VertexAIEmbeddings(model_name="textembedding-gecko@001")
     assert isinstance(embeddings_model.client, TextEmbeddingModel)
     assert embeddings_model.model_type == GoogleEmbeddingModelType.TEXT
 
 
+@pytest.mark.release
 def test_langchain_google_vertexai_multimodal_model() -> None:
     embeddings_model = VertexAIEmbeddings(model_name="multimodalembedding@001")
     assert isinstance(embeddings_model.client, MultiModalEmbeddingModel)

--- a/libs/vertexai/tests/integration_tests/test_embeddings.py
+++ b/libs/vertexai/tests/integration_tests/test_embeddings.py
@@ -4,12 +4,12 @@ Your end-user credentials would be used to make the calls (make sure you've run
 `gcloud auth login` first).
 """
 import pytest
-from vertexai.language_models import TextEmbeddingModel
-from vertexai.vision_models import MultiModalEmbeddingModel
+from vertexai.language_models import TextEmbeddingModel  # type: ignore
+from vertexai.vision_models import MultiModalEmbeddingModel  # type: ignore
 
 from langchain_google_vertexai.embeddings import (
-    VertexAIEmbeddings,
     GoogleEmbeddingModelType,
+    VertexAIEmbeddings,
 )
 
 

--- a/libs/vertexai/tests/integration_tests/test_embeddings.py
+++ b/libs/vertexai/tests/integration_tests/test_embeddings.py
@@ -4,6 +4,8 @@ Your end-user credentials would be used to make the calls (make sure you've run
 `gcloud auth login` first).
 """
 import pytest
+from vertexai.language_models import TextEmbeddingModel
+from vertexai.vision_models import MultiModalEmbeddingModel
 
 from langchain_google_vertexai.embeddings import VertexAIEmbeddings
 
@@ -80,3 +82,15 @@ def test_langchain_google_vertexai_image_embeddings(tmp_image) -> None:
     model = VertexAIEmbeddings(model_name="multimodalembedding")
     output = model.embed_image(tmp_image)
     assert len(output) == 1408
+
+
+def test_langchain_google_vertexai_text_model() -> None:
+    embeddings_model = VertexAIEmbeddings(model_name="textembedding-gecko@001")
+    assert isinstance(embeddings_model.client, TextEmbeddingModel)
+    assert not embeddings_model._is_multimodal_model(embeddings_model.model_name)
+
+
+def test_langchain_google_vertexai_multimodal_model() -> None:
+    embeddings_model = VertexAIEmbeddings(model_name="multimodalembedding@001")
+    assert isinstance(embeddings_model.client, MultiModalEmbeddingModel)
+    assert embeddings_model._is_multimodal_model(embeddings_model.model_name)

--- a/libs/vertexai/tests/integration_tests/test_embeddings.py
+++ b/libs/vertexai/tests/integration_tests/test_embeddings.py
@@ -7,7 +7,10 @@ import pytest
 from vertexai.language_models import TextEmbeddingModel
 from vertexai.vision_models import MultiModalEmbeddingModel
 
-from langchain_google_vertexai.embeddings import VertexAIEmbeddings
+from langchain_google_vertexai.embeddings import (
+    VertexAIEmbeddings,
+    GoogleEmbeddingModelType,
+)
 
 
 @pytest.mark.release
@@ -87,10 +90,10 @@ def test_langchain_google_vertexai_image_embeddings(tmp_image) -> None:
 def test_langchain_google_vertexai_text_model() -> None:
     embeddings_model = VertexAIEmbeddings(model_name="textembedding-gecko@001")
     assert isinstance(embeddings_model.client, TextEmbeddingModel)
-    assert not embeddings_model._is_multimodal_model(embeddings_model.model_name)
+    assert embeddings_model.model_type == GoogleEmbeddingModelType.TEXT
 
 
 def test_langchain_google_vertexai_multimodal_model() -> None:
     embeddings_model = VertexAIEmbeddings(model_name="multimodalembedding@001")
     assert isinstance(embeddings_model.client, MultiModalEmbeddingModel)
-    assert embeddings_model._is_multimodal_model(embeddings_model.model_name)
+    assert embeddings_model.model_type == GoogleEmbeddingModelType.MULTIMODAL

--- a/libs/vertexai/tests/integration_tests/test_embeddings.py
+++ b/libs/vertexai/tests/integration_tests/test_embeddings.py
@@ -74,3 +74,9 @@ def test_warning(caplog: pytest.LogCaptureFixture) -> None:
         "Feb-01-2024. Currently the default is set to textembedding-gecko@001"
     )
     assert record.message == expected_message
+
+
+def test_langchain_google_vertexai_image_embeddings(tmp_image) -> None:
+    model = VertexAIEmbeddings(model_name="multimodalembedding")
+    output = model.embed_image(tmp_image)
+    assert len(output) == 1408

--- a/libs/vertexai/tests/integration_tests/test_vision_models.py
+++ b/libs/vertexai/tests/integration_tests/test_vision_models.py
@@ -131,28 +131,3 @@ def test_vertex_ai_image_generation_and_edition():
 
     response = editor.invoke(messages)
     assert isinstance(response, AIMessage)
-
-
-@pytest.fixture
-def base64_image() -> str:
-    return (
-        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAA"
-        "BHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3"
-        "d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBap"
-        "ySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnx"
-        "BwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXr"
-        "CDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD"
-        "1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQD"
-        "ry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPs"
-        "gxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96Cu"
-        "tRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOM"
-        "OVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWqua"
-        "ZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYS"
-        "Ub3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6E"
-        "hOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oW"
-        "VeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmH"
-        "rwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz"
-        "8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66Pf"
-        "yuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UN"
-        "z8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
-    )

--- a/libs/vertexai/tests/unit_tests/test_embeddings.py
+++ b/libs/vertexai/tests/unit_tests/test_embeddings.py
@@ -1,0 +1,39 @@
+import pytest
+from vertexai.language_models import TextEmbeddingModel
+from vertexai.vision_models import MultiModalEmbeddingModel
+
+from langchain_google_vertexai import VertexAIEmbeddings
+
+
+def test_langchain_google_vertexai_text_model() -> None:
+    embeddings_model = VertexAIEmbeddings(model_name="textembedding-gecko@001")
+    assert isinstance(embeddings_model.client, TextEmbeddingModel)
+    assert not embeddings_model._is_multimodal_model(embeddings_model.model_name)
+
+
+def test_langchain_google_vertexai_multimodal_model() -> None:
+    embeddings_model = VertexAIEmbeddings(model_name="multimodalembedding@001")
+    assert isinstance(embeddings_model.client, MultiModalEmbeddingModel)
+    assert embeddings_model._is_multimodal_model(embeddings_model.model_name)
+
+
+def test_langchain_google_vertexai_embed_image_multimodal_only() -> None:
+    embeddings_model = VertexAIEmbeddings(model_name="textembedding-gecko@001")
+    with pytest.raises(NotImplementedError) as e:
+        embeddings_model.embed_image("test")
+        assert e.value == "Only supported for multimodal models"
+
+
+def test_langchain_google_vertexai_embed_documents_text_only() -> None:
+    embeddings_model = VertexAIEmbeddings(model_name="multimodalembedding@001")
+    with pytest.raises(NotImplementedError) as e:
+        embeddings_model.embed_documents(["test"])
+        assert e.value == "Not supported for multimodal models"
+
+
+def test_langchain_google_vertexai_embed_query_text_only() -> None:
+    embeddings_model = VertexAIEmbeddings(model_name="multimodalembedding@001")
+    with pytest.raises(NotImplementedError) as e:
+        embeddings_model.embed_query("test")
+        assert e.value == "Not supported for multimodal models"
+

--- a/libs/vertexai/tests/unit_tests/test_embeddings.py
+++ b/libs/vertexai/tests/unit_tests/test_embeddings.py
@@ -4,10 +4,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from langchain_google_vertexai import VertexAIEmbeddings
+from langchain_google_vertexai.embeddings import GoogleEmbeddingModelType
 
 
 def test_langchain_google_vertexai_embed_image_multimodal_only() -> None:
     mock_embeddings = MockVertexAIEmbeddings("textembedding-gecko@001")
+    assert mock_embeddings.model_type == GoogleEmbeddingModelType.TEXT
     with pytest.raises(NotImplementedError) as e:
         mock_embeddings.embed_image("test")
         assert e.value == "Only supported for multimodal models"
@@ -15,6 +17,7 @@ def test_langchain_google_vertexai_embed_image_multimodal_only() -> None:
 
 def test_langchain_google_vertexai_embed_documents_text_only() -> None:
     mock_embeddings = MockVertexAIEmbeddings("multimodalembedding@001")
+    assert mock_embeddings.model_type == GoogleEmbeddingModelType.MULTIMODAL
     with pytest.raises(NotImplementedError) as e:
         mock_embeddings.embed_documents(["test"])
         assert e.value == "Not supported for multimodal models"
@@ -22,6 +25,7 @@ def test_langchain_google_vertexai_embed_documents_text_only() -> None:
 
 def test_langchain_google_vertexai_embed_query_text_only() -> None:
     mock_embeddings = MockVertexAIEmbeddings("multimodalembedding@001")
+    assert mock_embeddings.model_type == GoogleEmbeddingModelType.MULTIMODAL
     with pytest.raises(NotImplementedError) as e:
         mock_embeddings.embed_query("test")
         assert e.value == "Not supported for multimodal models"

--- a/libs/vertexai/tests/unit_tests/test_embeddings.py
+++ b/libs/vertexai/tests/unit_tests/test_embeddings.py
@@ -1,39 +1,38 @@
+from typing import Any
+from unittest.mock import MagicMock
+
 import pytest
-from vertexai.language_models import TextEmbeddingModel
-from vertexai.vision_models import MultiModalEmbeddingModel
 
 from langchain_google_vertexai import VertexAIEmbeddings
 
 
-def test_langchain_google_vertexai_text_model() -> None:
-    embeddings_model = VertexAIEmbeddings(model_name="textembedding-gecko@001")
-    assert isinstance(embeddings_model.client, TextEmbeddingModel)
-    assert not embeddings_model._is_multimodal_model(embeddings_model.model_name)
-
-
-def test_langchain_google_vertexai_multimodal_model() -> None:
-    embeddings_model = VertexAIEmbeddings(model_name="multimodalembedding@001")
-    assert isinstance(embeddings_model.client, MultiModalEmbeddingModel)
-    assert embeddings_model._is_multimodal_model(embeddings_model.model_name)
-
-
 def test_langchain_google_vertexai_embed_image_multimodal_only() -> None:
-    embeddings_model = VertexAIEmbeddings(model_name="textembedding-gecko@001")
+    mock_embeddings = MockVertexAIEmbeddings("textembedding-gecko@001")
     with pytest.raises(NotImplementedError) as e:
-        embeddings_model.embed_image("test")
+        mock_embeddings.embed_image("test")
         assert e.value == "Only supported for multimodal models"
 
 
 def test_langchain_google_vertexai_embed_documents_text_only() -> None:
-    embeddings_model = VertexAIEmbeddings(model_name="multimodalembedding@001")
+    mock_embeddings = MockVertexAIEmbeddings("multimodalembedding@001")
     with pytest.raises(NotImplementedError) as e:
-        embeddings_model.embed_documents(["test"])
+        mock_embeddings.embed_documents(["test"])
         assert e.value == "Not supported for multimodal models"
 
 
 def test_langchain_google_vertexai_embed_query_text_only() -> None:
-    embeddings_model = VertexAIEmbeddings(model_name="multimodalembedding@001")
+    mock_embeddings = MockVertexAIEmbeddings("multimodalembedding@001")
     with pytest.raises(NotImplementedError) as e:
-        embeddings_model.embed_query("test")
+        mock_embeddings.embed_query("test")
         assert e.value == "Not supported for multimodal models"
 
+
+class MockVertexAIEmbeddings(VertexAIEmbeddings):
+    """
+    A mock class for avoiding instantiating VertexAI and the EmbeddingModel client
+    instance during init
+    """
+
+    def __init__(self, model_name, **kwargs: Any) -> None:
+        super().__init__(model_name, **kwargs)
+        self.client = MagicMock()

--- a/libs/vertexai/tests/unit_tests/test_embeddings.py
+++ b/libs/vertexai/tests/unit_tests/test_embeddings.py
@@ -1,7 +1,8 @@
-from typing import Any
+from typing import Any, Dict
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic.v1 import root_validator
 
 from langchain_google_vertexai import VertexAIEmbeddings
 from langchain_google_vertexai.embeddings import GoogleEmbeddingModelType
@@ -39,4 +40,12 @@ class MockVertexAIEmbeddings(VertexAIEmbeddings):
 
     def __init__(self, model_name, **kwargs: Any) -> None:
         super().__init__(model_name, **kwargs)
-        self.client = MagicMock()
+
+    @classmethod
+    def _init_vertexai(cls, values: Dict) -> None:
+        pass
+
+    @root_validator()
+    def validate_environment(cls, values: Dict) -> Dict:
+        values["client"] = MagicMock()
+        return values


### PR DESCRIPTION
Add support for multimodalembedding model as model type on VertexAIEmbeddings.

- Add embed_image method, only valid for multimodalembedding model.
- Make embed_documents and embed_query only available for text models.
- TODO: adapt embded_documents and embded_query to also work with multimodalembedding models. 