### PR TITLE
Make pillow a full dependency

### DIFF
--- a/libs/genai/pyproject.toml
+++ b/libs/genai/pyproject.toml
@@ -14,10 +14,7 @@ license = "MIT"
 python = ">=3.9,<4.0"
 langchain-core = "^0.1"
 google-generativeai = "^0.4.1"
-pillow = { version = "^10.1.0", optional = true }
-
-[tool.poetry.extras]
-images = ["pillow"]
+pillow = "^10.1.0"
 
 [tool.poetry.group.test]
 optional = true


### PR DESCRIPTION
# Issue:

Pillow is listed as a package.extra, even though it seems to be explicitly depended upon even when passing images as base64 instead of PIL images.
This seems to happen because the functions that support image formats other than PIL still convert the other formats to PIL during the process (_convert_to_parts, _load_image_from_gcs, etc)

# Proposal:
Convert pillow to a full dependency.

# Relevant lines:
https://github.com/langchain-ai/langchain-google/blob/main/libs/genai/langchain_google_genai/chat_models.py#L209-L261

# Error message:
  ```
File "/usr/local/lib/python3.12/site-packages/langchain_google_genai/chat_models.py", line 234, in _url_to_pil
    raise ImportError(
ImportError: PIL is required to load images. Please install it with `pip install pillow`
```