### PR TITLE
Moved failing test to extended to be skipped

### DIFF
--- a/libs/vertexai/tests/integration_tests/test_tools.py
+++ b/libs/vertexai/tests/integration_tests/test_tools.py
@@ -112,7 +112,7 @@ def test_stream() -> None:
     assert "function_call" in response[0].additional_kwargs
 
 
-@pytest.mark.release
+@pytest.mark.extended
 def test_multiple_tools() -> None:
     from langchain.agents import AgentExecutor
     from langchain.agents.format_scratchpad import format_to_openai_function_messages


### PR DESCRIPTION
As the tests/integration_tests/test_tools.py::test_multiple_tools is failing because of the missing GOOGLE_SEARCH_API_KEY we will temporary move it to extended so that it will be skipped