### PR TITLE
Add support for passing `credentials` param

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -447,6 +447,8 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         1. The ``GOOGLE_API_KEY``` environment variable set with your API key, or
         2. Pass your API key using the google_api_key kwarg to the ChatGoogle
            constructor.
+        3. Pass your OAuth 2 credentials using credentials kwargs to the 
+           ChatGoogle constructor.
 
     Example:
         .. code-block:: python
@@ -490,9 +492,10 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             google_api_key = google_api_key.get_secret_value()
 
         genai.configure(
-            api_key=google_api_key,
+            api_key=google_api_key if values.get("credentials") is None else None,
             transport=values.get("transport"),
             client_options=values.get("client_options"),
+            credentials=values.get("credentials")
         )
         if (
             values.get("temperature") is not None

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -486,8 +486,10 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     def validate_environment(cls, values: Dict) -> Dict:
         """Validates params and passes them to google-generativeai package."""
         google_api_key = get_from_dict_or_env(
-            values, "google_api_key", "GOOGLE_API_KEY"
+            values, "google_api_key", "GOOGLE_API_KEY", ''
         )
+        if google_api_key == '':
+            google_api_key = None
         if isinstance(google_api_key, SecretStr):
             google_api_key = google_api_key.get_secret_value()
 

--- a/libs/genai/langchain_google_genai/embeddings.py
+++ b/libs/genai/langchain_google_genai/embeddings.py
@@ -17,6 +17,8 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
         1. The ``GOOGLE_API_KEY``` environment variable set with your API key, or
         2. Pass your API key using the google_api_key kwarg to the ChatGoogle
            constructor.
+        3. Pass your OAuth 2 credentials using credentials kwargs to the 
+           ChatGoogle constructor.
 
     Example:
         .. code-block:: python
@@ -65,9 +67,10 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
             google_api_key = google_api_key.get_secret_value()
 
         genai.configure(
-            api_key=google_api_key,
+            api_key=google_api_key if values.get("credentials") is None else None,
             transport=values.get("transport"),
             client_options=values.get("client_options"),
+            credentials=values.get("credentials")
         )
         return values
 

--- a/libs/genai/langchain_google_genai/llms.py
+++ b/libs/genai/langchain_google_genai/llms.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from enum import Enum, auto
 from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
+from google.auth import credentials as ga_credentials
 import google.api_core
 import google.generativeai as genai  # type: ignore[import]
 from langchain_core.callbacks import (
@@ -122,6 +123,10 @@ Supported examples:
     )
     """Model name to use."""
     google_api_key: Optional[SecretStr] = None
+    
+    credentials: Optional[ga_credentials.Credentials | dict | None] = None
+    """credentials: the credentials passed to genai.configure method"""
+    
     temperature: float = 0.7
     """Run inference with this temperature. Must by in the closed interval
        [0.0, 1.0]."""
@@ -209,14 +214,16 @@ class GoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseLLM):
         model_name = values["model"]
 
         safety_settings = values["safety_settings"]
-
+        
         if isinstance(google_api_key, SecretStr):
             google_api_key = google_api_key.get_secret_value()
 
         genai.configure(
-            api_key=google_api_key,
+            # ignore api_key otherwise error occured
+            api_key=google_api_key if values.get("credentials") is None else None,
             transport=values.get("transport"),
             client_options=values.get("client_options"),
+            credentials=values.get("credentials")
         )
 
         if safety_settings and (


### PR DESCRIPTION
While I am using my fine-tuned model with langchain, I noticed that it requires for Google OAuth2 authentication. After spending 2 hours setting up oauth 2, I found that langchain does not support passing `credentials` param to `genai.configure` method, which is crucial for using Google OAuth 2 authentication. Hence this pull request were made. I have not tested yet. Moreover, I am currently a junior high school student. Sometimes, my changes might not be appropriate. Maintainers may review my code and edit themselves.