### PR TITLE
[feat]: add authorization identities to GoogleDriveLoader.

### DIFF
--- a/libs/community/langchain_google_community/drive.py
+++ b/libs/community/langchain_google_community/drive.py
@@ -45,6 +45,36 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
     """The file loader class to use."""
     file_loader_kwargs: Dict["str", Any] = {}
     """The file loader kwargs to use."""
+    load_auth: bool = False
+    """Whether to load authorization identities."""
+
+    def _get_identity_metadata_from_id(self, id: str):
+        """Fetch the list of people having access to ID file."""
+        try:
+            from googleapiclient.discovery import build
+        except ImportError as exc:
+            raise ImportError(
+                "You must run "
+                "`pip install --upgrade "
+                "google-api-python-client` "
+                "to load authorization identities."
+            ) from exc
+
+        authorized_identities = []
+        creds = self._load_credentials()
+        service = build("drive", "v3", credentials=creds)  # Build the service
+        permissions = service.permissions().list(fileId=id).execute()
+        for perm in permissions.get("permissions", {}):
+            email_id = (
+                service.permissions()
+                .get(fileId=id, permissionId=perm.get("id", ""), fields="emailAddress")
+                .execute()
+                .get("emailAddress")
+            )
+            if email_id:
+                authorized_identities.append(email_id)
+
+        return authorized_identities
 
     @root_validator
     def validate_inputs(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -157,6 +187,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
         sheets_service = build("sheets", "v4", credentials=creds)
         spreadsheet = sheets_service.spreadsheets().get(spreadsheetId=id).execute()
         sheets = spreadsheet.get("sheets", [])
+        if self.load_auth:
+            authorized_identities = self._get_identity_metadata_from_id(id)
 
         documents = []
         for sheet in sheets:
@@ -181,6 +213,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
                     "title": f"{spreadsheet['properties']['title']} - {sheet_name}",
                     "row": i,
                 }
+                if self.load_auth:
+                    metadata["authorized_identities"] = authorized_identities
                 content = []
                 for j, v in enumerate(row):
                     title = header[j].strip() if len(header) > j else ""
@@ -201,6 +235,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
 
         creds = self._load_credentials()
         service = build("drive", "v3", credentials=creds)
+        if self.load_auth:
+            authorized_identities = self._get_identity_metadata_from_id(id)
 
         file = (
             service.files()
@@ -227,6 +263,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
             "title": f"{file.get('name')}",
             "when": f"{file.get('modifiedTime')}",
         }
+        if self.load_auth:
+            metadata["authorized_identities"] = authorized_identities
         return Document(page_content=text, metadata=metadata)
 
     def _load_documents_from_folder(
@@ -304,6 +342,9 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
         creds = self._load_credentials()
         service = build("drive", "v3", credentials=creds)
 
+        if self.load_auth:
+            authorized_identities = self._get_identity_metadata_from_id(id)
+
         file = service.files().get(fileId=id, supportsAllDrives=True).execute()
         request = service.files().get_media(fileId=id)
         fh = BytesIO()
@@ -320,6 +361,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
                 doc.metadata["source"] = f"https://drive.google.com/file/d/{id}/view"
                 if "title" not in doc.metadata:
                     doc.metadata["title"] = f"{file.get('name')}"
+                if self.load_auth:
+                    doc.metadata["authorized_identities"] = authorized_identities
             return docs
 
         else:
@@ -328,17 +371,22 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
             content = fh.getvalue()
             pdf_reader = PdfReader(BytesIO(content))
 
-            return [
-                Document(
-                    page_content=page.extract_text(),
-                    metadata={
-                        "source": f"https://drive.google.com/file/d/{id}/view",
-                        "title": f"{file.get('name')}",
-                        "page": i,
-                    },
+            docs = []
+            for i, page in enumerate(pdf_reader.pages):
+                metadata = {
+                    "source": f"https://drive.google.com/file/d/{id}/view",
+                    "title": f"{file.get('name')}",
+                    "page": i,
+                }
+                if self.load_auth:
+                    metadata["authorized_identities"] = authorized_identities
+                docs.append(
+                    Document(
+                        page_content=page.extract_text(),
+                        metadata=metadata,
+                    )
                 )
-                for i, page in enumerate(pdf_reader.pages)
-            ]
+            return docs
 
     def _load_file_from_ids(self) -> List[Document]:
         """Load files from a list of IDs."""

--- a/libs/community/langchain_google_community/drive.py
+++ b/libs/community/langchain_google_community/drive.py
@@ -48,11 +48,11 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
     load_auth: bool = False
     """Whether to load authorization identities."""
 
-    def _get_identity_metadata_from_id(self, id: str)-> List[str]:
+    def _get_identity_metadata_from_id(self, id: str) -> List[str]:
         """Fetch the list of people having access to ID file."""
         try:
-            from googleapiclient.discovery import build # type: ignore[import]
-            import googleapiclient.errors # type: ignore[import]
+            import googleapiclient.errors  # type: ignore[import]
+            from googleapiclient.discovery import build  # type: ignore[import]
         except ImportError as exc:
             raise ImportError(
                 "You must run "
@@ -61,17 +61,22 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
                 "to load authorization identities."
             ) from exc
 
-        authorized_identities = []
+        authorized_identities: list = []
         creds = self._load_credentials()
         service = build("drive", "v3", credentials=creds)  # Build the service
         try:
             permissions = service.permissions().list(fileId=id).execute()
         except googleapiclient.errors.HttpError:
-            print(f"You dont have permission to retrieve permission for the file \
-                  with fileId: {id}")
+            print(
+                f"insufficientFilePermissions: The user does not have sufficient \
+                permissions to retrieve permission for the file with fileId: {id}"
+            )
             return authorized_identities
         except Exception as exc:
-            print(f"Error occured while fetching permission for the file with fileId: {id}")
+            print(
+                f"Error occurred while fetching the permissions for the file with \
+                fileId: {id}"
+            )
             print(f"Error: {exc}")
             return authorized_identities
 
@@ -154,7 +159,7 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
             )
         except ImportError:
             raise ImportError(
-                "You must run "
+                "Install prerequisites by running: "
                 "`pip install --upgrade "
                 "google-api-python-client google-auth-httplib2 "
                 "google-auth-oauthlib` "
@@ -275,7 +280,7 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
             "when": f"{file.get('modifiedTime')}",
         }
         if self.load_auth:
-            metadata["authorized_identities"] = authorized_identities
+            metadata["authorized_identities"] = authorized_identities  # type: ignore
         return Document(page_content=text, metadata=metadata)
 
     def _load_documents_from_folder(


### PR DESCRIPTION
**Description:** Add Google Drive document access identities to metadata
**Dependencies:** none
**Documentation:** GoogleDrive documentation update with `load_auth` usage to be updated with PR: https://github.com/langchain-ai/langchain/pull/18813