### PR TITLE
fix: Add `blob.reload()` to populate `blob.content_type`

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_image_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_image_utils.py
@@ -193,7 +193,6 @@ class ImageBytesLoader:
 
         gcs_client = storage.Client(project=self._project)
         blob = storage.Blob.from_string(gcs_uri, gcs_client)
-        # Remove once https://github.com/googleapis/python-storage/pull/1249 is released.
         blob.reload()
         return blob
 

--- a/libs/vertexai/langchain_google_vertexai/_image_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_image_utils.py
@@ -192,7 +192,10 @@ class ImageBytesLoader:
         """
 
         gcs_client = storage.Client(project=self._project)
-        return storage.Blob.from_string(gcs_uri, gcs_client)
+        blob = storage.Blob.from_string(gcs_uri, gcs_client)
+        # Remove once https://github.com/googleapis/python-storage/pull/1249 is released.
+        blob.reload()
+        return blob
 
     def _is_url(self, url_string: str) -> bool:
         """Checks if a url is valid.

--- a/libs/vertexai/langchain_google_vertexai/_image_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_image_utils.py
@@ -193,7 +193,7 @@ class ImageBytesLoader:
 
         gcs_client = storage.Client(project=self._project)
         blob = storage.Blob.from_string(gcs_uri, gcs_client)
-        blob.reload()
+        blob.reload(client=gcs_client)
         return blob
 
     def _is_url(self, url_string: str) -> bool:


### PR DESCRIPTION
- Follow-up to https://github.com/langchain-ai/langchain-google/pull/108
- Shouldn't be needed after https://github.com/googleapis/python-storage/pull/1249 is merged/released