### PR TITLE
[vectorstores] Implement BaseStore interface for document storage

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/vectorstores/__init__.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/__init__.py
@@ -1,3 +1,7 @@
+from langchain_google_vertexai.vectorstores.document_storage import (
+    DataStoreDocumentStorage,
+    GCSDocumentStorage,
+)
 from langchain_google_vertexai.vectorstores.vectorstores import (
     VectorSearchVectorStore,
     VectorSearchVectorStoreDatastore,
@@ -8,4 +12,6 @@ __all__ = [
     "VectorSearchVectorStore",
     "VectorSearchVectorStoreDatastore",
     "VectorSearchVectorStoreGCS",
+    "DataStoreDocumentStorage",
+    "GCSDocumentStorage"
 ]

--- a/libs/vertexai/langchain_google_vertexai/vectorstores/__init__.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
     "VectorSearchVectorStoreDatastore",
     "VectorSearchVectorStoreGCS",
     "DataStoreDocumentStorage",
-    "GCSDocumentStorage"
+    "GCSDocumentStorage",
 ]

--- a/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 class DocumentStorage(BaseStore[str, Document]):
     """Abstract interface of a key, text storage for retrieving documents."""
 
+
 class GCSDocumentStorage(DocumentStorage):
     """Stores documents in Google Cloud Storage.
     For each pair id, document_text the name of the blob will be {prefix}/{id} stored
@@ -31,9 +32,9 @@ class GCSDocumentStorage(DocumentStorage):
         super().__init__()
         self._bucket = bucket
         self._prefix = prefix
-    
+
     def mset(self, key_value_pairs: Sequence[Tuple[str, Document]]) -> None:
-        """ Stores a series of documents using each keys
+        """Stores a series of documents using each keys
 
         Args:
             key_value_pairs (Sequence[Tuple[K, V]]): A sequence of key-value pairs.
@@ -53,9 +54,9 @@ class GCSDocumentStorage(DocumentStorage):
                 None instead.
         """
         return [self._get_one(key) for key in keys]
-    
+
     def mdelete(self, keys: Sequence[str]) -> None:
-        """ Deletes a batch of documents by id.
+        """Deletes a batch of documents by id.
 
         Args:
             keys: List of ids for the text.
@@ -64,14 +65,13 @@ class GCSDocumentStorage(DocumentStorage):
             self._delete_one(key)
 
     def yield_keys(self, *, prefix: str | None = None) -> Iterator[str]:
-        """ Yields the keys present in the storage.
+        """Yields the keys present in the storage.
 
         Args:
             prefix: Ignored. Uses the prefix provided in the constructor.
         """
         for blob in self._bucket.list_blobs(prefix=self._prefix):
             yield blob.name.split("/")[-1]
-        
 
     def _get_one(self, key: str) -> Document | None:
         """Gets the text of a document by its id. If not found, returns None.
@@ -105,7 +105,7 @@ class GCSDocumentStorage(DocumentStorage):
         new_blow.upload_from_string(document_text)
 
     def _delete_one(self, key: str) -> None:
-        """ Deletes one document by its key.
+        """Deletes one document by its key.
 
         Args:
             key (str): Id of the document to delete.
@@ -168,12 +168,14 @@ class DataStoreDocumentStorage(DocumentStorage):
                 metadata=self._convert_entity_to_dict(
                     entity[self._metadata_property_name]
                 ),
-            ) if entity is not None else None
+            )
+            if entity is not None
+            else None
             for entity in entities
         ]
-    
+
     def mset(self, key_value_pairs: Sequence[Tuple[str, Document]]) -> None:
-        """ Stores a series of documents using each keys
+        """Stores a series of documents using each keys
 
         Args:
             key_value_pairs (Sequence[Tuple[K, V]]): A sequence of key-value pairs.
@@ -194,7 +196,7 @@ class DataStoreDocumentStorage(DocumentStorage):
             self._client.put_multi(entities)
 
     def mdelete(self, keys: Sequence[str]) -> None:
-        """ Deletes a sequence of documents by key.
+        """Deletes a sequence of documents by key.
 
         Args:
             keys (Sequence[str]): A sequence of keys to delete.
@@ -204,7 +206,7 @@ class DataStoreDocumentStorage(DocumentStorage):
             self._client.delete_multi(keys)
 
     def yield_keys(self, *, prefix: str | None = None) -> Iterator[str]:
-        """ Yields the keys of all documents in the storage.
+        """Yields the keys of all documents in the storage.
 
         Args:
             prefix: Ignored

--- a/libs/vertexai/langchain_google_vertexai/vectorstores/vectorstores.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/vectorstores.py
@@ -123,8 +123,8 @@ class _BaseVertexAIVectorStore(VectorStore):
             # Ignore typing because mypy doesn't seem to be able to identify that
             # in documents there is no possibility to have None values with the
             # check above.
-            return list(zip(documents, distances)) # type: ignore
-        else:  
+            return list(zip(documents, distances))  # type: ignore
+        else:
             missing_docs = [key for key, doc in zip(keys, documents) if doc is None]
             message = f"Documents with ids: {missing_docs} not found in the storage"
             raise ValueError(message)

--- a/libs/vertexai/tests/integration_tests/test_vectorstores.py
+++ b/libs/vertexai/tests/integration_tests/test_vectorstores.py
@@ -116,7 +116,6 @@ def test_vector_search_sdk_manager(sdk_manager: VectorSearchSDKManager):
     "storage_class", ["gcs_document_storage", "datastore_document_storage"]
 )
 def test_document_storage(
-    sdk_manager: VectorSearchSDKManager,
     storage_class: str,
     request: pytest.FixtureRequest,
 ):
@@ -138,6 +137,14 @@ def test_document_storage(
 
     for og_document, retrieved_document in zip(documents, retrieved_documents):
         assert og_document == retrieved_document
+
+    # Test key yielding
+    keys = list(document_storage.yield_keys())
+    assert all(id in keys for id in ids)
+
+    # Test deletion
+    document_storage.mdelete(ids)
+    assert all(item is None for item in document_storage.mget(ids))
 
 
 @pytest.mark.extended

--- a/libs/vertexai/tests/integration_tests/test_vectorstores.py
+++ b/libs/vertexai/tests/integration_tests/test_vectorstores.py
@@ -27,14 +27,14 @@ from google.cloud.aiplatform.matching_engine.matching_engine_index_endpoint impo
 from langchain_core.documents import Document
 
 from langchain_google_vertexai.embeddings import VertexAIEmbeddings
-from langchain_google_vertexai.vectorstores._document_storage import (
-    DataStoreDocumentStorage,
-    DocumentStorage,
-    GCSDocumentStorage,
-)
 from langchain_google_vertexai.vectorstores._sdk_manager import VectorSearchSDKManager
 from langchain_google_vertexai.vectorstores._searcher import (
     VectorSearchSearcher,
+)
+from langchain_google_vertexai.vectorstores.document_storage import (
+    DataStoreDocumentStorage,
+    DocumentStorage,
+    GCSDocumentStorage,
 )
 from langchain_google_vertexai.vectorstores.vectorstores import (
     VectorSearchVectorStore,
@@ -132,15 +132,9 @@ def test_document_storage(
     ]
     ids = [str(uuid4()) for i in range(N)]
 
-    # Test individual retrieval
-    for id, document in zip(ids, documents):
-        document_storage.store_by_id(document_id=id, document=document)
-        retrieved = document_storage.get_by_id(document_id=id)
-        assert document == retrieved
-
-    # Test batch regtrieval
-    document_storage.batch_store_by_id(ids, documents)
-    retrieved_documents = document_storage.batch_get_by_id(ids)
+    # Test batch storage and retrieval
+    document_storage.mset(list(zip(ids, documents)))
+    retrieved_documents = document_storage.mget(ids)
 
     for og_document, retrieved_document in zip(documents, retrieved_documents):
         assert og_document == retrieved_document


### PR DESCRIPTION
Implement `BaseStore` interface for document storage, both GCS and Datastore

- Change custom interface to conform to `mset` `mget`
- Implement `mdelete` and `yield_keys`
- Update tests