### PR TITLE
vertexai[patch]: enable agents for vertex

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -330,15 +330,11 @@ def _parse_response_candidate(
         )
         additional_kwargs["function_call"] = function_call
         if streaming:
-            if not function_call.get("id"):
-                tool_call_id = uuid.uuid4().hex[:]
-            else:
-                tool_call_id = None
             tool_call_chunks = [
                 ToolCallChunk(
                     name=function_call.get("name"),
                     args=function_call.get("arguments"),
-                    id=tool_call_id,
+                    id=function_call.get("id", str(uuid.uuid4())),
                     index=function_call.get("index"),
                 )
             ]
@@ -359,7 +355,7 @@ def _parse_response_candidate(
                     ToolCall(
                         name=tool_call["name"],
                         args=tool_call["args"],
-                        id=tool_call.get("id"),
+                        id=tool_call.get("id", str(uuid.uuid4())),
                     )
                     for tool_call in tool_calls_dicts
                 ]
@@ -368,7 +364,7 @@ def _parse_response_candidate(
                     InvalidToolCall(
                         name=function_call.get("name"),
                         args=function_call.get("arguments"),
-                        id=function_call.get("id"),
+                        id=function_call.get("id", str(uuid.uuid4())),
                         error=str(e),
                     )
                 ]


### PR DESCRIPTION
```python
from langchain.agents import AgentExecutor, create_tool_calling_agent, tool
from langchain_google_vertexai import ChatVertexAI
from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder


prompt = ChatPromptTemplate.from_messages(
    [
        ("human", "{input}"),
        MessagesPlaceholder("agent_scratchpad"),
    ]
)
model = ChatVertexAI(model_name="gemini-pro", temperature=0)


@tool
def magic_function(input: int) -> str:
    """Applies a magic function to an input."""
    return str(input + 2)



tools = [magic_function]

agent = create_tool_calling_agent(model, tools, prompt)
agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)

agent_executor.invoke({"input": "what is the value of magic_function(3)?"})
```
```
> Entering new AgentExecutor chain...

Invoking: `magic_function` with `{'input': 3.0}`


5The value of magic_function(3) is {"content": "5"}.

> Finished chain.
{'input': 'what is the value of magic_function(3)?',
 'output': 'The value of magic_function(3) is {"content": "5"}.'}
```