### PR TITLE
Add aditional parameters to vertexai init

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -100,6 +100,12 @@ class _VertexAICommon(_VertexAIBase):
             }
             """  # noqa: E501
 
+    api_transport: Optional[str] = None
+    """The desired API transport method, can be either 'grpc' or 'rest'"""
+
+    api_endpoint: Optional[str] = None
+    """The desired API endpoint, e.g., us-central1-aiplatform.googleapis.com"""
+
     @property
     def _llm_type(self) -> str:
         return "vertexai"
@@ -161,6 +167,8 @@ class _VertexAICommon(_VertexAIBase):
             project=values.get("project"),
             location=values.get("location"),
             credentials=values.get("credentials"),
+            api_transport=values.get("api_transport"),
+            api_endpoint=values.get("api_endpoint"),
         )
         return None
 


### PR DESCRIPTION
Added to additonal parameters to `_VertexAICommon` that affect `vertexai.__init__`.
- `api_transport`
- `api_endpoint`

There are additional parameters but I think it doesn't make sense to include them, is better to initialize them per session in my opinion.