### PR TITLE
fix: convert_to_genai_function_declarations

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import (
     Any,
     Callable,
+    Collection,
     Dict,
     List,
     Literal,
@@ -15,13 +16,9 @@ from typing import (
 )
 
 import google.ai.generativelanguage as glm
-from google.ai.generativelanguage import (
-    FunctionCallingConfig,
-    FunctionDeclaration,
-)
-from google.ai.generativelanguage import (
-    Tool as GoogleTool,
-)
+from google.ai.generativelanguage import FunctionCallingConfig, FunctionDeclaration
+from google.ai.generativelanguage import Tool as GoogleTool
+from google.generativeai.types.content_types import ToolDict  # type: ignore[import]
 from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.tools import BaseTool
 from langchain_core.tools import tool as callable_as_lc_tool
@@ -38,38 +35,74 @@ TYPE_ENUM = {
 
 TYPE_ENUM_REVERSE = {v: k for k, v in TYPE_ENUM.items()}
 
-_FunctionDeclarationLike = Union[
-    BaseTool, Type[BaseModel], dict, Callable, FunctionDeclaration
-]
+
+class _ToolDictLike(TypedDict):
+    function_declarations: _FunctionDeclarationLikeList
+
+
+class _FunctionDeclarationDict(TypedDict):
+    name: str
+    description: str
+    parameters: Dict[str, Collection[str]]
 
 
 class _ToolDict(TypedDict):
-    function_declarations: Sequence[_FunctionDeclarationLike]
+    function_declarations: Sequence[_FunctionDeclarationDict]
 
 
+# Info: This is a FunctionDeclaration(=fc).
+_FunctionDeclarationLike = Union[
+    BaseTool, Type[BaseModel], FunctionDeclaration, Callable, Dict[str, Any]
+]
+
+# Info: This mean one tool.
+_FunctionDeclarationLikeList = Sequence[_FunctionDeclarationLike]
+
+
+# Info: This means one tool=Sequence of FunctionDeclaration
+# The dict should be GoogleTool like. {"function_declarations": [ { "name": ...}.
+# OpenAI like dict is not be accepted. {{'type': 'function', 'function': {'name': ...}
+_ToolsType = Union[
+    GoogleTool,
+    ToolDict,
+    _ToolDictLike,
+    _FunctionDeclarationLikeList,
+    _FunctionDeclarationLike,
+]
+
+
+#
+# Info: GoogleTool means function_declarations and proto.Message.
 def convert_to_genai_function_declarations(
-    tool: Union[
-        GoogleTool,
-        _ToolDict,
-        _FunctionDeclarationLike,
-        Sequence[_FunctionDeclarationLike],
-    ],
+    tool: _ToolsType,
 ) -> GoogleTool:
-    if isinstance(tool, GoogleTool):
-        return cast(GoogleTool, tool)
-    if isinstance(tool, type) and issubclass(tool, BaseModel):
-        return GoogleTool(function_declarations=[_convert_to_genai_function(tool)])
-    if callable(tool):
-        return _convert_tool_to_genai_function(callable_as_lc_tool()(tool))
     if isinstance(tool, list):
-        return convert_to_genai_function_declarations({"function_declarations": tool})
-    if isinstance(tool, dict) and "function_declarations" in tool:
+        # multiple _FunctionDeclarationLike
+        return GoogleTool(
+            function_declarations=_convert_fc_likes_to_genai_function(tool)
+        )
+    elif isinstance(tool, (BaseTool, FunctionDeclaration)):
+        # single _FunctionDeclarationLike
+        return GoogleTool(
+            function_declarations=[_convert_fc_like_to_genai_function(tool)]
+        )
+    elif isinstance(tool, type) and issubclass(tool, BaseModel):
+        # single _FunctionDeclarationLike
+        return GoogleTool(
+            function_declarations=[_convert_fc_like_to_genai_function(tool)]
+        )
+    elif isinstance(tool, GoogleTool):
+        return cast(GoogleTool, tool)
+    elif callable(tool):
         return GoogleTool(
             function_declarations=[
-                _convert_to_genai_function(fc) for fc in tool["function_declarations"]
-            ],
+                _convert_tool_to_genai_function(callable_as_lc_tool()(tool))
+            ]
         )
-    return GoogleTool(function_declarations=[_convert_to_genai_function(tool)])  # type: ignore[arg-type]
+    elif isinstance(tool, dict):
+        return GoogleTool(function_declarations=_convert_dict_to_genai_functions(tool))  # type: ignore
+    else:
+        raise ValueError(f"Unsupported tool type {tool}")
 
 
 def tool_to_dict(tool: GoogleTool) -> _ToolDict:
@@ -87,64 +120,112 @@ def tool_to_dict(tool: GoogleTool) -> _ToolDict:
             if property_description:
                 property_dict["description"] = property_description
             properties[property] = property_dict
-        function_declaration = {
-            "name": function_declaration_proto.name,
-            "description": function_declaration_proto.description,
-            "parameters": {"type": "object", "properties": properties},
-        }
+        name = function_declaration_proto.name
+        description = function_declaration_proto.description
+        parameters = {"type": "object", "properties": properties}
         if function_declaration_proto.parameters.required:
-            function_declaration["parameters"][  # type: ignore[index]
-                "required"
-            ] = function_declaration_proto.parameters.required
+            parameters["required"] = function_declaration_proto.parameters.required
+        function_declaration = _FunctionDeclarationDict(
+            name=name, description=description, parameters=parameters
+        )
         function_declarations.append(function_declaration)
     return {"function_declarations": function_declarations}
 
 
-def _convert_to_genai_function(fc: _FunctionDeclarationLike) -> FunctionDeclaration:
-    if isinstance(fc, BaseTool):
-        return _convert_tool_to_genai_function(fc)
-    elif isinstance(fc, type) and issubclass(fc, BaseModel):
-        return _convert_pydantic_to_genai_function(fc)
-    elif callable(fc):
-        return _convert_tool_to_genai_function(callable_as_lc_tool()(fc))
-    elif isinstance(fc, dict):
-        formatted_fc = {"name": fc["name"], "description": fc.get("description")}
-        if "parameters" in fc:
-            formatted_fc["parameters"] = {
-                "properties": {
-                    k: {
-                        "type_": TYPE_ENUM[v["type"]],
-                        "description": v.get("description"),
-                    }
-                    for k, v in fc["parameters"]["properties"].items()
-                },
-                "required": fc.get("parameters", []).get("required", []),
-                "type_": TYPE_ENUM[fc["parameters"]["type"]],
-            }
-        return FunctionDeclaration(**formatted_fc)
+def _convert_fc_likes_to_genai_function(
+    fc_likes: _FunctionDeclarationLikeList,
+) -> Sequence[FunctionDeclaration]:
+    if isinstance(fc_likes, list):
+        return [_convert_fc_like_to_genai_function(fc) for fc in fc_likes]
+    raise ValueError(f"Unsupported fc_likes type {fc_likes}")
+
+
+def _convert_fc_like_to_genai_function(
+    fc_like: _FunctionDeclarationLike,
+) -> FunctionDeclaration:
+    if isinstance(fc_like, BaseTool):
+        return _convert_tool_to_genai_function(fc_like)
+    elif isinstance(fc_like, type) and issubclass(fc_like, BaseModel):
+        return _convert_pydantic_to_genai_function(fc_like)
+    elif isinstance(fc_like, dict):
+        # TODO: add declaration_index
+        return _convert_dict_to_genai_function(fc_like)
+    elif callable(fc_like):
+        return _convert_tool_to_genai_function(callable_as_lc_tool()(fc_like))
     else:
-        raise ValueError(f"Unsupported function call type {fc}")
+        raise ValueError(f"Unsupported fc_like type {fc_like}")
+
+
+def _convert_tool_dict_to_genai_functions(
+    tool_dict: _ToolDictLike,
+) -> Sequence[FunctionDeclaration]:
+    if "function_declarations" in tool_dict:
+        return _convert_dicts_to_genai_functions(tool_dict["function_declarations"])  # type: ignore
+    else:
+        raise ValueError(f"Unsupported function tool_dict type {tool_dict}")
+
+
+def _convert_dict_to_genai_functions(
+    function_declarations_dict: Dict[str, Any],
+) -> Sequence[FunctionDeclaration]:
+    if "function_declarations" in function_declarations_dict:
+        # GoogleTool like
+        return [
+            _convert_dict_to_genai_function(fc, i)
+            for i, fc in enumerate(function_declarations_dict["function_declarations"])
+        ]
+    d = function_declarations_dict
+    if "name" in d and "description" in d and "parameters" in d:
+        # _FunctionDeclarationDict
+        return [_convert_dict_to_genai_function(d)]
+    else:
+        # OpenAI like?
+        raise ValueError(f"Unsupported function call type {function_declarations_dict}")
+
+
+def _convert_dicts_to_genai_functions(
+    function_declaration_dicts: Sequence[Dict[str, Any]],
+) -> Sequence[FunctionDeclaration]:
+    return [
+        _convert_dict_to_genai_function(function_declaration_dict, i)
+        for i, function_declaration_dict in enumerate(function_declaration_dicts)
+    ]
+
+
+def _convert_dict_to_genai_function(
+    function_declaration_dict: Dict[str, Any], declaration_index: int = 0
+) -> FunctionDeclaration:
+    formatted_fc = {
+        "name": function_declaration_dict.get("name", f"unknown-{declaration_index}"),
+        "description": function_declaration_dict.get("description", "no-description"),
+    }
+    if "parameters" in function_declaration_dict:
+        formatted_fc["parameters"] = {
+            "properties": {
+                k: {
+                    "type_": TYPE_ENUM[v["type"]],
+                    "description": v.get("description"),
+                }
+                for k, v in function_declaration_dict["parameters"][
+                    "properties"
+                ].items()
+            },
+            "required": function_declaration_dict.get("parameters", []).get(
+                "required", []
+            ),
+            "type_": TYPE_ENUM[function_declaration_dict["parameters"]["type"]],
+        }
+    return FunctionDeclaration(**formatted_fc)
 
 
 def _convert_tool_to_genai_function(tool: BaseTool) -> FunctionDeclaration:
     if tool.args_schema:
-        schema = dereference_refs(tool.args_schema.schema())
-        schema.pop("definitions", None)
-        return FunctionDeclaration(
-            name=tool.name or schema["title"],
-            description=tool.description or schema["description"],
-            parameters={
-                "properties": {
-                    k: {
-                        "type_": TYPE_ENUM[v["type"]],
-                        "description": v.get("description"),
-                    }
-                    for k, v in schema["properties"].items()
-                },
-                "required": schema.get("required", []),
-                "type_": TYPE_ENUM[schema["type"]],
-            },
-        )
+        fc = tool.args_schema
+        if isinstance(fc, type) and issubclass(fc, BaseModel):
+            return _convert_pydantic_to_genai_function(
+                fc, tool_name=tool.name, tool_description=tool.description
+            )
+        raise ValueError(f"Unsupported function call type {fc}")
     else:
         return FunctionDeclaration(
             name=tool.name,
@@ -161,24 +242,46 @@ def _convert_tool_to_genai_function(tool: BaseTool) -> FunctionDeclaration:
 
 def _convert_pydantic_to_genai_function(
     pydantic_model: Type[BaseModel],
+    tool_name: Optional[str] = None,
+    tool_description: Optional[str] = None,
 ) -> FunctionDeclaration:
     schema = dereference_refs(pydantic_model.schema())
     schema.pop("definitions", None)
-    return FunctionDeclaration(
-        name=schema["title"],
-        description=schema.get("description", ""),
+    function_declaration = FunctionDeclaration(
+        name=tool_name if tool_name else schema.get("title"),
+        description=tool_description if tool_description else schema.get("description"),
         parameters={
             "properties": {
                 k: {
-                    "type_": TYPE_ENUM[v["type"]],
+                    "type_": _get_type_from_schema(v),
                     "description": v.get("description"),
                 }
                 for k, v in schema["properties"].items()
             },
-            "required": schema["required"],
+            "required": schema.get("required", []),
             "type_": TYPE_ENUM[schema["type"]],
         },
     )
+    return function_declaration
+
+
+def _get_type_from_schema(schema: Dict[str, Any]) -> int:
+    if "anyOf" in schema:
+        types = [_get_type_from_schema(sub_schema) for sub_schema in schema["anyOf"]]
+        types = [t for t in types if t is not None]  # Remove None values
+        if types:
+            return types[-1]  # TODO: update FunctionDeclaration and pass all types?
+        else:
+            pass
+    elif "type" in schema:
+        stype = str(schema["type"])
+        if stype in TYPE_ENUM:
+            return TYPE_ENUM[stype]
+        else:
+            pass
+    else:
+        pass
+    return TYPE_ENUM["string"]  # Default to string if no valid types found
 
 
 _ToolChoiceType = Union[

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -619,8 +619,8 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
     convert_system_message_to_human: bool = False
     """Whether to merge any leading SystemMessage into the following HumanMessage.
-    
-    Gemini does not support system messages; any unsupported messages will 
+
+    Gemini does not support system messages; any unsupported messages will
     raise an error."""
 
     class Config:
@@ -997,7 +997,9 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 f"both:\n\n{tool_choice=}\n\n{tool_config=}"
             )
         # Bind dicts for easier serialization/deserialization.
-        genai_tools = [tool_to_dict(convert_to_genai_function_declarations(tools))]
+        genai_tools = [
+            tool_to_dict(convert_to_genai_function_declarations(tool)) for tool in tools
+        ]
         if tool_choice:
             all_names = [
                 f["name"]  # type: ignore[index]
@@ -1005,4 +1007,5 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 for f in t["function_declarations"]
             ]
             tool_config = _tool_choice_to_tool_config(tool_choice, all_names)
+
         return self.bind(tools=genai_tools, tool_config=tool_config, **kwargs)


### PR DESCRIPTION
Fix #234.

I'm not sure the root cause.
_function_utils.py is refactored with investigating.

Sorry, I didn't care vertexai side because no environment with me.


## Test result

### before

```
(gamebook) jinno@jinno-desktop:~/git/drill/gamebook/codeinterpreter_api_agent$ python ../test/test_shell_tool.py 
・・・
  File "/home/jinno/.local/share/virtualenvs/gamebook-7W9hF6PY/lib/python3.10/site-packages/langchain_google_genai/_function_utils.py", line 139, in <dictcomp>
    "type_": TYPE_ENUM[v["type"]],
KeyError: 'type'
```

### after(with debug log)

```
(gamebook) jinno@jinno-desktop:~/git/drill/gamebook/codeinterpreter_api_agent$ python ../test/test_shell_tool.py 
_convert_pydantic_to_genai_function schema= {'title': 'ShellInput', 'description': 'Commands for the Bash Shell tool.', 'type': 'object', 'properties': {'commands': {'title': 'Commands', 'description': 'List of shell commands to run. Deserialized using json.loads', 'anyOf': [{'type': 'string'}, {'type': 'array', 'items': {'type': 'string'}}]}}, 'required': ['commands']}
_get_type_from_schema schema= {'title': 'Commands', 'description': 'List of shell commands to run. Deserialized using json.loads', 'anyOf': [{'type': 'string'}, {'type': 'array', 'items': {'type': 'string'}}]}
_get_type_from_schema schema= {'type': 'string'}
_get_type_from_schema schema= {'type': 'array', 'items': {'type': 'string'}}
types= [<Type.STRING: 1>, <Type.ARRAY: 5>]
_convert_pydantic_to_genai_function function_declaration= name: "terminal"
description: "Commands for the Bash Shell tool."
parameters {
  type_: OBJECT
  properties {
    key: "commands"
    value {
      type_: ARRAY
      description: "List of shell commands to run. Deserialized using json.loads"
    }
  }
  required: "commands"
}

_convert_pydantic_to_genai_function schema= {'title': 'ShellInput', 'description': 'Commands for the Bash Shell tool.', 'type': 'object', 'properties': {'commands': {'title': 'Commands', 'description': 'List of shell commands to run. Deserialized using json.loads', 'anyOf': [{'type': 'string'}, {'type': 'array', 'items': {'type': 'string'}}]}}, 'required': ['commands']}
_get_type_from_schema schema= {'title': 'Commands', 'description': 'List of shell commands to run. Deserialized using json.loads', 'anyOf': [{'type': 'string'}, {'type': 'array', 'items': {'type': 'string'}}]}
_get_type_from_schema schema= {'type': 'string'}
_get_type_from_schema schema= {'type': 'array', 'items': {'type': 'string'}}
types= [<Type.STRING: 1>, <Type.ARRAY: 5>]
_convert_pydantic_to_genai_function function_declaration= name: "terminal"
description: "Commands for the Bash Shell tool."
parameters {
  type_: OBJECT
  properties {
    key: "commands"
    value {
      type_: ARRAY
      description: "List of shell commands to run. Deserialized using json.loads"
    }
  }
  required: "commands"
}

/home/jinno/.local/share/virtualenvs/gamebook-7W9hF6PY/lib/python3.10/site-packages/langchain_community/tools/shell/tool.py:32: UserWarning: The shell tool has no safeguards by default. Use at your own risk.
  warnings.warn(
Executing command:
 ['pwd']
/home/jinno/.local/share/virtualenvs/gamebook-7W9hF6PY/lib/python3.10/site-packages/langchain_community/tools/shell/tool.py:32: UserWarning: The shell tool has no safeguards by default. Use at your own risk.
  warnings.warn(
Executing command:
 ['pwd']
result= {'input': 'please run pwd command.', 'agent_scratchpad': [], 'output': 'The current working directory is `/home/jinno/git/drill/gamebook/codeinterpreter_api_agent`. \n'}
```

### Note

1. This error also remained in my environment.
https://github.com/google-gemini/generative-ai-python/issues/207

2. libs/genai/langchain_google_genai/_function_utils.py still some problem remains.

- function_declarations inf GoogleTool is not set correctry.
- Maybe _convert_to_genai_function() should return function_declarations not function_declaration.
- But I had no time to care this.