### PR TITLE
require that async client be initialized inside a running event loop

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -558,6 +559,14 @@ def _response_to_result(
     return ChatResult(generations=generations, llm_output=llm_output)
 
 
+def _is_event_loop_running():
+    try:
+        asyncio.get_running_loop()
+        return True
+    except RuntimeError:
+        return False
+
+
 class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     """`Google Generative AI` Chat models API.
 
@@ -639,13 +648,15 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             client_options=values.get("client_options"),
             transport=transport,
         )
-        values["async_client"] = genaix.build_generative_async_service(
-            credentials=values.get("credentials"),
-            api_key=google_api_key,
-            client_info=client_info,
-            client_options=values.get("client_options"),
-            transport=transport,
-        )
+
+        if _is_event_loop_running():
+            values["async_client"] = genaix.build_generative_async_service(
+                credentials=values.get("credentials"),
+                api_key=google_api_key,
+                client_info=client_info,
+                client_options=values.get("client_options"),
+                transport=transport,
+            )
 
         return values
 
@@ -733,6 +744,10 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             tool_config=tool_config,
             generation_config=generation_config,
         )
+
+        if not self.async_client:
+            raise RuntimeError("Initialize ChatGoogleGenerativeAI with a running event loop to use async methods.")
+
         response: GenerateContentResponse = await _achat_with_retry(
             request=request,
             **kwargs,

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -649,9 +649,11 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             transport=transport,
         )
 
-        # NOTE: genaix.build_generative_async_service requires a running event loop, which causes an
-        # error when initialized inside a ThreadPoolExecutor. this check ensures that
-        # async client is only initialized within an asyncio event loop to avoid the error
+        # NOTE: genaix.build_generative_async_service requires
+        # a running event loop, which causes an error
+        # when initialized inside a ThreadPoolExecutor.
+        # this check ensures that async client is only initialized
+        # within an asyncio event loop to avoid the error
         if _is_event_loop_running():
             values["async_client"] = genaix.build_generative_async_service(
                 credentials=values.get("credentials"),

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -559,7 +559,7 @@ def _response_to_result(
     return ChatResult(generations=generations, llm_output=llm_output)
 
 
-def _is_event_loop_running():
+def _is_event_loop_running() -> bool:
     try:
         asyncio.get_running_loop()
         return True

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -746,7 +746,10 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         )
 
         if not self.async_client:
-            raise RuntimeError("Initialize ChatGoogleGenerativeAI with a running event loop to use async methods.")
+            raise RuntimeError(
+                "Initialize ChatGoogleGenerativeAI with a running event loop "
+                "to use async methods."
+            )
 
         response: GenerateContentResponse = await _achat_with_retry(
             request=request,

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -1,8 +1,8 @@
 """Test chat model integration."""
 
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 import json
+from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Optional, Union
 from unittest.mock import ANY, Mock, patch
 
@@ -54,7 +54,9 @@ def test_integration_initialization() -> None:
 
 def test_initialization_inside_threadpool() -> None:
     with ThreadPoolExecutor() as executor:
-        executor.submit(ChatGoogleGenerativeAI, model="gemini-nano", google_api_key="secret-api-key").result()
+        executor.submit(
+            ChatGoogleGenerativeAI, model="gemini-nano", google_api_key="secret-api-key"
+        ).result()
 
 
 def test_initalization_without_async() -> None:
@@ -64,7 +66,9 @@ def test_initalization_without_async() -> None:
 
 def test_initialization_with_async() -> None:
     async def initialize_chat_with_async_client() -> ChatGoogleGenerativeAI:
-        return ChatGoogleGenerativeAI(model="gemini-nano", google_api_key="secret-api-key")
+        return ChatGoogleGenerativeAI(
+            model="gemini-nano", google_api_key="secret-api-key"
+        )
 
     loop = asyncio.get_event_loop()
     chat = loop.run_until_complete(initialize_chat_with_async_client())

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -53,7 +53,8 @@ def test_integration_initialization() -> None:
 
 
 def test_initialization_inside_threadpool() -> None:
-    # new threads don't have a running event loop, thread pool executor easiest way to create one
+    # new threads don't have a running event loop,
+    # thread pool executor easiest way to create one
     with ThreadPoolExecutor() as executor:
         executor.submit(
             ChatGoogleGenerativeAI, model="gemini-nano", google_api_key="secret-api-key"

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -1,5 +1,7 @@
 """Test chat model integration."""
 
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import json
 from typing import Dict, List, Optional, Union
 from unittest.mock import ANY, Mock, patch
@@ -48,6 +50,25 @@ def test_integration_initialization() -> None:
         temperature=0.7,
         candidate_count=2,
     )
+
+
+def test_initialization_inside_threadpool() -> None:
+    with ThreadPoolExecutor() as executor:
+        executor.submit(ChatGoogleGenerativeAI, model="gemini-nano", google_api_key="secret-api-key").result()
+
+
+def test_initalization_without_async() -> None:
+    chat = ChatGoogleGenerativeAI(model="gemini-nano", google_api_key="secret-api-key")
+    assert chat.async_client is None
+
+
+def test_initialization_with_async() -> None:
+    async def initialize_chat_with_async_client() -> ChatGoogleGenerativeAI:
+        return ChatGoogleGenerativeAI(model="gemini-nano", google_api_key="secret-api-key")
+
+    loop = asyncio.get_event_loop()
+    chat = loop.run_until_complete(initialize_chat_with_async_client())
+    assert chat.async_client is not None
 
 
 def test_api_key_is_string() -> None:


### PR DESCRIPTION
This change fixes the issue with running `ChatGoogleGenerativeAI` inside a `ThreadPoolExecutor` and requires initializing the model inside an event loop to enable async client