### PR TITLE
community: enforce attribute validation in VertexAISearchRetriever

### DIFF
--- a/libs/community/langchain_google_community/vertex_ai_search.py
+++ b/libs/community/langchain_google_community/vertex_ai_search.py
@@ -252,7 +252,7 @@ class VertexAISearchRetriever(BaseRetriever, _BaseVertexAISearchRetriever):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.ignore
+        extra = Extra.forbid
         arbitrary_types_allowed = True
         underscore_attrs_are_private = True
 
@@ -267,7 +267,11 @@ class VertexAISearchRetriever(BaseRetriever, _BaseVertexAISearchRetriever):
                 "`pip install langchain-google-community[vertexaisearch]`"
             ) from exc
 
-        super().__init__(**kwargs)
+        try:
+            super().__init__(**kwargs)
+        except ValueError as e:
+            print(f"Error initializing GoogleVertexAISearchRetriever: {str(e)}")
+            raise
 
         #  For more information, refer to:
         # https://cloud.google.com/generative-ai-app-builder/docs/locations#specify_a_multi-region_for_your_data_store


### PR DESCRIPTION
This commit updates the VertexAISearchRetriever configuration to forbid unknown fields during initialization. This change ensures that users receive immediate feedback if they accidentally pass a wrong or misspelled attribute name, improving error handling and robustness of the initialization process.

The change modifies the Pydantic BaseModel configuration to set `extra = Extra.forbid`, which throws errors for any extraneous fields. This update is essential for preventing runtime errors related to attribute misconfigurations and is in line with best practices for Pydantic model setup.