### PR TITLE
vertexai, genai: add support for UsageMetadata

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -64,6 +64,7 @@ from langchain_core.messages import (
     ToolCallChunk,
     ToolMessage,
 )
+from langchain_core.messages.ai import UsageMetadata
 from langchain_core.output_parsers.openai_tools import parse_tool_calls
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.pydantic_v1 import Field, SecretStr, root_validator
@@ -526,6 +527,22 @@ def _response_to_result(
     """Converts a PaLM API response into a LangChain ChatResult."""
     llm_output = {"prompt_feedback": proto.Message.to_dict(response.prompt_feedback)}
 
+    # Get usage metadata
+    try:
+        input_tokens = response.usage_metadata.prompt_token_count
+        output_tokens = response.usage_metadata.candidates_token_count
+        total_tokens = response.usage_metadata.total_token_count
+        if input_tokens + output_tokens + total_tokens > 0:
+            lc_usage = UsageMetadata(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=total_tokens,
+            )
+        else:
+            lc_usage = None
+    except AttributeError:
+        lc_usage = None
+
     generations: List[ChatGeneration] = []
 
     for candidate in response.candidates:
@@ -536,9 +553,11 @@ def _response_to_result(
             proto.Message.to_dict(safety_rating, use_integers_for_enums=False)
             for safety_rating in candidate.safety_ratings
         ]
+        message = _parse_response_candidate(candidate, streaming=stream)
+        message.usage_metadata = lc_usage
         generations.append(
             (ChatGenerationChunk if stream else ChatGeneration)(
-                message=_parse_response_candidate(candidate, streaming=stream),
+                message=message,
                 generation_info=generation_info,
             )
         )

--- a/libs/genai/poetry.lock
+++ b/libs/genai/poetry.lock
@@ -469,7 +469,7 @@ files = [
 
 [[package]]
 name = "langchain-core"
-version = "0.2.0"
+version = "0.2.3"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.8.1,<4.0"
@@ -478,7 +478,7 @@ develop = false
 
 [package.dependencies]
 jsonpatch = "^1.33"
-langsmith = "^0.1.0"
+langsmith = "^0.1.65"
 packaging = "^23.2"
 pydantic = ">=1,<3"
 PyYAML = ">=5.3"
@@ -491,18 +491,18 @@ extended-testing = ["jinja2 (>=3,<4)"]
 type = "git"
 url = "https://github.com/langchain-ai/langchain.git"
 reference = "HEAD"
-resolved_reference = "c0e3c3a3508e2f2b5fcfff7dc697fa5eaa7d69d5"
+resolved_reference = "4d82cea71fc6e1dd3bebaf64db3c47ddb3762157"
 subdirectory = "libs/core"
 
 [[package]]
 name = "langsmith"
-version = "0.1.57"
+version = "0.1.67"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.1.57-py3-none-any.whl", hash = "sha256:dbd83b0944a2fbea4151f0aa053530d93fcf6784a580621bc60633cb890b57dc"},
-    {file = "langsmith-0.1.57.tar.gz", hash = "sha256:4682204de19f0218029c2b8445ce2cc3485c8d0df9796b31e2ce4c9051fce365"},
+    {file = "langsmith-0.1.67-py3-none-any.whl", hash = "sha256:7eb2e1c1b375925ff47700ed8071e10c15e942e9d1d634b4a449a9060364071a"},
+    {file = "langsmith-0.1.67.tar.gz", hash = "sha256:149558669a2ac4f21471cd964e61072687bba23b7c1ccb51f190a8f59b595b39"},
 ]
 
 [package.dependencies]
@@ -1380,4 +1380,4 @@ images = ["pillow"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "f64e624db97525f17985f04302131bc03e3779db64b952e5a17a8f6f5020024d"
+content-hash = "0db7cabe9f6895f9f550f33dc90454b6f9c569c62e2e320c9189b8fdddef8f87"

--- a/libs/genai/pyproject.toml
+++ b/libs/genai/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain-core = ">=0.2.0,<0.3"
+langchain-core = ">=0.2.2,<0.3"
 google-generativeai = "^0.5.2"
 pillow = { version = "^10.1.0", optional = true }
 

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -869,13 +869,15 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
                 message=question.content,
                 **msg_params,
             )
+        usage_metadata = response.raw_prediction_response.metadata
+        lc_usage = _get_usage_metadata_non_gemini(usage_metadata)
         generations = [
             ChatGeneration(
-                message=AIMessage(content=candidate.text),
+                message=AIMessage(content=candidate.text, usage_metadata=lc_usage),
                 generation_info=get_generation_info(
                     candidate,
                     self._is_gemini_model,
-                    usage_metadata=response.raw_prediction_response.metadata,
+                    usage_metadata=usage_metadata,
                 ),
             )
             for candidate in response.candidates
@@ -941,13 +943,15 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
                 max_retries=self.max_retries,
                 **msg_params,
             )
+        usage_metadata = response.raw_prediction_response.metadata
+        lc_usage = _get_usage_metadata_non_gemini(usage_metadata)
         generations = [
             ChatGeneration(
-                message=AIMessage(content=candidate.text),
+                message=AIMessage(content=candidate.text, usage_metadata=lc_usage),
                 generation_info=get_generation_info(
                     candidate,
                     self._is_gemini_model,
-                    usage_metadata=response.raw_prediction_response.metadata,
+                    usage_metadata=usage_metadata,
                 ),
             )
             for candidate in response.candidates
@@ -1205,11 +1209,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
     ) -> ChatResult:
         generations = []
         usage = proto.Message.to_dict(response.usage_metadata)
-        lc_usage = UsageMetadata(  # for langchain standard field
-            input_tokens=usage.get("prompt_token_count", 0),
-            output_tokens=usage.get("candidates_token_count", 0),
-            total_tokens=usage.get("total_token_count", 0),
-        )
+        lc_usage = _get_usage_metadata_gemini(usage)
         for candidate in response.candidates:
             info = get_generation_info(candidate, is_gemini=True, usage_metadata=usage)
             message = _parse_response_candidate(candidate)
@@ -1235,17 +1235,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         usage_metadata = proto.Message.to_dict(response_chunk.usage_metadata)
 
         # Gather langchain (standard) usage metadata
-        input_tokens = usage_metadata.get("prompt_token_count", 0)
-        output_tokens = usage_metadata.get("candidates_token_count", 0)
-        total_tokens = usage_metadata.get("total_token_count", 0)
-        if all(count == 0 for count in [input_tokens, output_tokens, total_tokens]):
-            lc_usage = None
-        else:
-            lc_usage = UsageMetadata(
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                total_tokens=total_tokens,
-            )
+        lc_usage = _get_usage_metadata_gemini(usage_metadata)
         if not response_chunk.candidates:
             message = AIMessageChunk(content="")
             if lc_usage:
@@ -1268,4 +1258,34 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         return ChatGenerationChunk(
             message=message,
             generation_info=generation_info,
+        )
+
+
+def _get_usage_metadata_gemini(raw_metadata: dict) -> Optional[UsageMetadata]:
+    """Get UsageMetadata from raw response metadata."""
+    input_tokens = raw_metadata.get("prompt_token_count", 0)
+    output_tokens = raw_metadata.get("candidates_token_count", 0)
+    total_tokens = raw_metadata.get("total_token_count", 0)
+    if all(count == 0 for count in [input_tokens, output_tokens, total_tokens]):
+        return None
+    else:
+        return UsageMetadata(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+        )
+
+
+def _get_usage_metadata_non_gemini(raw_metadata: dict) -> Optional[UsageMetadata]:
+    """Get UsageMetadata from raw response metadata."""
+    token_usage = raw_metadata.get("tokenMetadata", {})
+    input_tokens = token_usage.get("inputTokenCount", {}).get("totalTokens", 0)
+    output_tokens = token_usage.get("outputTokenCount", {}).get("totalTokens", 0)
+    if input_tokens == 0 and output_tokens == 0:
+        return None
+    else:
+        return UsageMetadata(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens = input_tokens + output_tokens,
         )

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -1287,5 +1287,5 @@ def _get_usage_metadata_non_gemini(raw_metadata: dict) -> Optional[UsageMetadata
         return UsageMetadata(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
-            total_tokens = input_tokens + output_tokens,
+            total_tokens=input_tokens + output_tokens,
         )

--- a/libs/vertexai/poetry.lock
+++ b/libs/vertexai/poetry.lock
@@ -1280,7 +1280,7 @@ subdirectory = "libs/langchain"
 
 [[package]]
 name = "langchain-core"
-version = "0.2.0"
+version = "0.2.3"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.8.1,<4.0"
@@ -1289,7 +1289,7 @@ develop = false
 
 [package.dependencies]
 jsonpatch = "^1.33"
-langsmith = "^0.1.0"
+langsmith = "^0.1.65"
 packaging = "^23.2"
 pydantic = ">=1,<3"
 PyYAML = ">=5.3"
@@ -1302,7 +1302,7 @@ extended-testing = ["jinja2 (>=3,<4)"]
 type = "git"
 url = "https://github.com/langchain-ai/langchain.git"
 reference = "HEAD"
-resolved_reference = "c0e3c3a3508e2f2b5fcfff7dc697fa5eaa7d69d5"
+resolved_reference = "8cbce684d4ec861cfd45edc4585365db81b93afd"
 subdirectory = "libs/core"
 
 [[package]]
@@ -1329,13 +1329,13 @@ subdirectory = "libs/text-splitters"
 
 [[package]]
 name = "langsmith"
-version = "0.1.43"
+version = "0.1.65"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.1.43-py3-none-any.whl", hash = "sha256:c0a3658f10cbefaa2f53d15db519592982b59d99f24e018dc73aca6092b4158d"},
-    {file = "langsmith-0.1.43.tar.gz", hash = "sha256:983c5a35bf191bb23d93e453c9fc6ea7cda998b1ca96f94680a1446092caf347"},
+    {file = "langsmith-0.1.65-py3-none-any.whl", hash = "sha256:ab4487029240e69cca30da1065f1e9138e5a7ca2bbe8c697f0bd7d5839f71cf7"},
+    {file = "langsmith-0.1.65.tar.gz", hash = "sha256:d3c2eb2391478bd79989f02652cf66e29a7959d677614b6993a47cef43f7f43b"},
 ]
 
 [package.dependencies]
@@ -2710,4 +2710,4 @@ anthropic = ["anthropic"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "eb51b29a359bc88d622e0da84e34e9f3804763e1ecf5a0c741d17d893d19244a"
+content-hash = "9cc6bc9f9038661b73dca7c080034d0b126013cfa6aca3ba2d63bddd93ce8a5f"

--- a/libs/vertexai/pyproject.toml
+++ b/libs/vertexai/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-langchain-core = ">=0.2.0,<0.3"
+langchain-core = ">=0.2.2,<0.3"
 google-cloud-aiplatform = "^1.47.0"
 google-cloud-storage = "^2.14.0"
 # optional dependencies

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -35,6 +35,10 @@ def _check_usage_metadata(message: AIMessage) -> None:
     assert message.usage_metadata["input_tokens"] > 0
     assert message.usage_metadata["output_tokens"] > 0
     assert message.usage_metadata["total_tokens"] > 0
+    assert (
+        message.usage_metadata["input_tokens"]
+        + message.usage_metadata["output_tokens"]
+    ) == message.usage_metadata["total_tokens"]
 
 
 @pytest.mark.release
@@ -59,8 +63,7 @@ def test_vertexai_single_call(model_name: Optional[str]) -> None:
     response = model([message])
     assert isinstance(response, AIMessage)
     assert isinstance(response.content, str)
-    if model_name == "gemini-1.0-pro-001":
-        _check_usage_metadata(response)
+    _check_usage_metadata(response)
 
 
 @pytest.mark.release
@@ -84,8 +87,7 @@ async def test_vertexai_agenerate(model_name: str) -> None:
     async_generation = cast(ChatGeneration, response.generations[0][0])
     output_message = async_generation.message
     assert isinstance(output_message, AIMessage)
-    if model_name == "gemini-1.0-pro-001":
-        _check_usage_metadata(output_message)
+    _check_usage_metadata(output_message)
 
     sync_response = model.generate([[message]])
     sync_generation = cast(ChatGeneration, sync_response.generations[0][0])

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -36,8 +36,7 @@ def _check_usage_metadata(message: AIMessage) -> None:
     assert message.usage_metadata["output_tokens"] > 0
     assert message.usage_metadata["total_tokens"] > 0
     assert (
-        message.usage_metadata["input_tokens"]
-        + message.usage_metadata["output_tokens"]
+        message.usage_metadata["input_tokens"] + message.usage_metadata["output_tokens"]
     ) == message.usage_metadata["total_tokens"]
 
 

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -113,7 +113,7 @@ def test_vertexai_stream(model_name: str) -> None:
         if chunk.usage_metadata:
             chunks_with_usage_metadata += 1
         full = chunk if full is None else full + chunk
-    if model_name == "gemini-1.0-pro-001":
+    if model._is_gemini_model:
         if chunks_with_usage_metadata != 1:
             pytest.fail("Expected exactly one chunk with usage metadata")
         assert isinstance(full, AIMessageChunk)


### PR DESCRIPTION
langchain-core 0.2.2 released a standard field to store usage metadata returned from chat model responses, such as input / output token counts. AIMessage objects have a `.usage_metadata` attribute which can hold a [UsageMetadata](https://api.python.langchain.com/en/latest/messages/langchain_core.messages.ai.UsageMetadata.html) dict. For now it is only holding token counts. Standardizing this information makes it simpler to track in monitoring / observability platforms and similar applications.

Here we unpack usage metadata returned by GenAI and Vertex gemini and non-gemini models onto AIMessages generated by chat models.