### PR TITLE
Fixes embeddings duplication in first call

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/embeddings.py
+++ b/libs/vertexai/langchain_google_vertexai/embeddings.py
@@ -265,6 +265,7 @@ class VertexAIEmbeddings(_VertexAICommon, Embeddings):
                     first_result = self._get_embeddings_with_retry(
                         first_batch, embeddings_type
                     )
+                    batches = batches[1:]
                     break
                 except InvalidArgument:
                     had_failure = True

--- a/libs/vertexai/tests/unit_tests/test_embeddings.py
+++ b/libs/vertexai/tests/unit_tests/test_embeddings.py
@@ -16,6 +16,18 @@ def test_langchain_google_vertexai_embed_image_multimodal_only() -> None:
         assert e.value == "Only supported for multimodal models"
 
 
+def test_langchain_google_vertexai_no_dups_dynamic_batch_size() -> None:
+    mock_embeddings = MockVertexAIEmbeddings("textembedding-gecko@001")
+    default_batch_size = mock_embeddings.instance["batch_size"]
+    texts = ["text_{i}" for i in range(default_batch_size * 2)]
+    # It should only return one batch (out of two) still to process
+    _, batches = mock_embeddings._prepare_and_validate_batches(texts=texts)
+    assert len(batches) == 1
+    # The second time it should return the batches unchanged
+    _, batches = mock_embeddings._prepare_and_validate_batches(texts=texts)
+    assert len(batches) == 2
+
+
 class MockVertexAIEmbeddings(VertexAIEmbeddings):
     """
     A mock class for avoiding instantiating VertexAI and the EmbeddingModel client


### PR DESCRIPTION
How to reproduce the error:

```
embedding_model = VertexAIEmbeddings(
    model_name="text-embedding-004",
    project=PROJECT_ID
)

queries = [f"random query{i}" for i in range(500)]

query_embeddings = embedding_model.embed(queries)

assert len(query_embeddings) == len(queries)
```