### PR TITLE
vertex: fix test

### DIFF
--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -609,7 +609,7 @@ def test_chat_vertexai_gemini_function_calling_with_multiple_parts() -> None:
         )
         tool_messages.append(tool_message)
 
-    result = llm_with_search.invoke([request, response, tool_message] + tool_messages)
+    result = llm_with_search.invoke([request, response] + tool_messages)
 
     assert isinstance(result, AIMessage)
     assert "brown" in result.content


### PR DESCRIPTION
Test has failed last two days with:

> google.api_core.exceptions.InvalidArgument: 400 Please ensure that function response turn comes immediately after a function call turn. And the number of function response parts should be equal to number of function call parts of the function call turn.

There should be one ToolMessage per tool call.