### PR TITLE
[Breaking] change the behavior of ChatVertexAI.with_structured_output when specifying a dict

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -1569,15 +1569,15 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             parser: OutputParserLike = PydanticToolsParser(
                 tools=[schema], first_tool_only=True
             )
-        elif isinstance(schema, dict) and all(
-            k in schema for k in ("title", "description", "properties")
-        ):
-            schema = convert_to_openai_function(schema)
-            parser = JsonOutputKeyToolsParser(
-                key_name=schema["name"], first_tool_only=True
-            )
         else:
-            parser = JsonOutputToolsParser()
+            try:
+                schema = convert_to_openai_function(schema)
+            except Exception:
+                parser = JsonOutputToolsParser()
+            else:
+                parser = JsonOutputKeyToolsParser(
+                    key_name=schema["name"], first_tool_only=True
+                )
         llm = self.bind_tools([schema], tool_choice=self._is_gemini_advanced)
         if include_raw:
             parser_with_fallback = RunnablePassthrough.assign(

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -52,15 +52,13 @@ from langchain_core.messages import (
 from langchain_core.messages.ai import UsageMetadata
 from langchain_core.output_parsers.base import OutputParserLike
 from langchain_core.output_parsers.openai_tools import (
-    JsonOutputKeyToolsParser,
     JsonOutputToolsParser,
     PydanticToolsParser,
 )
 from langchain_core.output_parsers.openai_tools import parse_tool_calls
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.pydantic_v1 import BaseModel, root_validator, Field
-from langchain_core.runnables import Runnable, RunnablePassthrough
-from langchain_core.utils.function_calling import convert_to_openai_function
+from langchain_core.runnables import Runnable, RunnablePassthrough, RunnableGenerator
 from vertexai.generative_models import (  # type: ignore
     Tool as VertexTool,
 )
@@ -1478,6 +1476,15 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
     ) -> Runnable[LanguageModelInput, Union[Dict, BaseModel]]:
         """Model wrapper that returns outputs formatted to match the given schema.
 
+        .. versionchanged:: 1.1.0
+
+            Return type corrected in version 1.1.0. Previously if a dict schema
+            was provided then the output had the form
+            ``[{"args": {}, "name": "schema_name"}]`` where the output was a list with
+            a single dict and the "args" of the one dict corresponded to the schema.
+            As of `1.1.0` this has been fixed so that the schema (the value
+            corresponding to the old "args" key) is returned directly.
+
         Args:
             schema: The output schema as a dict or a Pydantic class. If a Pydantic class
                 then the model output will be an object of that class. If a dict then
@@ -1570,14 +1577,9 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
                 tools=[schema], first_tool_only=True
             )
         else:
-            try:
-                schema = convert_to_openai_function(schema)
-            except Exception:
-                parser = JsonOutputToolsParser()
-            else:
-                parser = JsonOutputKeyToolsParser(
-                    key_name=schema["name"], first_tool_only=True
-                )
+            parser = JsonOutputToolsParser(first_tool_only=True) | RunnableGenerator(
+                _yield_args
+            )
         llm = self.bind_tools([schema], tool_choice=self._is_gemini_advanced)
         if include_raw:
             parser_with_fallback = RunnablePassthrough.assign(
@@ -1693,6 +1695,11 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             message=message,
             generation_info=generation_info,
         )
+
+
+def _yield_args(tool_call_chunks: Iterator[dict]) -> Iterator[dict]:
+    for tc in tool_call_chunks:
+        yield tc["args"]
 
 
 def _get_usage_metadata_gemini(raw_metadata: dict) -> Optional[UsageMetadata]:

--- a/libs/vertexai/langchain_google_vertexai/functions_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/functions_utils.py
@@ -24,7 +24,10 @@ from langchain_core.outputs import ChatGeneration, Generation
 from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.tools import BaseTool
 from langchain_core.tools import tool as callable_as_lc_tool
-from langchain_core.utils.function_calling import FunctionDescription
+from langchain_core.utils.function_calling import (
+    FunctionDescription,
+    convert_to_openai_tool,
+)
 from langchain_core.utils.json_schema import dereference_refs
 
 logger = logging.getLogger(__name__)
@@ -169,11 +172,8 @@ def _format_to_gapic_function_declaration(
     elif isinstance(tool, dict):
         # this could come from
         # 'langchain_core.utils.function_calling.convert_to_openai_tool'
-        if tool.get("type") == "function" and tool.get("function"):
-            return _format_dict_to_function_declaration(
-                cast(FunctionDescription, tool.get("function"))
-            )
-        return _format_dict_to_function_declaration(tool)
+        function = convert_to_openai_tool(cast(dict, tool))["function"]
+        return _format_dict_to_function_declaration(cast(FunctionDescription, function))
     else:
         raise ValueError(f"Unsupported tool call type {tool}")
 

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -545,16 +545,15 @@ def test_chat_vertexai_gemini_function_calling_with_structured_output() -> None:
         {"name": "MyModel", "description": "MyModel", "parameters": MyModel.schema()}
     )
     response = model.invoke([message])
-    expected = [
+    assert response == [
         {
             "type": "MyModel",
             "args": {
                 "name": "Erick",
                 "age": 27,
-            }
+            },
         }
     ]
-    assert response == expected
 
     model = llm.with_structured_output(
         {
@@ -569,11 +568,10 @@ def test_chat_vertexai_gemini_function_calling_with_structured_output() -> None:
         }
     )
     response = model.invoke([message])
-    expected = {
+    assert response == {
         "name": "Erick",
         "age": 27,
     }
-    assert response == expected
 
 
 @pytest.mark.release

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -545,10 +545,16 @@ def test_chat_vertexai_gemini_function_calling_with_structured_output() -> None:
         {"name": "MyModel", "description": "MyModel", "parameters": MyModel.schema()}
     )
     response = model.invoke([message])
-    expected = {
-        "name": "Erick",
-        "age": 27,
-    }
+    expected = [
+        {
+            "type": "MyModel",
+            "args": {
+                "name": "Erick",
+                "age": 27,
+            }
+        }
+    ]
+    assert response == expected
 
     model = llm.with_structured_output(
         {
@@ -563,6 +569,10 @@ def test_chat_vertexai_gemini_function_calling_with_structured_output() -> None:
         }
     )
     response = model.invoke([message])
+    expected = {
+        "name": "Erick",
+        "age": 27,
+    }
     assert response == expected
 
 

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -545,15 +545,18 @@ def test_chat_vertexai_gemini_function_calling_with_structured_output() -> None:
         {"name": "MyModel", "description": "MyModel", "parameters": MyModel.schema()}
     )
     response = model.invoke([message])
-    expected = [
-        {
-            "type": "MyModel",
-            "args": {
-                "name": "Erick",
-                "age": 27,
-            },
-        }
-    ]
+    expected = {
+        "name": "Erick",
+        "age": 27,
+    }
+
+    model = llm.with_structured_output(
+        {"title": "MyModel", "description": "MyModel", "type": "object", "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+        }, "required": ["name", "age"]}
+    )
+    response = model.invoke([message])
     assert response == expected
 
 

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -545,15 +545,10 @@ def test_chat_vertexai_gemini_function_calling_with_structured_output() -> None:
         {"name": "MyModel", "description": "MyModel", "parameters": MyModel.schema()}
     )
     response = model.invoke([message])
-    assert response == [
-        {
-            "type": "MyModel",
-            "args": {
-                "name": "Erick",
-                "age": 27,
-            },
-        }
-    ]
+    assert response == {
+        "name": "Erick",
+        "age": 27,
+    }
 
     model = llm.with_structured_output(
         {

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -551,10 +551,16 @@ def test_chat_vertexai_gemini_function_calling_with_structured_output() -> None:
     }
 
     model = llm.with_structured_output(
-        {"title": "MyModel", "description": "MyModel", "type": "object", "properties": {
-            "name": {"type": "string"},
-            "age": {"type": "integer"},
-        }, "required": ["name", "age"]}
+        {
+            "title": "MyModel",
+            "description": "MyModel",
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+            },
+            "required": ["name", "age"],
+        }
     )
     response = model.invoke([message])
     assert response == expected


### PR DESCRIPTION
The behavior of `ChatVertexAI.with_structured_output` when specifying a `dict` was different from `ChatOpenAI` and `ChatAnthropicVertex`, so it has been corrected.

- Modified to accept not only the `["name", "description", "parameters"]` format for the `dict` but also `["title", "description", "properties"]`.
- When a `dict` is specified as the schema, it now extracts properties from the output.

This is considered breaking as it changes existing functionality.
If this change is unacceptable, please feel free to close it.