### PR TITLE
chore: add stop_reason in ChatAnthropicVertex stream response

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
@@ -314,6 +314,10 @@ def _make_message_chunk_from_anthropic_event(
                 output_tokens=output_tokens,
                 total_tokens=output_tokens,
             ),
+            response_metadata={
+                "stop_reason": event.delta.stop_reason,
+                "stop_sequence": event.delta.stop_sequence,
+            },
         )
     else:
         pass


### PR DESCRIPTION
Allow `ChatVertexAI` to get `stop_reason` in the `AIMessage` of the `stream`, `astream` result.
The reason for this change is that the `stop_reason` is also used in streaming to determine the next action.

```python
ai_message_chunk: AIMessageChunk = None
for chunk in model.stream([HumanMessage(content="Hello, world!")]):
    ai_message_chunk = ai_message_chunk + chunk if ai_message_chunk else chunk
print(ai_message_chunk.response_metadata["stop_reason"], ai_message.response_metadata["stop_sequence"])
# end_turn None
```
