### PR TITLE
[ChatVertexAI] Get `api_transport` from  initializer when not provided

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -101,6 +101,8 @@ class _VertexAIBase(BaseModel):
             values["model_name"] = values.pop("model")
         if values.get("project") is None:
             values["project"] = initializer.global_config.project
+        if values.get("api_transport") is None:
+            values["api_transport"] = initializer.global_config._api_transport
         if values.get("api_endpoint"):
             api_endpoint = values["api_endpoint"]
         else:

--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -75,7 +75,9 @@ class _VertexAIBase(BaseModel):
     api_endpoint: Optional[str] = Field(None, alias="base_url")
     "Desired API endpoint, e.g., us-central1-aiplatform.googleapis.com"
     api_transport: Optional[str] = None
-    """The desired API transport method, can be either 'grpc' or 'rest'"""
+    """The desired API transport method, can be either 'grpc' or 'rest'. 
+    Uses the default parameter in vertexai.init if defined.
+    """
     default_metadata: Sequence[Tuple[str, str]] = Field(
         default_factory=list
     )  #: :meta private:


### PR DESCRIPTION
- Pulls the `api_transport` parameter from the default initializer if not provided