### PR TITLE
Add InternalServerError to retry_errors in VertexAIEmbeddings

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/embeddings.py
+++ b/libs/vertexai/langchain_google_vertexai/embeddings.py
@@ -12,6 +12,7 @@ from google.api_core.exceptions import (
     InvalidArgument,
     ResourceExhausted,
     ServiceUnavailable,
+    InternalServerError,
 )
 from google.cloud.aiplatform import telemetry
 from langchain_core.embeddings import Embeddings
@@ -154,6 +155,7 @@ class VertexAIEmbeddings(_VertexAICommon, Embeddings):
             ServiceUnavailable,
             Aborted,
             DeadlineExceeded,
+            InternalServerError,
         ]
         retry_decorator = create_base_retry_decorator(
             error_types=retry_errors, max_retries=self.max_retries

--- a/libs/vertexai/langchain_google_vertexai/embeddings.py
+++ b/libs/vertexai/langchain_google_vertexai/embeddings.py
@@ -9,10 +9,10 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Type
 from google.api_core.exceptions import (
     Aborted,
     DeadlineExceeded,
+    InternalServerError,
     InvalidArgument,
     ResourceExhausted,
     ServiceUnavailable,
-    InternalServerError,
 )
 from google.cloud.aiplatform import telemetry
 from langchain_core.embeddings import Embeddings


### PR DESCRIPTION
The endpoint sometimes returns 500 error but when retrying the call it works