### PR TITLE
Make GCSDocumentStorage.mset 10x faster and add default retry

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
@@ -4,10 +4,10 @@ import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Sequence, Tuple
-from google.cloud.storage import transfer_manager
-from google.cloud.storage.retry import DEFAULT_RETRY
 
 from google.cloud import storage  # type: ignore[attr-defined, unused-ignore]
+from google.cloud.storage import transfer_manager
+from google.cloud.storage.retry import DEFAULT_RETRY
 from langchain_core.documents import Document
 from langchain_core.stores import BaseStore
 
@@ -48,11 +48,13 @@ class GCSDocumentStorage(DocumentStorage):
                 with open(Path(tmp_folder) / key, "w") as f:
                     json.dump(value.dict(), f)
 
-            transfer_manager.upload_many_from_filenames(self._bucket,
-                                                        [item[0] for item in key_value_pairs],
-                                                        blob_name_prefix=f'{self._prefix}/',
-                                                        source_directory=tmp_folder,
-                                                        upload_kwargs={"retry": DEFAULT_RETRY})
+            transfer_manager.upload_many_from_filenames(
+                self._bucket,
+                [item[0] for item in key_value_pairs],
+                blob_name_prefix=f"{self._prefix}/",
+                source_directory=tmp_folder,
+                upload_kwargs={"retry": DEFAULT_RETRY},
+            )
 
     def mget(self, keys: Sequence[str]) -> List[Optional[Document]]:
         """Gets a batch of documents by id.

--- a/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
@@ -37,7 +37,7 @@ class GCSDocumentStorage(DocumentStorage):
         self._bucket = bucket
         self._prefix = prefix
 
-    def mset(self, key_value_pairs: Sequence[Tuple[str, Document]]) -> None:
+    def mset(self, key_value_pairs: Sequence[Tuple[str, Document]], **kwargs) -> None:
         """Stores a series of documents using each keys
 
         Args:
@@ -47,13 +47,15 @@ class GCSDocumentStorage(DocumentStorage):
             for key, value in key_value_pairs:
                 with open(Path(tmp_folder) / key, "w") as f:
                     json.dump(value.dict(), f)
-
+                    
+            prefix = f"{self._prefix}/" if self._prefix else ""
             transfer_manager.upload_many_from_filenames(
                 self._bucket,
                 [item[0] for item in key_value_pairs],
-                blob_name_prefix=f"{self._prefix}/",
+                blob_name_prefix=prefix,
                 source_directory=tmp_folder,
                 upload_kwargs={"retry": DEFAULT_RETRY},
+                **kwargs
             )
 
     def mget(self, keys: Sequence[str]) -> List[Optional[Document]]:


### PR DESCRIPTION
Currently GCSDocumentStorage.mset uploads files at a rate of about 200 per minute. That is very slow for large scale production projects so I refactored it to use transfer manager to get to a speed of about 2000 files per minute.
In addition currently this method fails on backend error which occur from time to time as mentioned in the GCS documentation. To prevent failures I've enabled the default retry mechanism.