### PR TITLE
Fix optional fields in Pydantic models

### DIFF
--- a/libs/community/langchain_google_community/gmail/create_draft.py
+++ b/libs/community/langchain_google_community/gmail/create_draft.py
@@ -24,11 +24,11 @@ class CreateDraftSchema(BaseModel):
         description="The subject of the message.",
     )
     cc: Optional[List[str]] = Field(
-        None,
+        default=None,
         description="The list of CC recipients.",
     )
     bcc: Optional[List[str]] = Field(
-        None,
+        default=None,
         description="The list of BCC recipients.",
     )
 

--- a/libs/community/langchain_google_community/gmail/send_message.py
+++ b/libs/community/langchain_google_community/gmail/send_message.py
@@ -27,11 +27,11 @@ class SendMessageSchema(BaseModel):
         description="The subject of the message.",
     )
     cc: Optional[Union[str, List[str]]] = Field(
-        None,
+        default=None,
         description="The list of CC recipients.",
     )
     bcc: Optional[Union[str, List[str]]] = Field(
-        None,
+        default=None,
         description="The list of BCC recipients.",
     )
 

--- a/libs/community/langchain_google_community/places_api.py
+++ b/libs/community/langchain_google_community/places_api.py
@@ -30,7 +30,7 @@ class GooglePlacesAPIWrapper(BaseModel):
     """
 
     gplaces_api_key: Optional[str] = None
-    google_map_client: Any  #: :meta private:
+    google_map_client: Any = None  #: :meta private:
     top_k_results: Optional[int] = None
 
     class Config:

--- a/libs/community/langchain_google_community/search.py
+++ b/libs/community/langchain_google_community/search.py
@@ -47,7 +47,7 @@ class GoogleSearchAPIWrapper(BaseModel):
 
     """
 
-    search_engine: Any  #: :meta private:
+    search_engine: Any = None  #: :meta private:
     google_api_key: Optional[str] = None
     google_cse_id: Optional[str] = None
     k: int = 10

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -788,7 +788,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
     client: Any  #: :meta private:
     async_client: Any  #: :meta private:
-    google_api_key: Optional[SecretStr] = Field(None, alias="api_key")
+    google_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
     """Google AI API key. 
         
     If not specified will be read from env var ``GOOGLE_API_KEY``."""

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -786,8 +786,8 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
     """  # noqa: E501
 
-    client: Any  #: :meta private:
-    async_client: Any  #: :meta private:
+    client: Any = None  #: :meta private:
+    async_client: Any = None  #: :meta private:
     google_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
     """Google AI API key. 
         

--- a/libs/genai/langchain_google_genai/embeddings.py
+++ b/libs/genai/langchain_google_genai/embeddings.py
@@ -46,13 +46,13 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
         "Example: models/embedding-001",
     )
     task_type: Optional[str] = Field(
-        None,
+        default=None,
         description="The task type. Valid options include: "
         "task_type_unspecified, retrieval_query, retrieval_document, "
         "semantic_similarity, classification, and clustering",
     )
     google_api_key: Optional[SecretStr] = Field(
-        None,
+        default=None,
         description="The Google API key to use. If not provided, "
         "the GOOGLE_API_KEY environment variable will be used.",
     )
@@ -64,18 +64,18 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
         "provided, credentials will be ascertained from the GOOGLE_API_KEY envvar",
     )
     client_options: Optional[Dict] = Field(
-        None,
+        default=None,
         description=(
             "A dictionary of client options to pass to the Google API client, "
             "such as `api_endpoint`."
         ),
     )
     transport: Optional[str] = Field(
-        None,
+        default=None,
         description="A string, one of: [`rest`, `grpc`, `grpc_asyncio`].",
     )
     request_options: Optional[Dict] = Field(
-        None,
+        default=None,
         description="A dictionary of request options to pass to the Google API client."
         "Example: `{'timeout': 10}`",
     )

--- a/libs/genai/langchain_google_genai/embeddings.py
+++ b/libs/genai/langchain_google_genai/embeddings.py
@@ -39,7 +39,7 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
             embeddings.embed_query("What's our Q1 revenue?")
     """
 
-    client: Any  #: :meta private:
+    client: Any = None  #: :meta private:
     model: str = Field(
         ...,
         description="The name of the embedding model to use. "

--- a/libs/genai/langchain_google_genai/llms.py
+++ b/libs/genai/langchain_google_genai/llms.py
@@ -212,7 +212,7 @@ class GoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseLLM):
             llm = GoogleGenerativeAI(model="gemini-pro")
     """
 
-    client: Any  #: :meta private:
+    client: Any = None  #: :meta private:
 
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:

--- a/libs/genai/langchain_google_genai/llms.py
+++ b/libs/genai/langchain_google_genai/llms.py
@@ -149,18 +149,18 @@ Supported examples:
     """The maximum number of seconds to wait for a response."""
 
     client_options: Optional[Dict] = Field(
-        None,
+        default=None,
         description=(
             "A dictionary of client options to pass to the Google API client, "
             "such as `api_endpoint`."
         ),
     )
     transport: Optional[str] = Field(
-        None,
+        default=None,
         description="A string, one of: [`rest`, `grpc`, `grpc_asyncio`].",
     )
     additional_headers: Optional[Dict[str, str]] = Field(
-        None,
+        default=None,
         description=(
             "A key-value dictionary representing additional headers for the model call"
         ),

--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -72,7 +72,7 @@ class _VertexAIBase(BaseModel):
     client_options: Optional["ClientOptions"] = Field(
         default=None, exclude=True
     )  #: :meta private:
-    api_endpoint: Optional[str] = Field(None, alias="base_url")
+    api_endpoint: Optional[str] = Field(default=None, alias="base_url")
     "Desired API endpoint, e.g., us-central1-aiplatform.googleapis.com"
     api_transport: Optional[str] = None
     """The desired API transport method, can be either 'grpc' or 'rest'. 

--- a/libs/vertexai/tests/integration_tests/test_chains.py
+++ b/libs/vertexai/tests/integration_tests/test_chains.py
@@ -16,7 +16,7 @@ class RecordPerson(BaseModel):
 
     name: str = Field(..., description="The person's name")
     age: int = Field(..., description="The person's age")
-    fav_food: Optional[str] = Field(None, description="The person's favorite food")
+    fav_food: Optional[str] = Field(default=None, description="The person's favorite food")
 
 
 class RecordDog(BaseModel):
@@ -24,7 +24,7 @@ class RecordDog(BaseModel):
 
     name: str = Field(..., description="The dog's name")
     color: str = Field(..., description="The dog's color")
-    fav_food: Optional[str] = Field(None, description="The dog's favorite food")
+    fav_food: Optional[str] = Field(default=None, description="The dog's favorite food")
 
 
 @pytest.mark.release

--- a/libs/vertexai/tests/integration_tests/test_chains.py
+++ b/libs/vertexai/tests/integration_tests/test_chains.py
@@ -16,7 +16,9 @@ class RecordPerson(BaseModel):
 
     name: str = Field(..., description="The person's name")
     age: int = Field(..., description="The person's age")
-    fav_food: Optional[str] = Field(default=None, description="The person's favorite food")
+    fav_food: Optional[str] = Field(
+        default=None, description="The person's favorite food"
+    )
 
 
 class RecordDog(BaseModel):


### PR DESCRIPTION
## Problem

[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) is flagging initialization of some [Pydantic](https://docs.pydantic.dev/latest/) objects (ie. objects of classes extending [`BaseModel`](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel)) as having missing arguments when optional arguments are not provided. Although the code still runs as it should, this type of error is a potential source of frustration for VS Code users.

### Example

For example, according to the doc string for the [`GoogleGenerativeAIEmbeddings`](https://api.python.langchain.com/en/latest/embeddings/langchain_google_genai.embeddings.GoogleGenerativeAIEmbeddings.html) class, it can be used in the following way:

```python
from langchain_google_genai import GoogleGenerativeAIEmbeddings

embeddings = GoogleGenerativeAIEmbeddings(model="models/embedding-001")
embeddings.embed_query("What's our Q1 revenue?")
```

When editing the same code in Visual Studio Code with the Pylance extension enabled, following error is encountered.
![image](https://github.com/user-attachments/assets/c8b97f79-a757-40a3-8828-2ffa7fe40a3d)

In this case, the parameters `task_type`, `google_api_key`, `client_options`, `transport`, and `request_options` are clearly optional, as indicated by the `None` type. `client` does not have the `None` type, but is also optional since it is not provided in the example code snippet.

Note that Pylance does not flag the absence of the `credentials` field, even though it is also optional, and that the only field with a _recognized_ default value (`= None`) is `credentials`.

## Causes

Upon closer examination of the code, it becomes evident that some definitions for Pydantic fields are not handled by Pylance as intended. Examining the definition of [`GoogleGenerativeAIEmbeddings`](https://api.python.langchain.com/en/latest/embeddings/langchain_google_genai.embeddings.GoogleGenerativeAIEmbeddings.html) from the previous example (some methods, field descriptions and doc string for class are redacted for the sake of brevity):

```python
class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
    # <doc string>

    client: Any  #: :meta private:
    model: str = Field(
        ...,
        description="...",
    )
    task_type: Optional[str] = Field(
        None,
        description="...",
    )
    google_api_key: Optional[SecretStr] = Field(
        None,
        description="...",
    )
    credentials: Any = Field(
        default=None,  # <- notice the default keyword
        exclude=True,
        description="...",
    )
    client_options: Optional[Dict] = Field(
        None,
        description="...",
    )
    transport: Optional[str] = Field(
        None,
        description="...",
    )
    request_options: Optional[Dict] = Field(
        None,
        description="...",
    )

    @root_validator()
    def validate_environment(cls, values: Dict) -> Dict:
        """Validates params and passes them to google-generativeai package."""
        google_api_key = get_from_dict_or_env(
            values, "google_api_key", "GOOGLE_API_KEY"
        )
        client_info = get_client_info("GoogleGenerativeAIEmbeddings")

        values["client"] = build_generative_service(
            credentials=values.get("credentials"),
            api_key=google_api_key,
            client_info=client_info,
            client_options=values.get("client_options"),
        )
        return values


    # <other methods>
```

we can see that except for `client` and `model` all other fields are given a default value by [`Field`](https://docs.pydantic.dev/latest/api/fields/#pydantic.fields.Field). However, the only default value recognized by Pylance is the one for `credentials`. And it is no coincidence that `credentials` is also the only field where the default value is defined using the `default` **keyword** argument.

It is safe to say that the errors related to `task_type`, `google_api_key`, `client_options`, `transport`, and `request_options` are caused by the default value for them not being provided with the keyword arguments. (Unfortunately, I am not sure why this is the case.)

For the `client` case, we can assume that it's default value is `None`, since it's set within the `validate_environment` method. This case is not explicitly declared, which makes Pylance angry.

### TL;DR
The problem seems to be caused by two different cases:

1. The default value for an optional field is not provided (such as `client` in [`GoogleGenerativeAIEmbeddings`](https://api.python.langchain.com/en/latest/embeddings/langchain_google_genai.embeddings.GoogleGenerativeAIEmbeddings.html)).
2. The default value for an optional field is provided without the `default` keyword using `Field`.

## Solution

Find all the field definitions that are causing problems and fix them. 

To find the examples for the first case, I searched for field definitions of type `Any` without a default value, similar to `client` in [`GoogleGenerativeAIEmbeddings`](https://api.python.langchain.com/en/latest/embeddings/langchain_google_genai.embeddings.GoogleGenerativeAIEmbeddings.html). For the second case, I searched for optional fields using the `Optional[.*] = Field(` regex and manually checked for definitions without the `default` keyword.

It was trivial to apply the fix after finding the faulty lines.
