### PR TITLE
Fix: BigQueryVectorStore crashes on BQ tables with more than 5000 rows

### DIFF
--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -138,7 +138,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
 
         if "_last_index_check" not in values:
             values["_last_index_check"] = datetime.min
-        
+ 
         if datetime.utcnow() - values["_last_index_check"] < INDEX_CHECK_INTERVAL:
             return values
 

--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -138,7 +138,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
 
         if "_last_index_check" not in values:
             values["_last_index_check"] = datetime.min
- 
+
         if datetime.utcnow() - values["_last_index_check"] < INDEX_CHECK_INTERVAL:
             return values
 

--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -136,6 +136,9 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             values["_logger"].debug("Not enough rows to create a vector index.")
             return values
 
+        if "_last_index_check" not in values:
+            values["_last_index_check"] = datetime.min
+        
         if datetime.utcnow() - values["_last_index_check"] < INDEX_CHECK_INTERVAL:
             return values
 


### PR DESCRIPTION
Fixes #364 