### PR TITLE
add finish_reason to gemini gen info

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_utils.py
@@ -178,6 +178,11 @@ def get_generation_info(
                 else None
             ),
             "usage_metadata": usage_metadata,
+            "finish_reason": (
+                candidate.finish_reason.name
+                if candidate.finish_reason
+                else None
+            ),
         }
         try:
             if candidate.grounding_metadata:

--- a/libs/vertexai/langchain_google_vertexai/_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_utils.py
@@ -179,9 +179,7 @@ def get_generation_info(
             ),
             "usage_metadata": usage_metadata,
             "finish_reason": (
-                candidate.finish_reason.name
-                if candidate.finish_reason
-                else None
+                candidate.finish_reason.name if candidate.finish_reason else None
             ),
         }
         try:


### PR DESCRIPTION
https://github.com/langchain-ai/langchain-google/issues/351

Note that `langchain_google_genai.chat_models` does not add the field if 'finish_reason' is empty.

https://github.com/langchain-ai/langchain-google/blob/c92d2b95145091aa0ee69d3db63ff882d7be8e45/libs/genai/langchain_google_genai/chat_models.py#L552-L553

However, I added the field as `None` to be consistent with 'citation_metadata'

https://github.com/langchain-ai/langchain-google/blob/c92d2b95145091aa0ee69d3db63ff882d7be8e45/libs/vertexai/langchain_google_vertexai/_utils.py#L175-L179

Let me know if you would like me to change it to match with `langchain_google_genai`