### PR TITLE
fix: wrong page number in document metadata

### DIFF
--- a/libs/community/langchain_google_community/vertex_ai_search.py
+++ b/libs/community/langchain_google_community/vertex_ai_search.py
@@ -150,14 +150,14 @@ class _BaseVertexAISearchRetriever(Serializable):
                 continue
 
             for chunk in derived_struct_data[chunk_type]:
-                doc_metadata["source"] = derived_struct_data.get("link", "")
+                chunk_metadata = doc_metadata.copy()
+                chunk_metadata["source"] = derived_struct_data.get("link", "")
 
                 if chunk_type == "extractive_answers":
-                    doc_metadata["source"] += f":{chunk.get('pageNumber', '')}"
-
+                    chunk_metadata["source"] += f":{chunk.get('pageNumber', '')}"
                 documents.append(
                     Document(
-                        page_content=chunk.get("content", ""), metadata=doc_metadata
+                        page_content=chunk.get("content", ""), metadata=chunk_metadata
                     )
                 )
 


### PR DESCRIPTION
Issue:
The doc_metadata dictionary is mutable, and its reference is reused across iterations. This means any modifications to doc_metadata during one iteration affect the metadata of all previously appended documents in the documents list. Since doc_metadata is modified in place (changing the "source" field), all documents in the documents list end up sharing the same metadata object. Thus, when the "source" is updated with a new pageNumber, it retroactively alters the metadata for all documents, causing unexpected and incorrect metadata values. Therefore, instead of each document having its own metadata with the correct pageNumber, all documents have their "source" pointing to the latest pageNumber processed in the loop.

Fix:
The changes are made by referring to [GoogleVertexAISearch](https://github.com/langchain-ai/langchain/blob/aade9bfde55c068648ab55a1a9f4098327d01be7/libs/community/langchain_community/retrievers/google_vertex_ai_search.py#L141). A new copy of the metadata is created for each iteration. This ensures that modifications in one iteration do not affect the metadata of documents created in previous iterations. Thus, each document appended to the documents list has its own independent chunk_metadata object, meaning changes to chunk_metadata only affect the current document being processed. Since each Document instance is associated with a separate chunk_metadata object, the source field accurately reflects the correct link and pageNumber for each chunk of data.