### PR TITLE
Support page number for segments

### DIFF
--- a/libs/community/langchain_google_community/vertex_ai_search.py
+++ b/libs/community/langchain_google_community/vertex_ai_search.py
@@ -152,7 +152,7 @@ class _BaseVertexAISearchRetriever(Serializable):
             for chunk in derived_struct_data[chunk_type]:
                 doc_metadata["source"] = derived_struct_data.get("link", "")
 
-                if chunk_type == "extractive_answers":
+                if chunk_type == "extractive_answers" or chunk_type == "extractive_segments":
                     doc_metadata["source"] += f":{chunk.get('pageNumber', '')}"
 
                 documents.append(

--- a/libs/community/langchain_google_community/vertex_ai_search.py
+++ b/libs/community/langchain_google_community/vertex_ai_search.py
@@ -152,7 +152,10 @@ class _BaseVertexAISearchRetriever(Serializable):
             for chunk in derived_struct_data[chunk_type]:
                 doc_metadata["source"] = derived_struct_data.get("link", "")
 
-                if chunk_type == "extractive_answers" or chunk_type == "extractive_segments":
+                if (
+                    chunk_type == "extractive_answers"
+                    or chunk_type == "extractive_segments"
+                ):
                     doc_metadata["source"] += f":{chunk.get('pageNumber', '')}"
 
                 documents.append(


### PR DESCRIPTION
Today, VertexAISearchRetriever allows to pass as arguments:
- get_extractive_answers=True => to get answers
- get_extractive_answers=False => to get segments

In the current behaviour, when get_extractive_answers=True (get answers), page numbers are appended at the end of the source field.
However, this is not the case for get_extractive_answers=False (get segments), although the field is present in the Vertex AI Search API answer.

This small change allows to also get the page number, when segments (get_extractive_answers=False) is used