### PR TITLE
Support chaining in vision models

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/vision_models.py
+++ b/libs/vertexai/langchain_google_vertexai/vision_models.py
@@ -459,9 +459,13 @@ class VertexAIImageGeneratorChat(_BaseVertexAIImageGenerator, BaseChatModel):
 
         # Only one message allowed with one text part.
         user_query = None
-        is_valid = len(messages) == 1 and len(messages[0].content) == 1
-        if is_valid:
-            user_query = get_text_str_from_content_part(messages[0].content[0])
+
+        if len(messages) == 1:
+            if isinstance(messages[0].content, str):
+                user_query = messages[0].content
+            elif len(messages[0].content) == 1:
+                user_query = get_text_str_from_content_part(messages[0].content[0])
+
         if user_query is None:
             raise ValueError(
                 "Only one message with one text part allowed for image generation"

--- a/libs/vertexai/tests/integration_tests/test_vision_models.py
+++ b/libs/vertexai/tests/integration_tests/test_vision_models.py
@@ -1,5 +1,6 @@
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.prompts import PromptTemplate
 
 from langchain_google_vertexai.vision_models import (
     VertexAIImageCaptioning,
@@ -127,6 +128,18 @@ def test_vertex_ai_image_generation_and_edition():
     assert isinstance(response, AIMessage)
 
     generated_image = response.content[0]
+
+    model = VertexAIImageGeneratorChat()
+
+    prompt = PromptTemplate(
+        template="I want an image of {img_object} in {img_context}.",
+        input_variables=["img_object", "img_context"],
+    )
+
+    chain = prompt | model
+
+    response = chain.invoke(dict(img_object="cat", img_context="beach"))
+    assert isinstance(response, AIMessage)
 
     editor = VertexAIImageEditorChat()
 


### PR DESCRIPTION
Add support for chains with text content in `VertexAIImageGeneratorChat`

Related to issue #382 