### PR TITLE
Fix support for additional headers

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -248,7 +248,7 @@ class _VertexAICommon(_VertexAIBase):
             credentials=values.get("credentials"),
             api_transport=values.get("api_transport"),
             api_endpoint=values.get("api_endpoint"),
-            request_metadata=values.get("request_metadata"),
+            request_metadata=values.get("default_metadata"),
         )
         return None
 


### PR DESCRIPTION
in current implementation there is :
```python
        vertexai.init(
            project=values.get("project"),
            location=values.get("location"),
            credentials=values.get("credentials"),
            api_transport=values.get("api_transport"),
            api_endpoint=values.get("api_endpoint"),
            request_metadata=values.get("request_metadata"),
        )
```
but `request_metadata` is ignored by pydantic as an extra and `default_metadata` is proper field that is storing additional headers