### PR TITLE
Fix vertexaimodel

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from concurrent.futures import Executor
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Sequence, Tuple
 
@@ -365,11 +366,16 @@ class _BaseVertexAIModelGarden(_VertexAIBase):
         return LLMResult(generations=generations)
 
     def _parse_prediction(self, prediction: Any) -> str:
+
         if isinstance(prediction, str):
+            if prediction.startswith("Prompt:\n"):
+                return re.search(r"(?s:.*)\nOutput:\n(.*)",prediction)[1]
             return prediction
 
         if self.result_arg:
             try:
+                if prediction[self.result_arg].startswith("Prompt:\n"):
+                    return re.search(r"(?s:.*)\nOutput:\n(.*)", prediction[self.result_arg])[1]
                 return prediction[self.result_arg]
             except KeyError:
                 if isinstance(prediction, str):
@@ -384,4 +390,6 @@ class _BaseVertexAIModelGarden(_VertexAIBase):
                 else:
                     raise ValueError(f"{self.result_arg} key not found in prediction!")
 
+        if prediction.startswith("Prompt:\n"):
+            return re.search(r"(?s:.*)\nOutput:\n(.*)", prediction)[1]
         return prediction


### PR DESCRIPTION
When deploying a model from Model Garden, such as [Mistral-7B](https://console.cloud.google.com/vertex-ai/publishers/mistral-ai/model-garden/mistral-7b?project=acn-gcp-octo-sas), the version of vLLM used to publish the model returns both the prompt and the response.

## Response with prompt and output
The Docker image used is: `us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-vllm-serve:20240725_0916_RC00`

You can test it as follows:
```
ENDPOINT_ID=" … Your endpoint ID … "
PROJECT_ID="... Your project ID … "
REGION_ID="... Your region"
INPUT_DATA_FILE="prompt.json"
cat <<EOF
{
  "instances":
  [
  		{
			"prompt": "&lt;s&gt; [INST] Could you help me with questions on traveling? [/INST] Of course!&lt;/s&gt; [INST] What is the best season to travel in Thailand? [/INST]",
			"max_tokens": 50,
			"temperature": 1.0,
			"top_p": 1.0,
			"top_k": 10
		}
	]
}
EOF > prompt.json

curl -X POST \
    -H "Authorization: Bearer $(gcloud auth print-access-token)" \
    -H "Content-Type: application/json" \
    https://${REGION_ID}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION_ID}/endpoints/${ENDPOINT_ID}:predict \
    -d "@${INPUT_DATA_FILE}"
```
The result is:
```
{
  "predictions": [
    "Prompt:\n&lt;s&gt; [INST] Could you help me with questions on traveling? [/INST] Of course!&lt;/s&gt; [INST] What is the best season to travel in Thailand? [/INST]\nOutput:\n It would depend on what you want to do when visiting Thailand. If you are a fan of the beach, you can visit Thailand any time of year. However, if you are a fan of water sports, you should come in the dry season which"
  ],
  "deployedModelId": "XXXX",
  "model": "projects/yyyy/locations/europe-west2/models/llama3-8b-001",
  "modelDisplayName": "llama3-8b-001",
  "modelVersionId": "1"
}
```
`predictions` includes both the prompt and the completion. This is in the code of `api_server.py`, [here](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/api_server.py#L60). `VertexAIModelGarden` is not able to remove the prompt from the response, in order to meet the specifications of Langchain, as with other models. Only the response should be returned, not the prompt+response.

## Analyse the image
The analysis of the image indicates the following:
- The script `vertex/gcs_download_launcher.sh` handles copying the model locally.
- The file `api_server.py` has indeed been modified to accept invocations according to the GCP protocol, with `instances` in the JSON.
- **The function `format_output()` constructs a response with the template `"Prompt:\n{prompt.strip()}\nOutput:\n{output}"`**.

It is therefore possible to identify the prompt from the output.

## api_server.py deprecated
The header of `api_server.py` say:
> NOTE: This API server is used only for demonstrating usage of AsyncEngine and simple performance benchmarks. It is not intended for production use.

### Notes:
In an example of using vLLM provided by Google [here](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/2d092701c4d16ebe0db959d7a8114f2300c325f4/community-content/vertex_model_garden/model_oss/vllm/vllm.patch#L306), there is a vLLM patch to handle this and the use of a specific image. Therefore, a particular vLLM image seems to be needed to publish the models. This image, in addition to offering some enhancements for Vertex (/ping) or the integration of local model copies via `gs:` or `az:`, uses an older version of vLLM, fixed [by a git hash](https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/2d092701c4d16ebe0db959d7a8114f2300c325f4/community-content/vertex_model_garden/model_oss/vllm/dockerfile/serve.Dockerfile#L54).

I suppose it's an old version.

# The solution
This pull-request fix that. The code adds a regex to extract the response.