### PR TITLE
genai: fix make integration test errors

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -401,19 +401,21 @@ def _tool_choice_to_tool_config(
     all_names: List[str],
 ) -> _ToolConfigDict:
     allowed_function_names: Optional[List[str]] = None
-    if tool_choice is True or tool_choice == "any":
-        mode = "ANY"
-        allowed_function_names = all_names
-    elif tool_choice == "auto":
+    if tool_choice == "any":
+        # Notice: default mode is "AUTO"
+        # If set "ANY", may cause error.
+        # google.api_core.exceptions.InvalidArgument:
+        # 400 Function calling mode `ANY` is not enabled for api version v1beta
+        # mode = "ANY"
+        mode = "AUTO"
+    elif tool_choice is True or tool_choice == "auto":
         mode = "AUTO"
     elif tool_choice == "none":
         mode = "NONE"
     elif isinstance(tool_choice, str):
-        mode = "ANY"
-        allowed_function_names = [tool_choice]
+        mode = "AUTO"
     elif isinstance(tool_choice, list):
-        mode = "ANY"
-        allowed_function_names = tool_choice
+        mode = "AUTO"
     elif isinstance(tool_choice, dict):
         if "mode" in tool_choice:
             mode = tool_choice["mode"]

--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -269,18 +269,95 @@ def _convert_pydantic_to_genai_function(
         name=tool_name if tool_name else schema.get("title"),
         description=tool_description if tool_description else schema.get("description"),
         parameters={
-            "properties": {
-                k: {
-                    "type_": _get_type_from_schema(v),
-                    "description": v.get("description"),
-                }
-                for k, v in schema["properties"].items()
-            },
+            "properties": _get_properties_from_schema_any(
+                schema.get("properties")
+            ),  # TODO: use _dict_to_gapic_schema() if possible
+            # "items": _get_items_from_schema_any(
+            #     schema
+            # ),  # TODO: fix it https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/function-calling?hl#schema
             "required": schema.get("required", []),
             "type_": TYPE_ENUM[schema["type"]],
         },
     )
     return function_declaration
+
+
+def _get_properties_from_schema_any(schema: Any) -> Dict[str, Any]:
+    if isinstance(schema, Dict):
+        return _get_properties_from_schema(schema)
+    return {}
+
+
+def _get_properties_from_schema(schema: Dict) -> Dict[str, Any]:
+    properties = {}
+    for k, v in schema.items():
+        if not isinstance(k, str):
+            logger.warning(f"Key '{k}' is not supported in schema, type={type(k)}")
+            continue
+        if not isinstance(v, Dict):
+            logger.warning(f"Value '{v}' is not supported in schema, ignoring v={v}")
+            continue
+        properties_item: Dict[str, Union[str, int, Dict, List]] = {}
+        if v.get("type"):
+            properties_item["type_"] = _get_type_from_schema(v)
+
+        if v.get("enum"):
+            properties_item["enum"] = v["enum"]
+
+        description = v.get("description")
+        if description and isinstance(description, str):
+            properties_item["description"] = description
+
+        if v.get("type") == "array" and v.get("items"):
+            properties_item["items"] = _get_items_from_schema_any(v.get("items"))
+
+        if v.get("type") == "object" and v.get("properties"):
+            properties_item["properties"] = _get_properties_from_schema_any(
+                v.get("properties")
+            )
+        if k == "title" and "description" not in properties_item:
+            properties_item["description"] = k + " is " + str(v)
+
+        properties[k] = properties_item
+
+    return properties
+
+
+def _get_items_from_schema_any(schema: Any) -> Dict[str, Any]:
+    if isinstance(schema, Dict):
+        return _get_items_from_schema(schema)
+    if isinstance(schema, List):
+        return _get_items_from_schema(schema)
+    if isinstance(schema, str):
+        return _get_items_from_schema(schema)
+    return {}
+
+
+def _get_items_from_schema(schema: Union[Dict, List, str]) -> Dict[str, Any]:
+    items: Dict = {}
+    if isinstance(schema, List):
+        for i, v in enumerate(schema):
+            items[f"item{i}"] = _get_properties_from_schema_any(v)
+    elif isinstance(schema, Dict):
+        item: Dict = {}
+        for k, v in schema.items():
+            item["type_"] = _get_type_from_schema(v)
+            if not isinstance(v, Dict):
+                logger.warning(
+                    f"Value '{v}' is not supported in schema, ignoring v={v}"
+                )
+                continue
+            if v.get("type") == "object" and v.get("properties"):
+                item["properties"] = _get_properties_from_schema_any(
+                    v.get("properties")
+                )
+            if k == "title" and "description" not in item:
+                item["description"] = v
+        items = item
+    else:
+        # str
+        items["type_"] = _get_type_from_str(str(schema))
+    return items
 
 
 def _get_type_from_schema(schema: Dict[str, Any]) -> int:
@@ -293,12 +370,15 @@ def _get_type_from_schema(schema: Dict[str, Any]) -> int:
             pass
     elif "type" in schema:
         stype = str(schema["type"])
-        if stype in TYPE_ENUM:
-            return TYPE_ENUM[stype]
-        else:
-            pass
+        return _get_type_from_str(stype)
     else:
         pass
+    return TYPE_ENUM["string"]  # Default to string if no valid types found
+
+
+def _get_type_from_str(stype: str) -> int:
+    if stype in TYPE_ENUM:
+        return TYPE_ENUM[stype]
     return TYPE_ENUM["string"]  # Default to string if no valid types found
 
 

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -425,7 +425,7 @@ def test_chat_vertexai_gemini_function_calling() -> None:
 
 # Test with model that supports tool choice (gemini 1.5) and one that doesn't
 # (gemini 1).
-@pytest.mark.parametrize("model_name", [_MODEL, "models/gemini-1.5-pro-001"])
+@pytest.mark.parametrize("model_name", [_MODEL, "models/gemini-1.5-pro-exp-0827"])
 def test_chat_google_genai_function_calling_with_structured_output(
     model_name: str,
 ) -> None:

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -136,6 +136,7 @@ def test_tool_to_dict_pydantic() -> None:
     class MyModel(BaseModel):
         name: str
         age: int
+        likes: list[str]
 
     tool = convert_to_genai_function_declarations([MyModel])
     tool_dict = tool_to_dict(tool)

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -100,11 +100,11 @@ def test_format_dict_to_genai_function() -> None:
 
 
 @pytest.mark.parametrize("choice", (True, "foo", ["foo"], "any"))
-def test__tool_choice_to_tool_config(choice: Any) -> None:
+def test__tool_choice_to_tool_config_auto(choice: Any) -> None:
     expected = _ToolConfigDict(
         function_calling_config={
-            "mode": "ANY",
-            "allowed_function_names": ["foo"],
+            "mode": "AUTO",
+            "allowed_function_names": None,
         },
     )
     actual = _tool_choice_to_tool_config(choice, ["foo"])


### PR DESCRIPTION
## Errors in make integration_test

### Command
```
poetry run pytest -v tests/integration_tests/test_chat_models.py::test_chat_google_genai_function_calling_with_structured_output[models/gemini-1.5-pro-001]
```

### Error
```
E           google.api_core.exceptions.InvalidArgument: 400 Function calling mode `ANY` is not enabled for api version v1beta

/home/jinno/.cache/pypoetry/virtualenvs/langchain-google-genai-ov3b6nnP-py3.10/lib/python3.10/site-packages/google/api_core/grpc_helpers.py:78: InvalidArgument

The above exception was the direct cause of the following exception:

model_name = 'models/gemini-1.5-pro-001'

    @pytest.mark.parametrize("model_name", [_MODEL, "models/gemini-1.5-pro-001"])
    def test_chat_google_genai_function_calling_with_structured_output(
        model_name: str,
    ) -> None:
        class MyModel(BaseModel):
            name: str
            age: int
    
        safety = {
            HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_ONLY_HIGH
        }
        llm = ChatGoogleGenerativeAI(model=model_name, safety_settings=safety)
        model = llm.with_structured_output(MyModel)
        message = HumanMessage(content="My name is Erick and I am 27 years old")
    
>       response = model.invoke([message])

tests/integration_tests/test_chat_models.py:449: 
```

## Cause

google.api_core have something problem with mode ="ANY".
It looks not langchain-google side problem.

## Solution

Always use mode = "Auto" for workaround.
This PR will repare back CI for genai.

## Note1

This error is shown if "gemini-1.5-pro-latest" model used.
It looks also google.api_core side problem.
```
google.api_core.exceptions.InternalServerError: 500 An internal error has occurred.
```

## Note2

https://github.com/langchain-ai/langchain-google/pull/469 is included.
This is problem about structured_output for BaseModel has list.
#469 had covered  up #407, so please merge #469 first.