### PR TITLE
vertex[patch]: fix streaming for gemini-1.5-pro + vision

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -1791,15 +1791,10 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             generation_info = get_generation_info(
                 top_candidate,
                 is_gemini=True,
-                usage_metadata=usage_metadata,
             )
             # is_blocked is part of "safety_ratings" list
             # but if it's True/False then chunks can't be marged
             generation_info.pop("is_blocked", None)
-            # remove 0 so that chunks can be merged
-            generation_info["usage_metadata"] = {
-                k: v for k, v in generation_info["usage_metadata"].items() if v
-            }
         return ChatGenerationChunk(
             message=message,
             generation_info=generation_info,

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -20,6 +20,7 @@ from typing import (
     Union,
     cast,
     Literal,
+    Tuple,
     TypedDict,
     overload,
 )
@@ -1512,8 +1513,11 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             metadata=self.default_metadata,
             **kwargs,
         )
+        total_lc_usage = None
         for response_chunk in response_iter:
-            chunk = self._gemini_chunk_to_generation_chunk(response_chunk)
+            chunk, total_lc_usage = self._gemini_chunk_to_generation_chunk(
+                response_chunk, prev_total_usage=total_lc_usage
+            )
             if run_manager and isinstance(chunk.message.content, str):
                 run_manager.on_llm_new_token(chunk.message.content)
             yield chunk
@@ -1564,8 +1568,11 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             is_gemini=True,
             **kwargs,
         )
+        total_lc_usage = None
         async for response_chunk in await response_iter:
-            chunk = self._gemini_chunk_to_generation_chunk(response_chunk)
+            chunk, total_lc_usage = self._gemini_chunk_to_generation_chunk(
+                response_chunk, prev_total_usage=total_lc_usage
+            )
             if run_manager and isinstance(chunk.message.content, str):
                 await run_manager.on_llm_new_token(chunk.message.content)
             yield chunk
@@ -1768,13 +1775,28 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         return ChatResult(generations=generations)
 
     def _gemini_chunk_to_generation_chunk(
-        self, response_chunk: GenerationResponse
-    ) -> ChatGenerationChunk:
+        self,
+        response_chunk: GenerationResponse,
+        prev_total_usage: Optional[UsageMetadata] = None,
+    ) -> Tuple[ChatGenerationChunk, Optional[UsageMetadata]]:
         # return an empty completion message if there's no candidates
         usage_metadata = proto.Message.to_dict(response_chunk.usage_metadata)
 
         # Gather langchain (standard) usage metadata
-        lc_usage = _get_usage_metadata_gemini(usage_metadata)
+        # Note: some models (e.g., gemini-1.5-pro with image inputs) return
+        # cumulative sums of token counts.
+        total_lc_usage = _get_usage_metadata_gemini(usage_metadata)
+        if total_lc_usage and prev_total_usage:
+            lc_usage: Optional[UsageMetadata] = UsageMetadata(
+                input_tokens=total_lc_usage["input_tokens"]
+                - prev_total_usage["input_tokens"],
+                output_tokens=total_lc_usage["output_tokens"]
+                - prev_total_usage["output_tokens"],
+                total_tokens=total_lc_usage["total_tokens"]
+                - prev_total_usage["total_tokens"],
+            )
+        else:
+            lc_usage = total_lc_usage
         if not response_chunk.candidates:
             message = AIMessageChunk(content="")
             if lc_usage:
@@ -1795,7 +1817,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         return ChatGenerationChunk(
             message=message,
             generation_info=generation_info,
-        )
+        ), total_lc_usage
 
 
 def _yield_args(tool_call_chunks: Iterator[dict]) -> Iterator[dict]:

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -1779,10 +1779,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             message = AIMessageChunk(content="")
             if lc_usage:
                 message.usage_metadata = lc_usage
-            if usage_metadata:
-                generation_info = {"usage_metadata": usage_metadata}
-            else:
-                generation_info = {}
+            generation_info = {}
         else:
             top_candidate = response_chunk.candidates[0]
             message = _parse_response_candidate(top_candidate, streaming=True)

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -189,7 +189,7 @@ def test_multimodal() -> None:
     _check_usage_metadata(output)
 
     # Test streaming with gemini-1.5-pro
-    llm = ChatVertexAI(model_name="gemini-1.5-pro-001", rate_limiter=rate_limiter)
+    llm = ChatVertexAI(model_name="gemini-1.5-pro", rate_limiter=rate_limiter)
     for chunk in llm.stream([message]):
         assert isinstance(chunk, AIMessageChunk)
 

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -188,6 +188,11 @@ def test_multimodal() -> None:
     assert isinstance(output, AIMessage)
     _check_usage_metadata(output)
 
+    # Test streaming with gemini-1.5-pro
+    llm = ChatVertexAI(model_name="gemini-1.5-pro-001", rate_limiter=rate_limiter)
+    for chunk in llm.stream([message]):
+        assert isinstance(chunk, AIMessageChunk)
+
 
 video_param = pytest.param(
     "gs://cloud-samples-data/generative-ai/video/pixel8.mp4",


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langchain-google/issues/383

[AIMessage.usage_metadata](https://api.python.langchain.com/en/latest/messages/langchain_core.messages.ai.AIMessage.html#langchain_core.messages.ai.AIMessage.usage_metadata) is a dedicated field for housing token counts. It supports [merging](https://github.com/langchain-ai/langchain/blob/3ab09d87d614686fb0341e47670d0bd611fb3449/libs/core/langchain_core/messages/ai.py#L349-L363) across message chunks.

Here we remove token counts from `generation_info`. In many cases, the token counts are zero for every chunk but the final chunk. So there was a work-around where token counts with value zero were removed (see `# remove 0 so that chunks can be merged` comment).

In some cases this doesn't hold-- specifically, streaming for `gemini-1.5-pro`, when the input contains images. Below is an example of token counts from the Message proto:
```
{'prompt_token_count': 265, 'candidates_token_count': 1, 'total_token_count': 266}
{'prompt_token_count': 265, 'candidates_token_count': 17, 'total_token_count': 282}
{'prompt_token_count': 265, 'candidates_token_count': 33, 'total_token_count': 298}
{'prompt_token_count': 265, 'candidates_token_count': 45, 'total_token_count': 310}
```
Here we assign these counts to the corresponding fields of `message.usage_metadata`. Noting that these appear to be cumulative sums, we difference counts for successive chunks as well. So the `.usage_metadata` for the above would be
```
{'input_tokens': 265, 'output_tokens': 1, 'total_tokens': 266}
{'input_tokens': 0, 'output_tokens': 16, 'total_tokens': 16}
{'input_tokens': 0, 'output_tokens': 16, 'total_tokens': 16}
{'input_tokens': 0, 'output_tokens': 12, 'total_tokens': 12}
```
Open to assigning the counts as-is as well.