### PR TITLE
genai: fix Makefile about ruff check

### DIFF
--- a/libs/genai/Makefile
+++ b/libs/genai/Makefile
@@ -38,21 +38,20 @@ lint_tests: MYPY_CACHE=.mypy_cache_test
 lint lint_diff lint_package lint_tests:
 	./scripts/check_pydantic.sh .
 	./scripts/lint_imports.sh
-	poetry run ruff .
+	poetry run ruff check .
 	poetry run ruff format $(PYTHON_FILES) --diff
-	poetry run ruff --select I $(PYTHON_FILES)
+	poetry run ruff check --select I $(PYTHON_FILES)
 	mkdir $(MYPY_CACHE); poetry run mypy $(PYTHON_FILES) --cache-dir $(MYPY_CACHE)
 
 format format_diff:
 	poetry run ruff format $(PYTHON_FILES)
-	poetry run ruff --select I --fix $(PYTHON_FILES)
+	poetry run ruff check --select I --fix $(PYTHON_FILES)
 
 spell_check:
 	poetry run codespell --toml pyproject.toml
 
 spell_fix:
 	poetry run codespell --toml pyproject.toml -w
-
 
 check_imports: $(shell find langchain_google_genai -name '*.py')
 	poetry run python ./scripts/check_imports.py $^
@@ -63,6 +62,7 @@ check_imports: $(shell find langchain_google_genai -name '*.py')
 
 help:
 	@echo '----'
+	@echo 'check_imports				- check imports'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'
 	@echo 'test                         - run unit tests'


### PR DESCRIPTION
Changed command ruff -> ruff check.

This change avoid this error.
```
poetry run ruff .
error: `ruff <path>` has been removed. Use `ruff check <path>` instead.
```

https://github.com/astral-sh/ruff/tree/v0.4.10?tab=readme-ov-file#usage