### PR TITLE
Update drive.py to only use drive.file scope

### DIFF
--- a/libs/community/langchain_google_community/drive.py
+++ b/libs/community/langchain_google_community/drive.py
@@ -15,7 +15,7 @@ from langchain_core.document_loaders import BaseLoader
 from langchain_core.documents import Document
 from langchain_core.pydantic_v1 import BaseModel, root_validator, validator
 
-SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
+SCOPES = ["https://www.googleapis.com/auth/drive.file"]
 
 
 class GoogleDriveLoader(BaseLoader, BaseModel):


### PR DESCRIPTION
the drive.readonly scope gives very broad access to an application and is therefore a restricted scope. Restricted scopes are a pain because it means the application using it needs to go through a google restricted scope security review (see: https://developers.google.com/identity/protocols/oauth2/production-readiness/restricted-scope-verification).

With this change, the scope gets reduced to a recommended scope (see: https://developers.google.com/drive/api/guides/api-specific-auth)