### PR TITLE
fix: Update Vertex AI Search Component APIs to v1

### DIFF
--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -30,7 +30,7 @@ google-cloud-speech = { version = "^2.26.0", optional = true }
 googlemaps = { version = "^4.10.0", optional = true }
 google-cloud-texttospeech = { version = "^2.16.3", optional = true }
 google-cloud-translate = { version = "^3.15.3", optional = true }
-google-cloud-discoveryengine = { version = "^0.11.13", optional = true }
+google-cloud-discoveryengine = { version = "^0.12.0", optional = true }
 google-cloud-vision = { version = "^3.7.2", optional = true }
 beautifulsoup4 = { version = "^4.12.3", optional = true }
 pandas = [


### PR DESCRIPTION
- Update Vertex AI Search Component APIs (Ranking, Check Grounding) to use v1 endpoints.
- Change `grounding_config` and `ranking_config` paths to use the client built-in methods.