### PR TITLE
fix: Standardize default parameters across Gemini and Gemini Advanced models

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -214,9 +214,9 @@ class _VertexAICommon(_VertexAIBase):
         if self.model_family == GoogleModelFamily.GEMINI:
             default_params: Dict[str, Any] = {}
         elif self.model_family == GoogleModelFamily.GEMINI_ADVANCED:
-            default_params: Dict[str, Any] = {}
+            default_params = {}
         else:
-            default_params: Dict[str, Any] = {
+            default_params = {
                 "temperature": _PALM_DEFAULT_TEMPERATURE,
                 "max_output_tokens": _PALM_DEFAULT_MAX_OUTPUT_TOKENS,
                 "top_p": _PALM_DEFAULT_TOP_P,

--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -212,11 +212,11 @@ class _VertexAICommon(_VertexAIBase):
     @property
     def _default_params(self) -> Dict[str, Any]:
         if self.model_family == GoogleModelFamily.GEMINI:
-            default_params = {}
+            default_params: Dict[str, Any] = {}
         elif self.model_family == GoogleModelFamily.GEMINI_ADVANCED:
-            default_params = {}
+            default_params: Dict[str, Any] = {}
         else:
-            default_params = {
+            default_params: Dict[str, Any] = {
                 "temperature": _PALM_DEFAULT_TEMPERATURE,
                 "max_output_tokens": _PALM_DEFAULT_MAX_OUTPUT_TOKENS,
                 "top_p": _PALM_DEFAULT_TOP_P,

--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -213,6 +213,8 @@ class _VertexAICommon(_VertexAIBase):
     def _default_params(self) -> Dict[str, Any]:
         if self.model_family == GoogleModelFamily.GEMINI:
             default_params = {}
+        elif self.model_family == GoogleModelFamily.GEMINI_ADVANCED:
+            default_params = {}
         else:
             default_params = {
                 "temperature": _PALM_DEFAULT_TEMPERATURE,


### PR DESCRIPTION
Currently, models in the `GEMINI` family have no default parameters set, whereas they are set for all other Google models. This implies models in the new `GEMINI_ADVANCED` family also have default parameters set, such `max_output_tokens=128` (which are meant for PaLM and Bison models). 

This PR aims to fix that by making the default parameter behavior of `GEMINI` and `GEMINI_ADVANCED` model families identical for now. We can update defaults for each model family in the future. 