### PR TITLE
genai: add mkdir -p option for make lint

### DIFF
--- a/libs/genai/Makefile
+++ b/libs/genai/Makefile
@@ -41,7 +41,7 @@ lint lint_diff lint_package lint_tests:
 	poetry run ruff check .
 	poetry run ruff format $(PYTHON_FILES) --diff
 	poetry run ruff check --select I $(PYTHON_FILES)
-	mkdir $(MYPY_CACHE); poetry run mypy $(PYTHON_FILES) --cache-dir $(MYPY_CACHE)
+	mkdir -p $(MYPY_CACHE); poetry run mypy $(PYTHON_FILES) --cache-dir $(MYPY_CACHE)
 
 format format_diff:
 	poetry run ruff format $(PYTHON_FILES)


### PR DESCRIPTION
## PR Description

add mkdir -p option for make lint

## Type

🧹 Refactoring

## Note(optional)

- before
```
mkdir .mypy_cache; poetry run mypy . --cache-dir .mypy_cache
mkdir: ディレクトリ `.mypy_cache' を作成できません: ファイルが存在します
```

- after
```
mkdir .mypy_cache; poetry run mypy . --cache-dir .mypy_cache
```
