### PR TITLE
genai[patch]: add standard tests

### DIFF
--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -1,0 +1,44 @@
+"""Standard LangChain interface tests"""
+
+from typing import Type
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.rate_limiters import InMemoryRateLimiter
+from langchain_standard_tests.integration_tests import ChatModelIntegrationTests
+import pytest
+
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+rate_limiter = InMemoryRateLimiter(requests_per_second=0.5)
+
+
+class TestGeminiAIStandard(ChatModelIntegrationTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatGoogleGenerativeAI
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {
+            "model": "models/gemini-1.0-pro-001",
+            "rate_limiter": rate_limiter,
+        }
+
+    @pytest.mark.xfail(reason="Gemini 1.0 doesn't support tool_choice='any'")
+    def test_structured_few_shot_examples(self, model: BaseChatModel) -> None:
+        super().test_structured_few_shot_examples(model)
+
+    @pytest.mark.xfail(reason="with_structured_output with JSON schema not supported.")
+    def test_structured_output(self, model: BaseChatModel) -> None:
+        super().test_structured_output(model)
+    
+    @pytest.mark.xfail(reason="with_structured_output with JSON schema not supported.")
+    def test_structured_output_pydantic_2_v1(self, model: BaseChatModel) -> None:
+        super().test_structured_output_pydantic_2_v1(model)
+
+    @pytest.mark.xfail(reason="Not yet supported")
+    def test_tool_message_histories_list_content(self, model: BaseChatModel) -> None:
+        super().test_tool_message_histories_list_content(model)
+
+
+# TODO: increase quota on gemini-1.5-pro-001 and test as well

--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -2,10 +2,10 @@
 
 from typing import Type
 
+import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.rate_limiters import InMemoryRateLimiter
 from langchain_standard_tests.integration_tests import ChatModelIntegrationTests
-import pytest
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
@@ -31,7 +31,7 @@ class TestGeminiAIStandard(ChatModelIntegrationTests):
     @pytest.mark.xfail(reason="with_structured_output with JSON schema not supported.")
     def test_structured_output(self, model: BaseChatModel) -> None:
         super().test_structured_output(model)
-    
+
     @pytest.mark.xfail(reason="with_structured_output with JSON schema not supported.")
     def test_structured_output_pydantic_2_v1(self, model: BaseChatModel) -> None:
         super().test_structured_output_pydantic_2_v1(model)

--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -9,7 +9,7 @@ from langchain_standard_tests.integration_tests import ChatModelIntegrationTests
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-rate_limiter = InMemoryRateLimiter(requests_per_second=0.5)
+rate_limiter = InMemoryRateLimiter(requests_per_second=0.25)
 
 
 class TestGeminiAIStandard(ChatModelIntegrationTests):

--- a/libs/genai/tests/unit_tests/test_standard.py
+++ b/libs/genai/tests/unit_tests/test_standard.py
@@ -1,0 +1,26 @@
+from typing import Type
+
+from langchain_core.language_models import BaseChatModel
+from langchain_standard_tests.unit_tests import ChatModelUnitTests
+
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+
+class TestGeminiAIStandard(ChatModelUnitTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatGoogleGenerativeAI
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {"model": "models/gemini-1.0-pro-001"}
+
+
+class TestGemini_15_AIStandard(ChatModelUnitTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatGoogleGenerativeAI
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {"model": "models/gemini-1.5-pro-001"}


### PR DESCRIPTION
TODO:
- Add quota so we can test vision models;
- Fix xfails on structured output (currently doesn't appear to support JSON-schema inputs)

Will plan to merge as-is to support testing for pydantic v2 migration.