### PR TITLE
genai[patch]: fix standard tests

### DIFF
--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -2,10 +2,9 @@
 
 import asyncio
 import json
-from typing import Generator, List, Optional, Type
+from typing import Generator, List, Optional
 
 import pytest
-from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
@@ -17,7 +16,6 @@ from langchain_core.messages import (
 )
 from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.tools import tool
-from langchain_standard_tests.integration_tests import ChatModelIntegrationTests
 
 from langchain_google_genai import (
     ChatGoogleGenerativeAI,
@@ -29,28 +27,6 @@ from langchain_google_genai.chat_models import ChatGoogleGenerativeAIError
 _MODEL = "models/gemini-1.0-pro-001"  # TODO: Use nano when it's available.
 _VISION_MODEL = "gemini-1.5-flash"
 _B64_string = """iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAABhGlDQ1BJQ0MgUHJvZmlsZQAAeJx9kT1Iw0AcxV8/xCIVQTuIKGSoTi2IijhqFYpQIdQKrTqYXPoFTRqSFBdHwbXg4Mdi1cHFWVcHV0EQ/ABxdXFSdJES/5cUWsR4cNyPd/ced+8Af6PCVDM4DqiaZaSTCSGbWxW6XxHECPoRQ0hipj4niil4jq97+Ph6F+dZ3uf+HL1K3mSATyCeZbphEW8QT29aOud94ggrSQrxOXHMoAsSP3JddvmNc9FhP8+MGJn0PHGEWCh2sNzBrGSoxFPEUUXVKN+fdVnhvMVZrdRY6578heG8trLMdZrDSGIRSxAhQEYNZVRgIU6rRoqJNO0nPPxDjl8kl0yuMhg5FlCFCsnxg//B727NwuSEmxROAF0vtv0xCnTvAs26bX8f23bzBAg8A1da219tADOfpNfbWvQI6NsGLq7bmrwHXO4Ag0+6ZEiOFKDpLxSA9zP6phwwcAv0rLm9tfZx+gBkqKvUDXBwCIwVKXvd492hzt7+PdPq7wdzbXKn5swsVgAAA8lJREFUeJx90dtPHHUUB/Dz+81vZhb2wrDI3soUKBSRcisF21iqqCRNY01NTE0k8aHpi0k18VJfjOFvUF9M44MmGrHFQqSQiKSmFloL5c4CXW6Fhb0vO3ufvczMzweiBGI9+eW8ffI95/yQqqrwv4UxBgCfJ9w/2NfSVB+Nyn6/r+vdLo7H6FkYY6yoABR2PJujj34MSo/d/nHeVLYbydmIp/bEO0fEy/+NMcbTU4/j4Vs6Lr0ccKeYuUKWS4ABVCVHmRdszbfvTgfjR8kz5Jjs+9RREl9Zy2lbVK9wU3/kWLJLCXnqza1bfVe7b9jLbIeTMcYu13Jg/aMiPrCwVFcgtDiMhnxwJ/zXVDwSdVCVMRV7nqzl2i9e/fKrw8mqSp84e2sFj3Oj8/SrF/MaicmyYhAaXu58NPAbeAeyzY0NLecmh2+ODN3BewYBAkAY43giI3kebrnsRmvV9z2D4ciOa3EBAf31Tp9sMgdxMTFm6j74/Ogb70VCYQKAAIDCXkOAIC6pkYBWdwwnpHEdf6L9dJtJKPh95DZhzFKMEWRAGL927XpWTmMA+s8DAOBYAoR483l/iHZ/8bXoODl8b9UfyH72SXepzbyRJNvjFGHKMlhvMBze+cH9+4lEuOOlU2X1tVkFTU7Om03q080NDGXV1cflRpHwaaoiiiildB8jhDLZ7HDfz2Yidba6Vn2L4fhzFrNRKy5OZ2QOZ1U5W8VtqlVH/iUHcM933zZYWS7Wtj66zZr65bzGJQt0glHgudi9XVzEl4vKw2kUPhO020oPYI1qYc+2Xc0bRXFwTLY0VXa2VibD/lBaIXm1UChN5JSRUcQQ1Tk/47Cf3x8bY7y17Y17PVYTG1UkLPBFcqik7Zoa9JcLYoHBqHhXNgd6gS1k9EJ1TQ2l9EDy1saErmQ2kGpwGC2MLOtCM8nZEV1K0tKJtEksSm26J/rHg2zzmabKisq939nHzqUH7efzd4f/nPGW6NP8ybNFrOsWQhpoCuuhnJ4hAnPhFam01K4oQMjBg/mzBjVhuvw2O++KKT+BIVxJKzQECBDLF2qu2WTMmCovtDQ1f8iyoGkUADBCCGPsdnvTW2OtFm01VeB06msvdWlpPZU0wJRG85ns84umU3k+VyxeEcWqvYUBAGsUrbvme4be99HFeisP/pwUOIZaOqQX31ISgrKmZhLHtXNXuJq68orrr5/9mBCglCLAGGPyy81votEbcjlKLrC9E8mhH3wdHRdcyyvjidSlxjftPJpD+o25JYvRHGFoZDdks1mBQhxJu9uxvwEiXuHnHbLd1AAAAABJRU5ErkJggg=="""  # noqa: E501
-
-
-class GoogleGenerativeAIStandardTests(ChatModelIntegrationTests):
-    @property
-    def chat_model_class(self) -> Type[BaseChatModel]:
-        return ChatGoogleGenerativeAI
-
-    @property
-    def chat_model_params(self) -> dict:
-        return {"model": _MODEL}
-
-    @property
-    def supports_image_inputs(self) -> bool:
-        return True
-
-    @property
-    def supports_video_inputs(self) -> bool:
-        return True
-
-    @property
-    def supports_audio_inputs(self) -> bool:
-        return True
 
 
 def _check_usage_metadata(message: AIMessage) -> None:

--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -1,0 +1,44 @@
+"""Standard LangChain interface tests"""
+
+from typing import Type
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_core.rate_limiters import InMemoryRateLimiter
+from langchain_standard_tests.integration_tests import ChatModelIntegrationTests
+
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+rate_limiter = InMemoryRateLimiter(requests_per_second=0.25)
+
+
+class TestGeminiAIStandard(ChatModelIntegrationTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatGoogleGenerativeAI
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {
+            "model": "models/gemini-1.0-pro-001",
+            "rate_limiter": rate_limiter,
+        }
+
+    @pytest.mark.xfail(reason="Gemini 1.0 doesn't support tool_choice='any'")
+    def test_structured_few_shot_examples(self, model: BaseChatModel) -> None:
+        super().test_structured_few_shot_examples(model)
+
+    @pytest.mark.xfail(reason="with_structured_output with JSON schema not supported.")
+    def test_structured_output(self, model: BaseChatModel) -> None:
+        super().test_structured_output(model)
+
+    @pytest.mark.xfail(reason="with_structured_output with JSON schema not supported.")
+    def test_structured_output_pydantic_2_v1(self, model: BaseChatModel) -> None:
+        super().test_structured_output_pydantic_2_v1(model)
+
+    @pytest.mark.xfail(reason="Not yet supported")
+    def test_tool_message_histories_list_content(self, model: BaseChatModel) -> None:
+        super().test_tool_message_histories_list_content(model)
+
+
+# TODO: increase quota on gemini-1.5-pro-001 and test as well

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional, Union
 from unittest.mock import ANY, Mock, patch
 
 import google.ai.generativelanguage as glm
@@ -14,7 +14,6 @@ from google.ai.generativelanguage_v1beta.types import (
     GenerateContentResponse,
     Part,
 )
-from langchain_core.language_models import BaseChatModel
 from langchain_core.load import dumps, loads
 from langchain_core.messages import (
     AIMessage,
@@ -25,7 +24,6 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import tool_call as create_tool_call
 from langchain_core.pydantic_v1 import SecretStr
-from langchain_standard_tests.unit_tests import ChatModelUnitTests
 from pytest import CaptureFixture
 
 from langchain_google_genai.chat_models import (
@@ -33,28 +31,6 @@ from langchain_google_genai.chat_models import (
     _parse_chat_history,
     _parse_response_candidate,
 )
-
-
-class GoogleGenerativeAIStandardTests(ChatModelUnitTests):
-    @property
-    def chat_model_class(self) -> Type[BaseChatModel]:
-        return ChatGoogleGenerativeAI
-
-    @property
-    def chat_model_params(self) -> dict:
-        return {"model": "gemini-1.5-pro"}
-
-    @property
-    def supports_image_inputs(self) -> bool:
-        return True
-
-    @property
-    def supports_video_inputs(self) -> bool:
-        return True
-
-    @property
-    def supports_audio_inputs(self) -> bool:
-        return True
 
 
 def test_integration_initialization() -> None:

--- a/libs/genai/tests/unit_tests/test_standard.py
+++ b/libs/genai/tests/unit_tests/test_standard.py
@@ -1,0 +1,26 @@
+from typing import Type
+
+from langchain_core.language_models import BaseChatModel
+from langchain_standard_tests.unit_tests import ChatModelUnitTests
+
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+
+class TestGeminiAIStandard(ChatModelUnitTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatGoogleGenerativeAI
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {"model": "models/gemini-1.0-pro-001"}
+
+
+class TestGemini_15_AIStandard(ChatModelUnitTests):
+    @property
+    def chat_model_class(self) -> Type[BaseChatModel]:
+        return ChatGoogleGenerativeAI
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {"model": "models/gemini-1.5-pro-001"}


### PR DESCRIPTION
Existing tests do not run because they don't start with a `Test` prefix. Here we separate them into their own modules and get them in a running state.