### PR TITLE
vertex: fix gapic conversion

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/functions_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/functions_utils.py
@@ -69,11 +69,44 @@ _ALLOWED_SCHEMA_FIELDS.extend(
 _ALLOWED_SCHEMA_FIELDS_SET = set(_ALLOWED_SCHEMA_FIELDS)
 
 
+def _format_json_schema_to_gapic_v1(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Format a JSON schema from a Pydantic V1 BaseModel to gapic."""
+    converted_schema: Dict[str, Any] = {}
+    for key, value in schema.items():
+        if key == "definitions":
+            continue
+        elif key == "items":
+            converted_schema["items"] = _format_json_schema_to_gapic_v1(value)
+        elif key == "properties":
+            if "properties" not in converted_schema:
+                converted_schema["properties"] = {}
+            for pkey, pvalue in value.items():
+                converted_schema["properties"][pkey] = _format_json_schema_to_gapic_v1(
+                    pvalue
+                )
+            continue
+        elif key in ["type", "_type"]:
+            converted_schema["type"] = str(value).upper()
+        elif key == "allOf":
+            if len(value) > 1:
+                logger.warning(
+                    "Only first value for 'allOf' key is supported. "
+                    f"Got {len(value)}, ignoring other than first value!"
+                )
+            return _format_json_schema_to_gapic_v1(value[0])
+        elif key not in _ALLOWED_SCHEMA_FIELDS_SET:
+            logger.warning(f"Key '{key}' is not supported in schema, ignoring")
+        else:
+            converted_schema[key] = value
+    return converted_schema
+
+
 def _format_json_schema_to_gapic(
     schema: Dict[str, Any],
     parent_key: Optional[str] = None,
     required_fields: Optional[list] = None,
 ) -> Dict[str, Any]:
+    """Format a JSON schema from a Pydantic V2 BaseModel to gapic."""
     converted_schema: Dict[str, Any] = {}
     for key, value in schema.items():
         if key == "definitions":
@@ -118,9 +151,14 @@ def _format_json_schema_to_gapic(
     return converted_schema
 
 
-def _dict_to_gapic_schema(schema: Dict[str, Any]) -> gapic.Schema:
+def _dict_to_gapic_schema(
+    schema: Dict[str, Any], pydantic_version: str = "v1"
+) -> gapic.Schema:
     dereferenced_schema = dereference_refs(schema)
-    formatted_schema = _format_json_schema_to_gapic(dereferenced_schema)
+    if pydantic_version == "v1":
+        formatted_schema = _format_json_schema_to_gapic_v1(dereferenced_schema)
+    else:
+        formatted_schema = _format_json_schema_to_gapic(dereferenced_schema)
     json_schema = json.dumps(formatted_schema)
     return gapic.Schema.from_json(json_schema)
 
@@ -142,8 +180,14 @@ def _format_base_tool_to_function_declaration(
             ),
         )
 
-    schema = tool.args_schema.schema()
-    parameters = _dict_to_gapic_schema(schema)
+    if hasattr(tool.args_schema, "model_json_schema"):
+        schema = tool.args_schema.model_json_schema()
+        pydantic_version = "v2"
+    else:
+        schema = tool.args_schema.schema()
+        pydantic_version = "v1"
+
+    parameters = _dict_to_gapic_schema(schema, pydantic_version=pydantic_version)
 
     return gapic.FunctionDeclaration(
         name=tool.name or schema.get("title"),
@@ -155,12 +199,17 @@ def _format_base_tool_to_function_declaration(
 def _format_pydantic_to_function_declaration(
     pydantic_model: Type[BaseModel],
 ) -> gapic.FunctionDeclaration:
-    schema = pydantic_model.schema()
+    if hasattr(pydantic_model, "model_json_schema"):
+        schema = pydantic_model.model_json_schema()
+        pydantic_version = "v2"
+    else:
+        schema = pydantic_model.schema()
+        pydantic_version = "v1"
 
     return gapic.FunctionDeclaration(
         name=schema["title"],
         description=schema.get("description", ""),
-        parameters=_dict_to_gapic_schema(schema),
+        parameters=_dict_to_gapic_schema(schema, pydantic_version=pydantic_version),
     )
 
 

--- a/libs/vertexai/tests/unit_tests/test_function_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_function_utils.py
@@ -27,6 +27,28 @@ from langchain_google_vertexai.functions_utils import (
 
 
 def test_format_json_schema_to_gapic():
+    # Simple case
+    class RecordPerson(BaseModel):
+        """Record some identifying information about a person."""
+
+        name: str
+        age: Optional[int]
+
+    schema = RecordPerson.model_json_schema()
+    result = _format_json_schema_to_gapic(schema)
+    expected = {
+        "title": "RecordPerson",
+        "type": "OBJECT",
+        "description": "Record some identifying information about a person.",
+        "properties": {
+            "name": {"title": "Name", "type": "STRING"},
+            "age": {"type": "INTEGER", "title": "Age"},
+        },
+        "required": ["name"],
+    }
+    assert result == expected
+
+    # Nested case
     class StringEnum(str, Enum):
         pear = "pear"
         banana = "banana"
@@ -41,7 +63,10 @@ def test_format_json_schema_to_gapic():
         array_field: Sequence[A]
         int_field: int = Field(description="int field", ge=1, le=10)
         str_field: str = Field(
-            min_length=1, max_length=10, pattern="^[A-Z]{1,10}$", examples=["ABCD"]
+            min_length=1,
+            max_length=10,
+            pattern="^[A-Z]{1,10}$",
+            example="ABCD",  # type: ignore[call-arg]
         )
         str_enum_field: StringEnum
 
@@ -53,6 +78,7 @@ def test_format_json_schema_to_gapic():
             "object_field": {
                 "description": "Class A",
                 "properties": {"int_field": {"type": "INTEGER", "title": "Int Field"}},
+                "required": [],
                 "title": "A",
                 "type": "OBJECT",
             },
@@ -62,6 +88,7 @@ def test_format_json_schema_to_gapic():
                     "properties": {
                         "int_field": {"type": "INTEGER", "title": "Int Field"}
                     },
+                    "required": [],
                     "title": "A",
                     "type": "OBJECT",
                 },
@@ -70,8 +97,8 @@ def test_format_json_schema_to_gapic():
             },
             "int_field": {
                 "description": "int field",
-                "maximum": 10.0,
-                "minimum": 1.0,
+                "maximum": 10,
+                "minimum": 1,
                 "title": "Int Field",
                 "type": "INTEGER",
             },
@@ -84,7 +111,6 @@ def test_format_json_schema_to_gapic():
                 "type": "STRING",
             },
             "str_enum_field": {
-                "description": "An enumeration.",
                 "enum": ["pear", "banana"],
                 "title": "StringEnum",
                 "type": "STRING",

--- a/libs/vertexai/tests/unit_tests/test_function_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_function_utils.py
@@ -1,6 +1,6 @@
 import json
 from enum import Enum
-from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, cast
 from unittest.mock import Mock, patch
 
 import google.cloud.aiplatform_v1beta1.types as gapic
@@ -239,6 +239,27 @@ def test_format_json_schema_to_gapic_v1():
         gapic_schema.properties["str_field"].example
         == expected["properties"]["str_field"]["example"]  # type: ignore
     )
+
+
+def test_format_json_schema_to_gapic_union_types() -> None:
+    """Test that union types are consistent between v1 and v2."""
+
+    class RecordPerson_v1(BaseModelV1):
+        name: str
+        age: Union[int, str]
+
+    class RecordPerson(BaseModel):
+        name: str
+        age: Union[int, str]
+
+    schema_v1 = RecordPerson_v1.schema()
+    schema_v2 = RecordPerson.model_json_schema()
+
+    result_v1 = _format_json_schema_to_gapic_v1(schema_v1)
+    result_v2 = _format_json_schema_to_gapic(schema_v2)
+    result_v1["title"] = "RecordPerson"
+
+    assert result_v1 == result_v2
 
 
 # reusable test inputs


### PR DESCRIPTION
`_format_json_schema_to_gapic` translates json schema to gapic. It appears tailored to json schema as generated from Pydantic V1 BaseModels. Here we update this function to accommodate Pydantic V2 models. We keep the original function as `_format_json_schema_to_gapic_v1` and route V1 BaseModels through it.

In Pydantic V1, an `Optional[int]` will be represented as an `integer` type that is not included in `required` fields. In Pydantic V2, it is represented as a union type (e.g., `{'anyOf': [{'type': 'integer'}, {'type': 'null'}], 'title': 'field_name'}` and included in `required` fields. Example:
```python
from typing import Optional

from pydantic.v1 import BaseModel as BaseModelV1

class PersonV1(BaseModelV1):
    name: str
    age: Optional[int]


PersonV1.schema()
```
```
{'title': 'PersonV1',
 'type': 'object',
 'properties': {'name': {'title': 'Name', 'type': 'string'},
  'age': {'title': 'Age', 'type': 'integer'}},
 'required': ['name']}
```
```python
from typing import Optional

from pydantic import BaseModel

class Person(BaseModel):
    name: str
    age: Optional[int]


Person.model_json_schema()
```
```
{'properties': {'name': {'title': 'Name', 'type': 'string'},
  'age': {'anyOf': [{'type': 'integer'}, {'type': 'null'}], 'title': 'Age'}},
 'required': ['name', 'age'],
 'title': 'Person',
 'type': 'object'}
```

`_format_json_schema_to_gapic` does not support this (`anyOf` is not in `_ALLOWED_SCHEMA_FIELDS_SET`). Here we add a condition for `anyOf`: if the `anyOf` consists of two elements, one of which is null, we simplify the schema to contain a single type and remove it from `required` (similar to Pydantic V1).