### PR TITLE
vertex[patch]: update parser in with_structured_output

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -1856,11 +1856,6 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         ), total_lc_usage
 
 
-def _yield_args(tool_call_chunks: Iterator[dict]) -> Iterator[dict]:
-    for tc in tool_call_chunks:
-        yield tc["args"]
-
-
 def _get_usage_metadata_gemini(raw_metadata: dict) -> Optional[UsageMetadata]:
     """Get UsageMetadata from raw response metadata."""
     input_tokens = raw_metadata.get("prompt_token_count", 0)


### PR DESCRIPTION
`ChatVertex.with_structured_output` has a bug in the case of:
- async
- schema passed as dict

Example:
```python
from langchain_google_vertexai import ChatVertexAI

model = ChatVertexAI(model_name="gemini-pro").with_structured_output(
    schema={
        "type": "object",
        "title": "Grade",
        "required": ["score"],
        "properties": {
            "score": {"type": "integer", "description": "Provide the score:"}
        },
        "description": "Grade the quiz based upon the above criteria with a score.",
    }
)
await model.ainvoke("Mostly correct, 7.")
```
raises `NotImplementedError: RunnableGenerator(_yield_args) only supports sync methods.`.

Adding a standard test for this in monorepo.