### PR TITLE
genai: add integration_test help message for Makefile

### DIFF
--- a/libs/genai/Makefile
+++ b/libs/genai/Makefile
@@ -64,9 +64,10 @@ check_imports: $(shell find langchain_google_genai -name '*.py')
 
 help:
 	@echo '----'
-	@echo 'check_imports				- check imports'
+	@echo 'check_imports                - check imports'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'
 	@echo 'test                         - run unit tests'
 	@echo 'tests                        - run unit tests'
+	@echo 'integration_test             - run integration tests(NOTE: "export GOOGLE_API_KEY=..." is needed.)'
 	@echo 'test TEST_FILE=<test_file>   - run all tests in file'


### PR DESCRIPTION
I was always forget the test command.

```
$ make 
Makefile:59: 警告: ターゲット 'check_imports' のためのレシピを置き換えます
Makefile:15: 警告: ターゲット 'check_imports' のための古いレシピは無視されます
----
check_imports                - check imports
format                       - run code formatters
lint                         - run linters
test                         - run unit tests
tests                        - run unit tests
integration_test             - run integration tests(NOTE: "export GOOGLE_API_KEY=..." is needed.)  <= new
test TEST_FILE=<test_file>   - run all tests in file
```

## Type

📖 Documentation

## Note

I think integration_test will be fixed by.
https://github.com/langchain-ai/langchain-google/pull/465
But this PR passed. It looks rundomly.
