### PR TITLE
genai: fix integration_test to avoid 429 Resource has been exhausted

### DIFF
--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -410,7 +410,7 @@ def test_chat_vertexai_gemini_function_calling() -> None:
 
 # Test with model that supports tool choice (gemini 1.5) and one that doesn't
 # (gemini 1).
-@pytest.mark.parametrize("model_name", [_MODEL, "models/gemini-1.5-pro-001"])
+@pytest.mark.parametrize("model_name", [_MODEL, "models/gemini-1.5-flash-latest"])
 def test_chat_google_genai_function_calling_with_structured_output(
     model_name: str,
 ) -> None:

--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -20,7 +20,7 @@ class TestGeminiAIStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model": "models/gemini-1.0-pro-001",
+            "model": "models/gemini-1.5-flash-latest",
             "rate_limiter": rate_limiter,
         }
 


### PR DESCRIPTION
## PR Description

In my local, these errors was shown.

```
FAILED tests/integration_tests/test_standard.py::TestGeminiAIStandard::test_stop_sequence - google.api_core.exceptions.ResourceExhausted: 429 Resource has been exhausted (e.g. check quota).
```

```
FAILED tests/integration_tests/test_chat_models.py::test_chat_google_genai_function_calling_with_structured_output[models/gemini-1.5-pro-001] - google.api_core.exceptions.ResourceExhausted: 429 Resource has been exhausted (e.g. check quota).
```

## Relevant issues

https://github.com/langchain-ai/langchain-google/pull/465

## Type

✅ Test

