### PR TITLE
community: Fix gmail search for threads

### DIFF
--- a/libs/community/langchain_google_community/gmail/search.py
+++ b/libs/community/langchain_google_community/gmail/search.py
@@ -130,16 +130,23 @@ class GmailSearch(GmailBaseTool):
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> List[Dict[str, Any]]:
         """Run the tool."""
-        results = (
-            self.api_resource.users()
-            .messages()
-            .list(userId="me", q=query, maxResults=max_results)
-            .execute()
-            .get(resource.value, [])
-        )
-        if resource == Resource.THREADS:
-            return self._parse_threads(results)
-        elif resource == Resource.MESSAGES:
+        if resource == Resource.MESSAGES:
+            results = (
+                self.api_resource.users()
+                .messages()
+                .list(userId="me", q=query, maxResults=max_results)
+                .execute()
+                .get(resource.value, [])
+            )
             return self._parse_messages(results)
+        elif resource == Resource.THREADS:
+            results = (
+                self.api_resource.users()
+                .threads()
+                .list(userId="me", q=query, maxResults=max_results)
+                .execute()
+                .get(resource.value, [])
+            )
+            return self._parse_threads(results)
         else:
             raise NotImplementedError(f"Resource of type {resource} not implemented.")


### PR DESCRIPTION

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description
The gmail search tool would always return an empty list when searching for threads. This was due to the search resource being `messages()` even if `resource == Resource.THREADS`

Simple fix that searches based on resource.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes(optional)

<!-- List of changes -->
- Retrieve results based on resource before calling parse methods
## Testing(optional)

### Test procedure
- Call an instance of the GmailSearch tool with `resource=Resource.THREADS`

### Test result
- Retrieved threads instead of empty list

## Note(optional)

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
