### PR TITLE
vertexai: postpone `_VertexAIBase.project` validation

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -103,8 +103,6 @@ class _VertexAIBase(BaseModel):
     def validate_params_base(cls, values: dict) -> Any:
         if "model" in values and "model_name" not in values:
             values["model_name"] = values.pop("model")
-        if values.get("project") is None:
-            values["project"] = initializer.global_config.project
         if values.get("api_transport") is None:
             values["api_transport"] = initializer.global_config._api_transport
         if values.get("api_endpoint"):
@@ -119,6 +117,12 @@ class _VertexAIBase(BaseModel):
         additional_headers = values.get("additional_headers", {})
         values["default_metadata"] = tuple(additional_headers.items())
         return values
+
+    @model_validator(mode="after")
+    def validate_project(self) -> Any:
+        if self.project is None:
+            self.project = initializer.global_config.project
+        return self
 
     @property
     def prediction_client(self) -> v1beta1PredictionServiceClient:


### PR DESCRIPTION
## PR Description

Before this PR, subclasses of `_VertexAIBase` could have problems setting a default value (or `default_factory`) for the `project` attribute. For example,

```python
import pydantic as pd
from langchain_core.utils import from_env
from langchain_google_vertexai.chat_models import ChatVertexAI

class MyVertexChat(ChatVertexAI):
    project: pd.Field(default_factory=from_env("MY_GOOGLE_PROJ"))
```

```
>>> MyVertexChat()
...
GoogleAuthError: Unable to find your project. Please provide a project ID by: ...
```

This is because not passing a `project` to the constructor means that `values["project"]` is unset in the `before` model validator, triggering the project lookup in the global config (which can fail).

https://github.com/langchain-ai/langchain-google/blob/af2ef994ee5429bce18899b2c0c327470eba7032/libs/vertexai/langchain_google_vertexai/_base.py#L106-L107

This PR moves that global config fallback to an `after` validator, giving the `project` field a chance to be set by downstream defaults.

<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## Type

🐛 Bug Fix