### PR TITLE
vertexai[patch]: exclude full_model_name from ser

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -68,7 +68,9 @@ class _VertexAIBase(BaseModel):
     "Optional list of stop words to use when generating."
     model_name: Optional[str] = Field(default=None, alias="model")
     "Underlying model name."
-    full_model_name: Optional[str] = Field(default=None, exclude=True)  #: :meta private:
+    full_model_name: Optional[str] = Field(
+        default=None, exclude=True
+    )  #: :meta private:
     "The full name of the model's endpoint."
     client_options: Optional["ClientOptions"] = Field(
         default=None, exclude=True

--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -68,7 +68,7 @@ class _VertexAIBase(BaseModel):
     "Optional list of stop words to use when generating."
     model_name: Optional[str] = Field(default=None, alias="model")
     "Underlying model name."
-    full_model_name: Optional[str] = None  #: :meta private:
+    full_model_name: Optional[str] = Field(default=None, exclude=True)  #: :meta private:
     "The full name of the model's endpoint."
     client_options: Optional["ClientOptions"] = Field(
         default=None, exclude=True

--- a/libs/vertexai/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/vertexai/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -10,7 +10,6 @@
     'kwargs': dict({
       'default_metadata': list([
       ]),
-      'full_model_name': 'projects/test-project/locations/us-central1/publishers/google/models/gemini-1.0-pro-001',
       'location': 'us-central1',
       'max_output_tokens': 100,
       'max_retries': 2,
@@ -39,7 +38,6 @@
     'kwargs': dict({
       'default_metadata': list([
       ]),
-      'full_model_name': 'projects/test-project/locations/us-central1/publishers/google/models/gemini-1.5-pro-001',
       'location': 'us-central1',
       'max_output_tokens': 100,
       'max_retries': 2,


### PR DESCRIPTION
there's already project, location and model. no need for full_model_name to be serialized