### PR TITLE
community: Add support for order_by and canonical_filter fields in VertexAISearchRetriever

### DIFF
--- a/libs/community/langchain_google_community/vertex_ai_search.py
+++ b/libs/community/langchain_google_community/vertex_ai_search.py
@@ -229,6 +229,10 @@ class VertexAISearchRetriever(BaseRetriever, _BaseVertexAISearchRetriever):
 
     filter: Optional[str] = None
     """Filter expression."""
+    order_by: Optional[str] = None
+    """Comma-separated list of fields to order by."""
+    canonical_filter: Optional[str] = None
+    """Canonical filter expression."""
     get_extractive_answers: bool = False
     """If True return Extractive Answers, otherwise return Extractive Segments or Snippets."""  # noqa: E501
     max_documents: int = Field(default=5, ge=1, le=100)
@@ -385,6 +389,8 @@ class VertexAISearchRetriever(BaseRetriever, _BaseVertexAISearchRetriever):
         return SearchRequest(
             query=query,
             filter=self.filter,
+            order_by=self.order_by,
+            canonical_filter=self.canonical_filter,
             serving_config=self._serving_config,
             page_size=self.max_documents,
             content_search_spec=content_search_spec,

--- a/libs/community/langchain_google_community/vertex_ai_search.py
+++ b/libs/community/langchain_google_community/vertex_ai_search.py
@@ -237,13 +237,11 @@ class VertexAISearchRetriever(BaseRetriever, _BaseVertexAISearchRetriever):
     """If True return Extractive Answers, otherwise return Extractive Segments or Snippets."""  # noqa: E501
     max_documents: int = Field(default=5, ge=1, le=100)
     """The maximum number of documents to return."""
-    max_extractive_answer_count: int = Field(default=1, ge=1, le=1)
-    """The maximum number of extractive answers returned in each search result.
-    Currently one extractive answer will be returned for each SearchResult.
+    max_extractive_answer_count: int = Field(default=1, ge=1, le=5)
+    """The maximum number of extractive answers to return per search result.
     """
-    max_extractive_segment_count: int = Field(default=1, ge=1, le=1)
-    """The maximum number of extractive segments returned in each search result.
-    Currently one segment will be returned for each SearchResult.
+    max_extractive_segment_count: int = Field(default=1, ge=1, le=10)
+    """The maximum number of extractive segments to return per search result.
     """
     return_extractive_segment_score: bool = False
     """If set to True, the relevance score for each extractive segment will be included

--- a/libs/community/tests/unit_tests/test_vertex_ai_search.py
+++ b/libs/community/tests/unit_tests/test_vertex_ai_search.py
@@ -1,10 +1,56 @@
+from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.auth import credentials as ga_credentials
 from google.cloud.discoveryengine_v1beta import Document as DiscoveryEngineDocument
-from google.cloud.discoveryengine_v1beta.types import SearchResponse
+from google.cloud.discoveryengine_v1beta.types import SearchRequest, SearchResponse
 
 from langchain_google_community.vertex_ai_search import VertexAISearchRetriever
+
+
+def test_search_request_with_auto_populated_fields() -> None:
+    """
+    Test the creation of a search request with automatically populated fields.
+    This test verifies that the VertexAISearchRetriever correctly creates a
+    SearchRequest object with the expected auto-populated fields.
+    """
+
+    # Mock the SearchServiceClient to avoid real network calls
+    with mock.patch(
+        "google.cloud.discoveryengine_v1beta.SearchServiceClient"
+    ) as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.serving_config_path.return_value = "serving_config_value"
+
+        retriever = VertexAISearchRetriever(
+            project_id="project_id_value",
+            data_store_id="data_store_id_value",
+            location_id="location_id_value",
+            serving_config_id="serving_config_id_value",
+            credentials=ga_credentials.AnonymousCredentials(),
+            filter="filter_value",
+            order_by="title desc",
+            canonical_filter="true",
+        )
+
+        # Assert that serving_config_path was called with the correct arguments
+        mock_client.serving_config_path.assert_called_once_with(
+            project="project_id_value",
+            location="location_id_value",
+            data_store="data_store_id_value",
+            serving_config="serving_config_id_value",
+        )
+
+        search_request = retriever._create_search_request(query="query_value")
+
+        assert isinstance(search_request, SearchRequest)
+        assert search_request.query == "query_value"
+        assert search_request.filter == "filter_value"
+        assert search_request.order_by == "title desc"
+        assert search_request.canonical_filter == "true"
+        assert search_request.serving_config == "serving_config_value"
+        assert search_request.page_size == 5
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [X ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ X] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [X ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ X] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ X] PR title and description are appropriate
- [ X] Necessary tests and documentation have been added
- [ X] Lint and tests pass successfully
- [ X] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

This PR introduces two new optional fields, `order_by` and `canonical_filter`, to the `VertexAISearchRetriever` class. These fields enhance the flexibility and control over search queries when using Google Vertex AI Search.

## Type

🆕 New Feature
✅ Test

## Issue

https://github.com/langchain-ai/langchain-google/issues/530

## Testing

I added the corresponding unit test for creating a search request to verify that the VertexAISearchRetriever correctly creates a `SearchRequest` object with the expected auto-populated fields, including the newly added `order_by` and `canonical_filter` fields.
 
Also, I tested it using my data in GCP, checking different configurations and verifying that the parameters are correctly applied and produce the expected results.

```
vertex = VertexAISearchRetriever(
    project_id=project_id,
    data_store_id=data_store_id,
    max_documents=2,
    max_extractive_segment_count=1,
    num_previous_segments=3,
    num_next_segments=3,
    return_extractive_segment_score=True,
    order_by="title desc",  # Add order_by parameter
    canonical_filter="true"  # Add canonical_filter parameter
)
```

Thank you again Team!