### PR TITLE
community: Change post-filters to pre-filters in BigQueryVectorStore

### DIFF
--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -333,9 +333,9 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         full_query = f"""{embeddings_query}
         {select_clause}
         FROM VECTOR_SEARCH(
-            TABLE `{self.full_table_id}`,
+            (SELECT * FROM `{self.full_table_id}` WHERE {where_filter_expr}),
             "{self.embedding_field}",
-            (SELECT row_num, {self.embedding_field} from embeddings),
+            (SELECT row_num, {self.embedding_field} FROM embeddings),
             distance_type => "{self.distance_type}",
             top_k => {k}
         )
@@ -346,7 +346,6 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         FROM (
             {full_query}
         ) AS result
-        WHERE {where_filter_expr}
         ORDER BY row_num, score
         """
         return full_query_wrapper


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

BigQueryVectorStore's `_create_filters` are post-filters. Now that BigQuery Vector Search supports pre-filtering on stored columns (https://cloud.google.com/bigquery/docs/vector-index#stored-columns), we can change all post-filters to pre-filters.

Note that this requires storing the columns that are referenced by the pre-filter. This cannot be done in Langchain yet (have to use the BQ CLI/UI directly). If the required columns are not stored, then the pre-filters will act as post-filters.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes(optional)

Change the vector search query from:

```sql
SELECT *
FROM VECTOR_SEARCH(
  Table <table>,
  ...)
WHERE <filter>
```

to 

```sql
SELECT *
FROM VECTOR_SEARCH(
  (SELECT * FROM <table> WHERE <filter>),
  ...)
```

## Testing(optional)

Run unit and integration tests.

<!-- Test procedure -->
<!-- Test result -->

## Note(optional)

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
