### PR TITLE
[vertexai] Fix Datastore error on indexing large fields

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
@@ -289,7 +289,10 @@ class DataStoreDocumentStorage(DocumentStorage):
 
             entities = []
             for key, document in zip(keys, documents):
-                entity = self._client.entity(key=key, exclude_from_indexes=[self._text_property_name])
+                entity = self._client.entity(
+                    key=key,
+                    exclude_from_indexes=[self._text_property_name]
+                )
                 entity[self._text_property_name] = document.page_content
                 entity[self._metadata_property_name] = document.metadata
                 entities.append(entity)

--- a/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
@@ -234,6 +234,7 @@ class DataStoreDocumentStorage(DocumentStorage):
         kind: str = "document_id",
         text_property_name: str = "text",
         metadata_property_name: str = "metadata",
+        exclude_from_indexes: List[str] = [],
     ) -> None:
         """Constructor.
         Args:
@@ -244,6 +245,7 @@ class DataStoreDocumentStorage(DocumentStorage):
         self._client = datastore_client
         self._text_property_name = text_property_name
         self._metadata_property_name = metadata_property_name
+        self.exclude_from_indexes = exclude_from_indexes
         self._kind = kind
 
     def mget(self, keys: Sequence[str]) -> List[Optional[Document]]:
@@ -290,8 +292,7 @@ class DataStoreDocumentStorage(DocumentStorage):
             entities = []
             for key, document in zip(keys, documents):
                 entity = self._client.entity(
-                    key=key,
-                    exclude_from_indexes=[self._text_property_name]
+                    key=key, exclude_from_indexes=self.exclude_from_indexes
                 )
                 entity[self._text_property_name] = document.page_content
                 entity[self._metadata_property_name] = document.metadata

--- a/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
@@ -234,7 +234,7 @@ class DataStoreDocumentStorage(DocumentStorage):
         kind: str = "document_id",
         text_property_name: str = "text",
         metadata_property_name: str = "metadata",
-        exclude_from_indexes: List[str] = [],
+        exclude_from_indexes: Optional[List[str]] = None,
     ) -> None:
         """Constructor.
         Args:

--- a/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/document_storage.py
@@ -289,7 +289,7 @@ class DataStoreDocumentStorage(DocumentStorage):
 
             entities = []
             for key, document in zip(keys, documents):
-                entity = self._client.entity(key=key)
+                entity = self._client.entity(key=key, exclude_from_indexes=[self._text_property_name])
                 entity[self._text_property_name] = document.page_content
                 entity[self._metadata_property_name] = document.metadata
                 entities.append(entity)

--- a/libs/vertexai/langchain_google_vertexai/vectorstores/vectorstores.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/vectorstores.py
@@ -375,10 +375,11 @@ class VectorSearchVectorStoreDatastore(_BaseVertexAIVectorStore):
         embedding: Optional[Embeddings] = None,
         stream_update: bool = False,
         datastore_client_kwargs: Optional[Dict[str, Any]] = None,
+        exclude_from_indexes: Optional[List[str]] = None,
         datastore_kind: str = "document_id",
         datastore_text_property_name: str = "text",
         datastore_metadata_property_name: str = "metadata",
-        exclude_from_indexes: List[str] = [],
+        
         **kwargs: Dict[str, Any],
     ) -> "VectorSearchVectorStoreDatastore":
         """Takes the object creation out of the constructor.
@@ -427,6 +428,8 @@ class VectorSearchVectorStoreDatastore(_BaseVertexAIVectorStore):
 
         datastore_client = sdk_manager.get_datastore_client(**datastore_client_kwargs)
 
+        if exclude_from_indexes is None:
+            exclude_from_indexes = []
         document_storage = DataStoreDocumentStorage(
             datastore_client=datastore_client,
             kind=datastore_kind,

--- a/libs/vertexai/langchain_google_vertexai/vectorstores/vectorstores.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/vectorstores.py
@@ -379,7 +379,6 @@ class VectorSearchVectorStoreDatastore(_BaseVertexAIVectorStore):
         datastore_kind: str = "document_id",
         datastore_text_property_name: str = "text",
         datastore_metadata_property_name: str = "metadata",
-        
         **kwargs: Dict[str, Any],
     ) -> "VectorSearchVectorStoreDatastore":
         """Takes the object creation out of the constructor.

--- a/libs/vertexai/langchain_google_vertexai/vectorstores/vectorstores.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/vectorstores.py
@@ -378,6 +378,7 @@ class VectorSearchVectorStoreDatastore(_BaseVertexAIVectorStore):
         datastore_kind: str = "document_id",
         datastore_text_property_name: str = "text",
         datastore_metadata_property_name: str = "metadata",
+        exclude_from_indexes: List[str] = [],
         **kwargs: Dict[str, Any],
     ) -> "VectorSearchVectorStoreDatastore":
         """Takes the object creation out of the constructor.
@@ -399,6 +400,7 @@ class VectorSearchVectorStoreDatastore(_BaseVertexAIVectorStore):
                 index must be compatible with stream/batch updates.
             kwargs: Additional keyword arguments to pass to
                 VertexAIVectorSearch.__init__().
+            exclude_from_indexes: Fields to exclude from datastore indexing
 
         Returns:
             A configured VectorSearchVectorStoreDatastore.
@@ -430,6 +432,7 @@ class VectorSearchVectorStoreDatastore(_BaseVertexAIVectorStore):
             kind=datastore_kind,
             text_property_name=datastore_text_property_name,
             metadata_property_name=datastore_metadata_property_name,
+            exclude_from_indexes=exclude_from_indexes,
         )
 
         return cls(


### PR DESCRIPTION
As the `self._text_property_name` and other fields might contain large text, this fix prevents from indexing such fields that currently triggers an error (see Datastores's maximum size of an indexed string property [limitation](https://cloud.google.com/datastore/docs/concepts/limits)). This also saves datastore's costs, preventing a non necessary field to be indexed. We can now pass a list `exclude_from_indexes` to the class, which is the same list that the sdk expects in input when creating an entity.

🐛 Bug Fix