### PR TITLE
vertexai: Fix returning average log probabilities

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_utils.py
@@ -182,7 +182,7 @@ def get_generation_info(
             if (
                 isinstance(candidate.avg_logprobs, float)
                 and not math.isnan(candidate.avg_logprobs)
-                and candidate.avg_logprobs > 0
+                and candidate.avg_logprobs < 0
             ):
                 info["avg_logprobs"] = candidate.avg_logprobs
 


### PR DESCRIPTION
## PR Description

Fixes an issue where the Google VertexAI API integration was not correctly returning average log probabilities due to a condition that they be greater than zero. This PR ensures that the average log probabilities are returned by setting the condition that they be less than zero.

Co-authored-by: @jaymon0703

## Relevant Issues

vertexai: fix avg log probs nan values #550

## Type

🐛 Bug Fix

## Changes

- Modified the check that average log probabilities are greater than zero to be less than zero.

## Testing

Tested locally by running `make test` for the vertexai package, and all tests passed successfully.