### PR TITLE
genai: Removed forgotten "print" statement in _function_utils.py

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -132,7 +132,6 @@ def _dict_to_gapic_schema(schema: Dict[str, Any]) -> Optional[gapic.Schema]:
 def _format_dict_to_function_declaration(
     tool: Union[FunctionDescription, Dict[str, Any]],
 ) -> gapic.FunctionDeclaration:
-    print(tool)
     return gapic.FunctionDeclaration(
         name=tool.get("name") or tool.get("title"),
         description=tool.get("description"),


### PR DESCRIPTION
While doing simple llm.invoke(...) call, with model that has binded tools via .bind_tools then it starts to print all tools info while invoking. The problem is in _function_utils.py file in _format_dict_to_function_declaration, which has forgotten (i believe) print statement which fires everytime on the function start.