### PR TITLE
vertexai[refactor]: Enhance logprobs

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_utils.py
@@ -154,7 +154,7 @@ def get_generation_info(
     *,
     stream: bool = False,
     usage_metadata: Optional[Dict] = None,
-    logprobs: Optional[int] = 0,
+    logprobs: Union[bool, int] = False,
 ) -> Dict[str, Any]:
     if is_gemini:
         # https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/gemini#response_body
@@ -188,45 +188,48 @@ def get_generation_info(
                 info["avg_logprobs"] = candidate.avg_logprobs
 
         if hasattr(candidate, "logprobs_result"):
-            logprobs_int = logprobs if logprobs is not None else 0
-            log_probs = [
-                {
-                    "token": candidate.token,
-                    "logprob": candidate.log_probability,
-                    "top_logprobs": [],
-                }
-                for candidate in candidate.logprobs_result.chosen_candidates
-            ]
+            if isinstance(logprobs, int):
+                logprobs_int = logprobs if logprobs is not None else 0
+                log_probs = [
+                    {
+                        "token": candidate.token,
+                        "logprob": candidate.log_probability,
+                        "top_logprobs": [],
+                    }
+                    for candidate in candidate.logprobs_result.chosen_candidates
+                ]
 
-            # Add list of top token candidates for given token
-            top_logprobs = [
-                {"token": candidate.token, "logprob": candidate.log_probability}
-                for top_candidates in candidate.logprobs_result.top_candidates
-                for candidate in top_candidates.candidates
-            ]
-            # Iterate over top_logprobs logprobs_int times
-            for i in range(len(candidate.logprobs_result.chosen_candidates)):
-                for j in range(i * logprobs_int, (i + 1) * logprobs_int):
-                    if j < len(top_logprobs):
-                        log_probs[i]["top_logprobs"].append(top_logprobs[j])
+                # Add list of top token candidates for given token
+                top_logprobs = [
+                    {"token": candidate.token, "logprob": candidate.log_probability}
+                    for top_candidates in candidate.logprobs_result.top_candidates
+                    for candidate in top_candidates.candidates
+                ]
+                # Iterate over top_logprobs logprobs_int times
+                for i in range(len(candidate.logprobs_result.chosen_candidates)):
+                    for j in range(i * logprobs_int, (i + 1) * logprobs_int):
+                        if j < len(top_logprobs):
+                            log_probs[i]["top_logprobs"].append(top_logprobs[j])
 
-            # Check and add
-            for candidate in log_probs:
-                logprob = candidate.get("logprob")
-                candidate_top_logprobs = candidate.get("top_logprobs", [])
+                # Check and add
+                for candidate in log_probs:
+                    logprob = candidate.get("logprob")
+                    candidate_top_logprobs = candidate.get("top_logprobs", [])
 
-                if (
-                    isinstance(logprob, float)
-                    and not math.isnan(logprob)
-                    and logprob < 0
-                    and all(
-                        isinstance(top_candidate.get("logprob"), float)
-                        and not math.isnan(top_candidate.get("logprob"))
-                        and top_candidate.get("logprob") < 0
-                        for top_candidate in candidate_top_logprobs
-                    )
-                ):
-                    info["logprobs_result"] = log_probs
+                    if (
+                        isinstance(logprob, float)
+                        and not math.isnan(logprob)
+                        and logprob < 0
+                        and all(
+                            isinstance(top_candidate.get("logprob"), float)
+                            and not math.isnan(top_candidate.get("logprob"))
+                            and top_candidate.get("logprob") < 0
+                            for top_candidate in candidate_top_logprobs
+                        )
+                    ):
+                        info["logprobs_result"] = log_probs
+            else:
+                pass
 
         try:
             if candidate.grounding_metadata:

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -1047,7 +1047,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         models. Must be a string containing the cache name (A sequence of numbers)
     """
 
-    logprobs: Optional[int] = 0
+    logprobs: Union[bool, int] = False
     """Whether to return logprobs as part of AIMessage.response_metadata.
     
     If False, don't return logprobs. If True, return logprobs for top candidate. 

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -1128,4 +1128,6 @@ def test_logprobs() -> None:
             assert isinstance(token.get("logprob"), float)
             if "top_logprobs" in token and token.get("top_logprobs") is not None:
                 assert isinstance(token.get("top_logprobs"), list)
-                stack.extend(token["top_logprobs"])
+                stack.extend(token.get("top_logprobs", []))
+    msg2 = llm.invoke("hey", logprobs=False)
+    assert msg2.response_metadata.get("logprobs_result") is None

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -1117,7 +1117,6 @@ def test_logprobs() -> None:
     llm = ChatVertexAI(model="gemini-1.5-flash", logprobs=2)
     msg = llm.invoke("hey")
     tokenprobs = msg.response_metadata.get("logprobs_result")
-    print(tokenprobs)
     assert tokenprobs is None or isinstance(tokenprobs, list)
     if tokenprobs:
         stack = tokenprobs[:]

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -1117,6 +1117,7 @@ def test_logprobs() -> None:
     llm = ChatVertexAI(model="gemini-1.5-flash", logprobs=2)
     msg = llm.invoke("hey")
     tokenprobs = msg.response_metadata.get("logprobs_result")
+    print(tokenprobs)
     assert tokenprobs is None or isinstance(tokenprobs, list)
     if tokenprobs:
         stack = tokenprobs[:]
@@ -1129,5 +1130,11 @@ def test_logprobs() -> None:
             if "top_logprobs" in token and token.get("top_logprobs") is not None:
                 assert isinstance(token.get("top_logprobs"), list)
                 stack.extend(token.get("top_logprobs", []))
-    msg2 = llm.invoke("hey", logprobs=False)
-    assert msg2.response_metadata.get("logprobs_result") is None
+
+    llm2 = ChatVertexAI(model="gemini-1.5-flash", logprobs=True)
+    msg2 = llm2.invoke("how are you")
+    assert msg2.response_metadata["logprobs_result"]
+
+    llm3 = ChatVertexAI(model="gemini-1.5-flash", logprobs=False)
+    msg3 = llm3.invoke("howdy")
+    assert msg3.response_metadata.get("logprobs_result") is None

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -579,7 +579,7 @@ def test_default_params_gemini() -> None:
             == "Hello"
         )
         expected = GenerationConfig(
-            candidate_count=1, logprobs=0, response_logprobs=True
+            candidate_count=1,
         )
         assert (
             mock_generate_content.call_args.kwargs["request"].generation_config
@@ -915,8 +915,6 @@ def test_generation_config_gemini() -> None:
         temperature=0.3,
         top_k=3,
         candidate_count=2,
-        logprobs=0,
-        response_logprobs=True,
     )
     assert generation_config == expected
 

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -578,7 +578,9 @@ def test_default_params_gemini() -> None:
             mock_generate_content.call_args.kwargs["request"].contents[0].parts[0].text
             == "Hello"
         )
-        expected = GenerationConfig(candidate_count=1)
+        expected = GenerationConfig(
+            candidate_count=1, logprobs=0, response_logprobs=True
+        )
         assert (
             mock_generate_content.call_args.kwargs["request"].generation_config
             == expected
@@ -909,7 +911,12 @@ def test_generation_config_gemini() -> None:
         temperature=0.3, stop=["stop"], candidate_count=2
     )
     expected = GenerationConfig(
-        stop_sequences=["stop"], temperature=0.3, top_k=3, candidate_count=2
+        stop_sequences=["stop"],
+        temperature=0.3,
+        top_k=3,
+        candidate_count=2,
+        logprobs=0,
+        response_logprobs=True,
     )
     assert generation_config == expected
 


### PR DESCRIPTION
## PR Description

Issue #570 mentions a unified logprobs interface that could improve upon the default formatting returned from Google. Inspired by OpenAI's formatting found [here](https://python.langchain.com/docs/how_to/logprobs/), this format was created for the `logprobs_result` from Google VertexAI.

## Relevant issues

Adds to - vertexai[patch]: Add logprobs support #570

## Type

🧹 Refactoring


## Changes
```ruby
llm = ChatVertexAI(model="gemini-1.5-flash-001", logprobs=True) 
ai_msg = llm.invoke(messages)
ai_msg.response_metadata["logprobs_result"]
```
```
[
    {'token': 'J', 'logprob': -1.549651415189146e-06, 'top_logprobs': []},
    {'token': "'", 'logprob': -1.549651415189146e-06, 'top_logprobs': []},
    {'token': 'adore', 'logprob': 0.0, 'top_logprobs': []},
    {'token': ' programmer', 'logprob': -1.1922384146600962e-07, 'top_logprobs': []},
    {'token': '.', 'logprob': -4.827636439586058e-05, 'top_logprobs': []},
    {'token': ' ', 'logprob': -0.018011733889579773, 'top_logprobs': []},
    {'token': '\n', 'logprob': -0.0008687592926435173, 'top_logprobs': []}
]
```
If `logprobs` = int, the `top_logprobs` lists contain int # of dicts of top candidate tokens and their logprobs.