### PR TITLE
vertexai: add finish message when available to the response object from gemini …

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_utils.py
@@ -177,6 +177,9 @@ def get_generation_info(
             "finish_reason": (
                 candidate.finish_reason.name if candidate.finish_reason else None
             ),
+            "finish_message": (
+                candidate.finish_message if candidate.finish_message else None
+            )
         }
         if hasattr(candidate, "avg_logprobs") and candidate.avg_logprobs is not None:
             if (

--- a/libs/vertexai/langchain_google_vertexai/_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_utils.py
@@ -179,7 +179,7 @@ def get_generation_info(
             ),
             "finish_message": (
                 candidate.finish_message if candidate.finish_message else None
-            )
+            ),
         }
         if hasattr(candidate, "avg_logprobs") and candidate.avg_logprobs is not None:
             if (


### PR DESCRIPTION
## PR Description

Currently the response from gemini is parsed into a dict which is passed as the `generation_info` to a `ChatGeneration` object. However, this is missing a key piece of information useful for debugging when function calls fail when using function calling via the `bind_tools` syntax which is the `finish_message`. The finish message is populated with information about the malformed function call in the case of `MALFORMED_FUNCTION_CALL` errors. This PR simply adds this field when available to the dictionary passed back.

## Relevant issues

None

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes(optional)

Added in `finish_message` field to the `generation_info` in the case of a gemini model invocation.
