### PR TITLE
Update GoogleDriveLoader to allow bring your own credentials

### DIFF
--- a/libs/community/langchain_google_community/drive.py
+++ b/libs/community/langchain_google_community/drive.py
@@ -27,6 +27,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
     """Path to the credentials file."""
     token_path: Path = Path.home() / ".credentials" / "token.json"
     """Path to the token file."""
+    credentials: Any = None
+    """Your own google credentials created via your own mechanism"""    
     folder_id: Optional[str] = None
     """The folder id to load from."""
     document_ids: Optional[List[str]] = None
@@ -276,6 +278,11 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
         if self.token_path.exists():
             creds = Credentials.from_authorized_user_file(str(self.token_path), SCOPES)
 
+        if self.credentials:
+            # use whatever was passed to us
+            creds = self.credentials
+            return creds        
+        
         if not creds or not creds.valid:
             if creds and creds.expired and creds.refresh_token:
                 creds.refresh(Request())

--- a/libs/community/langchain_google_community/drive.py
+++ b/libs/community/langchain_google_community/drive.py
@@ -28,7 +28,7 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
     token_path: Path = Path.home() / ".credentials" / "token.json"
     """Path to the token file."""
     credentials: Any = None
-    """Your own google credentials created via your own mechanism"""    
+    """Your own google credentials created via your own mechanism"""
     folder_id: Optional[str] = None
     """The folder id to load from."""
     document_ids: Optional[List[str]] = None
@@ -281,8 +281,8 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
         if self.credentials:
             # use whatever was passed to us
             creds = self.credentials
-            return creds        
-        
+            return creds
+
         if not creds or not creds.valid:
             if creds and creds.expired and creds.refresh_token:
                 creds.refresh(Request())


### PR DESCRIPTION
issue: https://github.com/langchain-ai/langchain-google/issues/168


## PR Description

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"
  Adds 'bring your own credentials' to the drive loader to allow more flexibility in deployments (cloud run service accounts, command line, jupyter notebooks, colab, etc).

## PR Description and Relevant issues:

  - Allows for declaration of credentials created elsewhere (outside this module) to be used
  - Relevant issues [(Port randomness)](issue: https://github.com/langchain-ai/langchain-google/issues/168)
  - Any dependencies required for this change: None

  Adds 'bring your own credentials' to the drive loader to allow more flexibility in deployments (cloud run service accounts, command line, jupyter notebooks, colab, etc).

## Relevant issues

Fixes issue: https://github.com/langchain-ai/langchain-google/issues/168

🐛 Bug Fix
🧹 Refactoring


## Testing(optional)
Tested in jupyter notebook
