### PR TITLE
[vertexai]: Use one gcs client in Imageutils 

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
@@ -31,7 +31,7 @@ from langchain_core.utils.function_calling import convert_to_openai_tool
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
-    from anthropic.types import RawMessageStreamEvent  # type: ignore
+    from anthropic.types import RawMessageStreamEvent
 
 _message_type_lookups = {
     "human": "user",

--- a/libs/vertexai/langchain_google_vertexai/_image_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_image_utils.py
@@ -203,7 +203,7 @@ class ImageBytesLoader:
             storage.Blob
         """
 
-        gcs_client = self._storage_client()
+        gcs_client = self._storage_client
         blob = storage.Blob.from_string(gcs_uri, gcs_client)
         blob.reload(client=gcs_client)
         return blob

--- a/libs/vertexai/langchain_google_vertexai/_image_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_image_utils.py
@@ -4,6 +4,7 @@ import base64
 import os
 import re
 from enum import Enum
+from functools import cached_property
 from typing import Dict, Optional, Union
 from urllib.parse import urlparse
 
@@ -42,6 +43,10 @@ class ImageBytesLoader:
             project: Google Cloud project id. Defaults to none.
         """
         self._project = project
+
+    @cached_property
+    def _storage_client(self):
+        return storage.Client(project=self._project)
 
     def load_bytes(self, image_string: str) -> bytes:
         """Routes to the correct loader based on the image_string.
@@ -198,7 +203,7 @@ class ImageBytesLoader:
             storage.Blob
         """
 
-        gcs_client = storage.Client(project=self._project)
+        gcs_client = self._storage_client()
         blob = storage.Blob.from_string(gcs_uri, gcs_client)
         blob.reload(client=gcs_client)
         return blob

--- a/libs/vertexai/langchain_google_vertexai/model_garden.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden.py
@@ -148,7 +148,7 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
 
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
-        from anthropic import (  # type: ignore
+        from anthropic import (
             AnthropicVertex,
             AsyncAnthropicVertex,
         )


### PR DESCRIPTION
Fixes #594

Till now very time the load_bytes was called a new gcs client was created. Now just one client is created. First i wanted to create the client in the constructor but I saw in the code that not always a client is created and in some environments it could have failed. So i want to be on the safe side and don't change the current behavior.

I don't know which tests i can add as i don't change any visible behavior. So tests should pass without problems.