### PR TITLE
genai[feat]: add filetype detection for images from bytes

### DIFF
--- a/libs/genai/langchain_google_genai/_image_utils.py
+++ b/libs/genai/langchain_google_genai/_image_utils.py
@@ -8,8 +8,8 @@ from enum import Enum
 from typing import Any, Dict
 from urllib.parse import urlparse
 
+import filetype  # type: ignore[import]
 import requests
-import filetype
 from google.ai.generativelanguage_v1beta.types import Part
 
 
@@ -88,7 +88,7 @@ class ImageBytesLoader:
             raise ValueError(msg)
 
         inline_data: Dict[str, Any] = {"data": bytes_}
-        
+
         mime_type, _ = mimetypes.guess_type(image_string)
         if not mime_type:
             kind = filetype.guess(bytes_)

--- a/libs/genai/langchain_google_genai/_image_utils.py
+++ b/libs/genai/langchain_google_genai/_image_utils.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 from urllib.parse import urlparse
 
 import requests
+import filetype
 from google.ai.generativelanguage_v1beta.types import Part
 
 
@@ -87,7 +88,13 @@ class ImageBytesLoader:
             raise ValueError(msg)
 
         inline_data: Dict[str, Any] = {"data": bytes_}
+        
         mime_type, _ = mimetypes.guess_type(image_string)
+        if not mime_type:
+            kind = filetype.guess(bytes_)
+            if kind:
+                mime_type = kind.mime
+
         if mime_type:
             inline_data["mime_type"] = mime_type
 

--- a/libs/genai/poetry.lock
+++ b/libs/genai/poetry.lock
@@ -212,6 +212,17 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "filetype"
+version = "1.2.0"
+description = "Infer file type and MIME type of any file/buffer. No external dependencies."
+optional = false
+python-versions = "*"
+files = [
+    {file = "filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25"},
+    {file = "filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb"},
+]
+
+[[package]]
 name = "freezegun"
 version = "1.5.1"
 description = "Let your Python tests travel through time"
@@ -1470,4 +1481,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "988b5a557506419d3750476d499929c8e3d3f7a0f37f4ca8c5ec5064227f2671"
+content-hash = "07647d94d5cbab0a6be38f492be4a97837ad4164d1437d9a11723235a34c9e45"

--- a/libs/genai/pyproject.toml
+++ b/libs/genai/pyproject.toml
@@ -15,6 +15,7 @@ python = ">=3.9,<4.0"
 langchain-core = ">=0.3.15,<0.4"
 google-generativeai = "^0.8.0"
 pydantic = ">=2,<3"
+filetype = "^1.2.0"
 
 [tool.poetry.group.test]
 optional = true

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -158,6 +158,33 @@ def test_chat_google_genai_invoke_multimodal() -> None:
         assert len(chunk.content.strip()) > 0
 
 
+def test_chat_google_genai_invoke_multimodal_by_url() -> None:
+    messages: list = [
+        HumanMessage(
+            content=[
+                {
+                    "type": "text",
+                    "text": "Guess what's in this picture! You have 3 guesses.",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": "https://picsum.photos/seed/picsum/200/300",
+                },
+            ]
+        ),
+    ]
+    llm = ChatGoogleGenerativeAI(model=_VISION_MODEL)
+    response = llm.invoke(messages)
+    assert isinstance(response.content, str)
+    assert len(response.content.strip()) > 0
+
+    # Try streaming
+    for chunk in llm.stream(messages):
+        print(chunk)  # noqa: T201
+        assert isinstance(chunk.content, str)
+        assert len(chunk.content.strip()) > 0
+
+
 def test_chat_google_genai_invoke_multimodal_multiple_messages() -> None:
     messages: list = [
         HumanMessage(content="Hi there"),


### PR DESCRIPTION
## PR Description
This pull request enhances the process of guessing MIME types by introducing an alternative method to determine the MIME type from file bytes when guessing from the filename fails. Additionally, it includes an integration test for a specific case related to remote URL images without file extensions.

###  MIME Type Detection:
- Updated `pyproject.toml` to add new dependency: `filetype`.
- Implemented MIME type guessing using the `filetype` library to analyze image bytes as a fallback mechanism.

### Integration Test:
- Added a new integration test for a remote URL image without a file extension (`https://picsum.photos/seed/picsum/200/300`). This URL is currently used in the example section of the README, but it does not work as intended.


## Type
🆕 New Feature
✅ Test