### PR TITLE
genai: fix 'title' field handling issue in nested Pydantic schemas with .with_structured_output()

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -342,8 +342,6 @@ def _get_items_from_schema(schema: Union[Dict, List, str]) -> Dict[str, Any]:
         items["type_"] = _get_type_from_schema(schema)
         if items["type_"] == glm.Type.OBJECT and "properties" in schema:
             items["properties"] = _get_properties_from_schema_any(schema["properties"])
-        if "title" in schema:
-            items["title"] = schema
         if "title" in schema or "description" in schema:
             items["description"] = (
                 schema.get("description") or schema.get("title") or ""


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

This PR addresses an error that occurs when using `.with_structured_output` with nested Pydantic schemas. The error, `ValueError: Unknown field for Schema: title`, arises because of redundant lines in the `_get_items_from_schema` function, which unintentionally retain the 'title' key if it exists.

Specifically, the following redundant lines caused the 'title' key to be incorrectly retained if it exists:

```python
if "title" in schema:
    items["title"] = schema
```

### Problem:
- The error occurs specifically when dealing with nested Pydantic schemas, where a second 'title' key is introduced.
- The 'title' field is problematic because the schema that Google accepts for function declaration doesn't allow for a key named "title" for its properties. This causes a conflict, leading to the `ValueError` when the 'title' field is included in the schema.

#### Example code that causes the problem:
```python
from typing import Optional
from langchain_core.prompts import ChatPromptTemplate
from langchain_google_genai import ChatGoogleGenerativeAI
from pydantic import BaseModel, Field


prompt_template = ChatPromptTemplate.from_messages(
    [
        (
            "system",
            "You are an expert extraction algorithm. "
            "Only extract relevant information from the text. "
            "If you do not know the value of an attribute asked to extract, "
            "return null for the attribute's value.",
        ),
        ("human", "{text}"),
    ]
)

class Person(BaseModel):
    """Information about a person."""
    name: Optional[str] = Field(default=None, description="The name of the person")

class Data(BaseModel):
    people: List[Person]


llm = ChatGoogleGenerativeAI(model="gemini-1.5-flash")
structured_llm = llm.with_structured_output(schema=Data)

text = "My name is Jeff, my hair is black and i am 6 feet tall. Anna has the same color hair as me."
prompt = prompt_template.invoke({"text": text})
structured_llm.invoke(prompt)

```
#### Result:
```text
ValueError: Unknown field for Schema: title
```

### Solution:
- The redundant lines responsible for retaining the 'title' key were removed from the `_get_items_from_schema` function. This ensures that the 'title' key is not incorrectly added in the case of nested schemas.
- This fix ensures that nested schemas are handled properly without causing issues related to the extra 'title' field.


## Relevant issues
- No issue reference or bug report was specifically linked, but this is a critical bug fix related to schema handling.
<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix


## Changes:
- Removed redundant lines in the `_get_items_from_schema` function to prevent the issue of retaining an extra 'title' field in nested schemas.

### Changes Made in `_function_utils` Module:
The changes were made in the `_get_items_from_schema` function to address the issue with the redundant 'title' field. Below is the updated code with the deleted lines highlighted.

```python
def _get_items_from_schema(schema: Union[Dict, List, str]) -> Dict[str, Any]:
    items: Dict = {}
    if isinstance(schema, List):
        for i, v in enumerate(schema):
            items[f"item{i}"] = _get_properties_from_schema_any(v)
    elif isinstance(schema, Dict):
        items["type_"] = _get_type_from_schema(schema)
        if items["type_"] == glm.Type.OBJECT and "properties" in schema:
            items["properties"] = _get_properties_from_schema_any(schema["properties"])

        #############################################
        if "title" in schema:  # Deleted
            items["title"] = schema  # Deleted
        #################################################

        if "title" in schema or "description" in schema:
            items["description"] = (
                schema.get("description") or schema.get("title") or ""
            )


        # Rest of code

    return items
```

## Testing:
- All relevant tests passed, and the issue was resolved with nested schemas.

#### Result of code that was resulting the problem this time:
```text
Data(people=[Person(name='Jeff', hair_color='black', height_in_meters='1.83'), Person(name='Anna', hair_color='black', height_in_meters=None)])
```

<!-- Test procedure -->
<!-- Test result -->

