### PR TITLE
vertexai: fix model family is always set even for non-google models

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -217,7 +217,7 @@ class _VertexAICommon(_VertexAIBase):
 
     @property
     def _is_gemini_model(self) -> bool:
-        return is_gemini_model(self.model_family)  # type: ignore[arg-type]
+        return is_gemini_model(self.model_family)
 
     @property
     def _llm_type(self) -> str:

--- a/libs/vertexai/langchain_google_vertexai/_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_utils.py
@@ -123,7 +123,7 @@ class GoogleModelFamily(str, Enum):
     PALM = auto()
 
     @classmethod
-    def _missing_(cls, value: Any) -> "GoogleModelFamily":
+    def _missing_(cls, value: Any) -> Union["GoogleModelFamily", None]:
         # https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versioning
         model_name = value.lower()
         gemini_advanced_models = {
@@ -145,10 +145,10 @@ class GoogleModelFamily(str, Enum):
             return GoogleModelFamily.GEMINI
         if "bison" in model_name or "medlm" in model_name:
             return GoogleModelFamily.PALM
-        return GoogleModelFamily.GEMINI
+        return None
 
 
-def is_gemini_model(model_family: GoogleModelFamily) -> bool:
+def is_gemini_model(model_family: Union[GoogleModelFamily, None]) -> bool:
     """Returns True if the model name is a Gemini model."""
     return model_family in [GoogleModelFamily.GEMINI, GoogleModelFamily.GEMINI_ADVANCED]
 

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -1083,7 +1083,10 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         """Validate that the python package exists in environment."""
         safety_settings = self.safety_settings
         tuned_model_name = self.tuned_model_name
-        self.model_family = GoogleModelFamily(self.model_name)
+        try:
+            self.model_family = GoogleModelFamily(self.model_name)
+        except ValueError:
+            self.model_family = None
 
         if self.model_name == "chat-bison-default":
             logger.warning(


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ x PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [x] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [x] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [x] PR title and description are appropriate
- [x] Necessary tests and documentation have been added
- [x] Lint and tests pass successfully
- [x] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

When using models outside the google family the model family is still set. This results in f.e. get_num_tokens hitting an enpoint while it should not.

## Relevant issues

N/A

## Type

🐛 Bug Fix

## Changes(optional)

N/A

## Testing(optional)

N/A

## Note(optional)

N/A
