### PR TITLE
genai: Fixed nested pydantic structures recursion

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -316,11 +316,17 @@ def _get_properties_from_schema(schema: Dict) -> Dict[str, Any]:
             properties_item["items"] = _get_items_from_schema_any(v.get("items"))
 
         if properties_item.get("type_") == glm.Type.OBJECT:
-            if v.get('anyOf') and isinstance(v['anyOf'], list) and isinstance(v['anyOf'][0], dict):
-                v = v['anyOf'][0]
+            if (
+                v.get("anyOf")
+                and isinstance(v["anyOf"], list)
+                and isinstance(v["anyOf"][0], dict)
+            ):
+                v = v["anyOf"][0]
             v_properties = v.get("properties")
             if v_properties:
-                properties_item["properties"] = _get_properties_from_schema_any(v_properties)
+                properties_item["properties"] = _get_properties_from_schema_any(
+                    v_properties
+                )
                 if isinstance(v_properties, dict):
                     properties_item["required"] = [
                         k for k, v in v_properties.items() if "default" not in v

--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -316,6 +316,8 @@ def _get_properties_from_schema(schema: Dict) -> Dict[str, Any]:
             properties_item["items"] = _get_items_from_schema_any(v.get("items"))
 
         if properties_item.get("type_") == glm.Type.OBJECT:
+            if v.get('anyOf') and isinstance(v['anyOf'], list) and isinstance(v['anyOf'][0], dict):
+                v = v['anyOf'][0]
             v_properties = v.get("properties")
             if v_properties:
                 properties_item["properties"] = _get_properties_from_schema_any(v_properties)
@@ -323,7 +325,7 @@ def _get_properties_from_schema(schema: Dict) -> Dict[str, Any]:
                     properties_item["required"] = [
                         k for k, v in v_properties.items() if "default" not in v
                     ]
-                    
+
         if k == "title" and "description" not in properties_item:
             properties_item["description"] = k + " is " + str(v)
 

--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -315,10 +315,15 @@ def _get_properties_from_schema(schema: Dict) -> Dict[str, Any]:
         if properties_item.get("type_") == glm.Type.ARRAY and v.get("items"):
             properties_item["items"] = _get_items_from_schema_any(v.get("items"))
 
-        if properties_item.get("type_") == glm.Type.OBJECT and v.get("properties"):
-            properties_item["properties"] = _get_properties_from_schema_any(
-                v.get("properties")
-            )
+        if properties_item.get("type_") == glm.Type.OBJECT:
+            v_properties = v.get("properties")
+            if v_properties:
+                properties_item["properties"] = _get_properties_from_schema_any(v_properties)
+                if isinstance(v_properties, dict):
+                    properties_item["required"] = [
+                        k for k, v in v_properties.items() if "default" not in v
+                    ]
+                    
         if k == "title" and "description" not in properties_item:
             properties_item["description"] = k + " is " + str(v)
 

--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -325,6 +325,9 @@ def _get_properties_from_schema(schema: Dict) -> Dict[str, Any]:
                     properties_item["required"] = [
                         k for k, v in v_properties.items() if "default" not in v
                     ]
+            else:
+                # Providing dummy type for object without properties
+                properties_item["type_"] = glm.Type.STRING
 
         if k == "title" and "description" not in properties_item:
             properties_item["description"] = k + " is " + str(v)

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Generator, Optional, Union
+from typing import Any, Generator, List, Optional, Union
 from unittest.mock import MagicMock, patch
 
 import google.ai.generativelanguage as glm
@@ -15,6 +15,169 @@ from langchain_google_genai._function_utils import (
     convert_to_genai_function_declarations,
     tool_to_dict,
 )
+
+
+def test_tool_with_anyof_nullable_param() -> None:
+    """
+    Example test that checks a string parameter marked as Optional,
+    verifying it's recognized as a 'string' & 'nullable'.
+    """
+
+    @tool(parse_docstring=True)
+    def possibly_none(
+        a: Optional[str] = None,
+    ) -> str:
+        """
+        A test function whose argument can be a string or None.
+
+        Args:
+          a: Possibly none.
+        """
+        return "value"
+
+    # Convert to OpenAI, then to GenAI, then to dict
+    oai_tool = convert_to_openai_tool(possibly_none)
+    genai_tool = convert_to_genai_function_declarations([oai_tool])
+    genai_tool_dict = tool_to_dict(genai_tool)
+
+    fn_decl = genai_tool_dict["function_declarations"][0]
+    parameters = fn_decl["parameters"]
+    a_property = parameters["properties"]["a"]
+
+    assert a_property["type_"] == glm.Type.STRING, "Expected 'a' to be STRING."
+    assert a_property.get("nullable") is True, "Expected 'a' to be marked as nullable."
+
+
+def test_tool_with_array_anyof_nullable_param() -> None:
+    """
+    Checks an array parameter marked as Optional, verifying it's recognized
+    as an 'array' & 'nullable', and that the items are correctly typed.
+    """
+
+    @tool(parse_docstring=True)
+    def possibly_none_list(
+        items: Optional[List[str]] = None,
+    ) -> str:
+        """
+        A test function whose argument can be a list of strings or None.
+
+        Args:
+          items: Possibly a list of strings or None.
+        """
+        return "value"
+
+    # Convert to OpenAI tool
+    oai_tool = convert_to_openai_tool(possibly_none_list)
+
+    # Manually assign the 'items' type in the parameters
+    oai_tool["function"]["parameters"]["properties"]["items"]["items"] = {
+        "type": "string"
+    }
+
+    # Convert to GenAI, then to dict
+    genai_tool = convert_to_genai_function_declarations([oai_tool])
+    genai_tool_dict = tool_to_dict(genai_tool)
+
+    fn_decl = genai_tool_dict["function_declarations"][0]
+    parameters = fn_decl["parameters"]
+    items_property = parameters["properties"]["items"]
+
+    # Assertions
+    assert items_property["type_"] == glm.Type.ARRAY, "Expected 'items' to be ARRAY."
+    assert (
+        items_property.get("nullable") is True
+    ), "Expected 'items' to be marked as nullable."
+    # Check that the array items are recognized as strings
+    assert (
+        items_property["items"]["type_"] == glm.Type.STRING
+    ), "Expected array items to be STRING."
+
+
+def test_tool_with_nested_object_anyof_nullable_param() -> None:
+    """
+    Checks an object parameter (dict) marked as Optional, verifying it's recognized
+    as an 'object' but defaults to string if there are no real properties,
+    and that it is 'nullable'.
+    """
+
+    @tool(parse_docstring=True)
+    def possibly_none_dict(
+        data: Optional[dict] = None,
+    ) -> str:
+        """
+        A test function whose argument can be an object (dict) or None.
+
+        Args:
+          data: Possibly a dict or None.
+        """
+        return "value"
+
+    # Convert to OpenAI, then to GenAI, then to dict
+    oai_tool = convert_to_openai_tool(possibly_none_dict)
+    genai_tool = convert_to_genai_function_declarations([oai_tool])
+    genai_tool_dict = tool_to_dict(genai_tool)
+
+    fn_decl = genai_tool_dict["function_declarations"][0]
+    parameters = fn_decl["parameters"]
+    data_property = parameters["properties"]["data"]
+
+    assert data_property["type_"] in [
+        glm.Type.OBJECT,
+        glm.Type.STRING,
+    ], "Expected 'data' to be recognized as an OBJECT or fallback to STRING."
+    assert (
+        data_property.get("nullable") is True
+    ), "Expected 'data' to be marked as nullable."
+
+
+def test_tool_with_enum_anyof_nullable_param() -> None:
+    """
+    Checks a parameter with an enum, marked as Optional, verifying it's recognized
+    as 'string' & 'nullable', and that the 'enum' field is captured.
+    """
+
+    @tool(parse_docstring=True)
+    def possibly_none_enum(
+        status: Optional[str] = None,
+    ) -> str:
+        """
+        A test function whose argument can be an enum string or None.
+
+        Args:
+          status: Possibly one of ("active", "inactive", "pending") or None.
+        """
+        return "value"
+
+    # Convert to OpenAI tool
+    oai_tool = convert_to_openai_tool(possibly_none_enum)
+
+    # Manually override the 'enum' for the 'status' property in the parameters
+    oai_tool["function"]["parameters"]["properties"]["status"]["enum"] = [
+        "active",
+        "inactive",
+        "pending",
+    ]
+
+    # Convert to GenAI, then to dict
+    genai_tool = convert_to_genai_function_declarations([oai_tool])
+    genai_tool_dict = tool_to_dict(genai_tool)
+
+    fn_decl = genai_tool_dict["function_declarations"][0]
+    parameters = fn_decl["parameters"]
+    status_property = parameters["properties"]["status"]
+
+    # Assertions
+    assert (
+        status_property["type_"] == glm.Type.STRING
+    ), "Expected 'status' to be STRING."
+    assert (
+        status_property.get("nullable") is True
+    ), "Expected 'status' to be marked as nullable."
+    assert status_property.get("enum") == [
+        "active",
+        "inactive",
+        "pending",
+    ], "Expected 'status' to have enum values."
 
 
 def test_format_tool_to_genai_function() -> None:

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -39,12 +39,27 @@ def test_tool_with_anyof_nullable_param() -> None:
     oai_tool = convert_to_openai_tool(possibly_none)
     genai_tool = convert_to_genai_function_declarations([oai_tool])
     genai_tool_dict = tool_to_dict(genai_tool)
+    assert isinstance(genai_tool_dict, dict), "Expected a dict."
 
-    fn_decl = genai_tool_dict["function_declarations"][0]
-    parameters = fn_decl["parameters"]
-    a_property = parameters["properties"]["a"]
+    function_declarations = genai_tool_dict.get("function_declarations")
+    assert isinstance(
+        function_declarations,
+        list,
+    ), "Expected a list."
 
-    assert a_property["type_"] == glm.Type.STRING, "Expected 'a' to be STRING."
+    fn_decl = function_declarations[0]
+    assert isinstance(fn_decl, dict), "Expected a dict."
+
+    parameters = fn_decl.get("parameters")
+    assert isinstance(parameters, dict), "Expected a dict."
+
+    properties = parameters.get("properties")
+    assert isinstance(properties, dict), "Expected a dict."
+
+    a_property = properties.get("a")
+    assert isinstance(a_property, dict), "Expected a dict."
+
+    assert a_property.get("type_") == glm.Type.STRING, "Expected 'a' to be STRING."
     assert a_property.get("nullable") is True, "Expected 'a' to be marked as nullable."
 
 
@@ -77,20 +92,34 @@ def test_tool_with_array_anyof_nullable_param() -> None:
     # Convert to GenAI, then to dict
     genai_tool = convert_to_genai_function_declarations([oai_tool])
     genai_tool_dict = tool_to_dict(genai_tool)
+    assert isinstance(genai_tool_dict, dict), "Expected a dict."
 
-    fn_decl = genai_tool_dict["function_declarations"][0]
-    parameters = fn_decl["parameters"]
-    items_property = parameters["properties"]["items"]
+    function_declarations = genai_tool_dict.get("function_declarations")
+    assert isinstance(function_declarations, list), "Expected a list."
+
+    fn_decl = function_declarations[0]
+    assert isinstance(fn_decl, dict), "Expected a dict."
+
+    parameters = fn_decl.get("parameters")
+    assert isinstance(parameters, dict), "Expected a dict."
+
+    properties = parameters.get("properties")
+    assert isinstance(properties, dict), "Expected a dict."
+
+    items_property = properties.get("items")
+    assert isinstance(items_property, dict), "Expected a dict."
 
     # Assertions
-    assert items_property["type_"] == glm.Type.ARRAY, "Expected 'items' to be ARRAY."
     assert (
-        items_property.get("nullable") is True
-    ), "Expected 'items' to be marked as nullable."
+        items_property.get("type_") == glm.Type.ARRAY
+    ), "Expected 'items' to be ARRAY."
+    assert items_property.get("nullable"), "Expected 'items' to be marked as nullable."
     # Check that the array items are recognized as strings
-    assert (
-        items_property["items"]["type_"] == glm.Type.STRING
-    ), "Expected array items to be STRING."
+
+    items = items_property.get("items")
+    assert isinstance(items, dict), "Expected 'items' to be a dict."
+
+    assert items.get("type_") == glm.Type.STRING, "Expected array items to be STRING."
 
 
 def test_tool_with_nested_object_anyof_nullable_param() -> None:
@@ -116,12 +145,24 @@ def test_tool_with_nested_object_anyof_nullable_param() -> None:
     oai_tool = convert_to_openai_tool(possibly_none_dict)
     genai_tool = convert_to_genai_function_declarations([oai_tool])
     genai_tool_dict = tool_to_dict(genai_tool)
+    assert isinstance(genai_tool_dict, dict), "Expected a dict."
 
-    fn_decl = genai_tool_dict["function_declarations"][0]
-    parameters = fn_decl["parameters"]
-    data_property = parameters["properties"]["data"]
+    function_declarations = genai_tool_dict.get("function_declarations")
+    assert isinstance(function_declarations, list), "Expected a list."
 
-    assert data_property["type_"] in [
+    fn_decl = function_declarations[0]
+    assert isinstance(fn_decl, dict), "Expected a dict."
+
+    parameters = fn_decl.get("parameters")
+    assert isinstance(parameters, dict), "Expected a dict."
+
+    properties = parameters.get("properties")
+    assert isinstance(properties, dict), "Expected a dict."
+
+    data_property = properties.get("data")
+    assert isinstance(data_property, dict), "Expected a dict."
+
+    assert data_property.get("type_") in [
         glm.Type.OBJECT,
         glm.Type.STRING,
     ], "Expected 'data' to be recognized as an OBJECT or fallback to STRING."
@@ -161,14 +202,26 @@ def test_tool_with_enum_anyof_nullable_param() -> None:
     # Convert to GenAI, then to dict
     genai_tool = convert_to_genai_function_declarations([oai_tool])
     genai_tool_dict = tool_to_dict(genai_tool)
+    assert isinstance(genai_tool_dict, dict), "Expected a dict."
 
-    fn_decl = genai_tool_dict["function_declarations"][0]
-    parameters = fn_decl["parameters"]
-    status_property = parameters["properties"]["status"]
+    function_declarations = genai_tool_dict.get("function_declarations")
+    assert isinstance(function_declarations, list), "Expected a list."
+
+    fn_decl = function_declarations[0]
+    assert isinstance(fn_decl, dict), "Expected a dict."
+
+    parameters = fn_decl.get("parameters")
+    assert isinstance(parameters, dict), "Expected a dict."
+
+    properties = parameters.get("properties")
+    assert isinstance(properties, dict), "Expected a dict."
+
+    status_property = properties.get("status")
+    assert isinstance(status_property, dict), "Expected a dict."
 
     # Assertions
     assert (
-        status_property["type_"] == glm.Type.STRING
+        status_property.get("type_") == glm.Type.STRING
     ), "Expected 'status' to be STRING."
     assert (
         status_property.get("nullable") is True


### PR DESCRIPTION
## PR Description

While working with [gregpr07/browser-use](https://github.com/gregpr07/browser-use), @mahlertom and I found several bugs in langchain handling of nested `Pydantic` structured in `with_structured_output`. Specifically, the issues occurred in `_get_properties_from_schema` method in `libs\genai\langchain_google_genai\_function_utils.py`.

1. The current implementation did not recursively handle cases of nested `glm.Type.OBJECT` and only took care of the first layer.
2. In cases where `pydantic` fields are required (no default value is provided), the method did not properly add these fields to the `required` list.
3. In cases where an object of type `glm.Type.OBJECT` had empty properties, there was an error that properties of type `glm.Type.OBJECT` must not be empty.


## Relevant issues

Fixes https://github.com/langchain-ai/langchain-google/issues/657, 
May be related to https://github.com/langchain-ai/langchain/issues/24225

## Type 
🐛 Bug Fix


## Changes
As mentioned above:

1. The previous implementation did not recursively handle cases of nested `glm.Type.OBJECT` and only took care of the first layer. We fixed the recursion with:
```python
if properties_item.get("type_") == glm.Type.OBJECT:
    if v.get('anyOf') and isinstance(v['anyOf'], list) and isinstance(v['anyOf'][0], dict):
        v = v['anyOf'][0]
    v_properties = v.get("properties")
    if v_properties:
        properties_item["properties"] = _get_properties_from_schema_any(v_properties)
```

However, we found that when sending nested `pedantic` objects with required fields as expected output structure, like the case in the following method from [gregpr07/browser-use](https://github.com/gregpr07/browser-use) below:

```python
@time_execution_async('--get_next_action')
	async def get_next_action(self, input_messages: list[BaseMessage]) -> AgentOutput:
		"""Get next action from LLM based on current state"""

		structured_llm = self.llm.with_structured_output(self.AgentOutput, include_raw=True)
		response: dict[str, Any] = await structured_llm.ainvoke(input_messages)  # type: ignore

		parsed: AgentOutput = response['parsed']

		self._log_response(parsed)
		self.n_steps += 1

		return parsed
```

Here, when we observed the `response['parsed']` was often `None` and `response['parsing_error']` included validation errors for missing fields that were required.

2. To fix that error, we realized we needed to add the `required` list when parsing the `pydantic` objects. We added the nested `if` to our fix:

```python
if properties_item.get("type_") == glm.Type.OBJECT:
    if v.get('anyOf') and isinstance(v['anyOf'], list) and isinstance(v['anyOf'][0], dict):
        v = v['anyOf'][0]
    v_properties = v.get("properties")
    if v_properties:
        properties_item["properties"] = _get_properties_from_schema_any(v_properties)
        if isinstance(v_properties, dict):
            properties_item["required"] = [
                k for k, v in v_properties.items() if "default" not in v
            ]
```

But still got this error:
```text
Unexpected error: Invalid argument provided to Gemini: 400 * GenerateContentRequest.tools[0].function_declarations[0].parameters.properties[action].properties[go_back].properties: should be non-empty for OBJECT type
```

This was because in cases where an object of type `glm.Type.OBJECT` had empty properties, as was the case with the 'go_back' action in [gregpr07/browser-use](https://github.com/gregpr07/browser-use), there was an error that properties of type `glm.Type.OBJECT` must not be empty. We changed that by adding dummy type in such cases adding the last `else` statement:

```python
if properties_item.get("type_") == glm.Type.OBJECT:
    if v.get('anyOf') and isinstance(v['anyOf'], list) and isinstance(v['anyOf'][0], dict):
        v = v['anyOf'][0]
    v_properties = v.get("properties")
    if v_properties:
        properties_item["properties"] = _get_properties_from_schema_any(v_properties)
        if isinstance(v_properties, dict):
            properties_item["required"] = [
                k for k, v in v_properties.items() if "default" not in v
            ]
    else:
        # Providing dummy type for object without properties
        properties_item["type_"] = glm.Type.STRING
```
## Testing

Tested on the code described in https://github.com/langchain-ai/langchain-google/issues/657

## Note
- [x] PR title and description are appropriate
- [x] Necessary tests and documentation have been added
- [x] Lint and tests pass successfully
- [x] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
