### PR TITLE
genai: Fix handling of optional arrays in tool input

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -314,6 +314,16 @@ def _get_properties_from_schema(schema: Dict) -> Dict[str, Any]:
 
         if properties_item.get("type_") == glm.Type.ARRAY and v.get("items"):
             properties_item["items"] = _get_items_from_schema_any(v.get("items"))
+        elif properties_item.get("type_") == glm.Type.ARRAY and v.get("anyOf"):
+            types_with_items = [t for t in v.get("anyOf") if t.get("items")]
+            if len(types_with_items) > 1:
+                len_types = len(types_with_items)
+                logger.warning(
+                    "Only first value for 'anyOf' key is supported in array types."
+                    f"Got {len_types} types, using first one: {types_with_items[0]}"
+                )
+            items = types_with_items[0]['items']
+            properties_item["items"] = _get_items_from_schema_any(items)
 
         if properties_item.get("type_") == glm.Type.OBJECT:
             if (

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -6,7 +6,7 @@ import pytest
 from langchain_core.documents import Document
 from langchain_core.tools import InjectedToolArg, tool
 from langchain_core.utils.function_calling import convert_to_openai_tool
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
 from langchain_google_genai._function_utils import (
@@ -525,3 +525,13 @@ def test_tool_to_dict_pydantic_without_import(mock_safe_import: MagicMock) -> No
     gapic_tool = convert_to_genai_function_declarations([MyModel])
     tool_dict = tool_to_dict(gapic_tool)
     assert gapic_tool == convert_to_genai_function_declarations([tool_dict])
+
+
+def test_tool_input_can_have_optional_arrays() -> None:
+    class ExampleToolInput(BaseModel):
+        numbers: Optional[List[str]] = Field()
+
+    gapic_tool = convert_to_genai_function_declarations([ExampleToolInput])
+    properties = gapic_tool.function_declarations[0].parameters.properties
+    assert properties.get('numbers').items.type_ == 1
+


### PR DESCRIPTION
## PR Description

This code fixes handling of optional arrays in pydantic models provided as tool inputs like this:
```   
class ExampleToolInput(BaseModel):
        numbers: Optional[List[str]] = Field()
```

Optional parameters are handled by setting `nullable` field in gemini API. Current code works for every type, except for arrays, because `items` field, that contains information about type of values inside the array, is present in `anyOf` field as one of the possibilities, where it's ignored.

Also added log where user is warned that only only type can be used inside array. Before, last defined type was used.
This is an edge case where user could be trying to use an array with multiple types which is not supported by genai, but can be useful for finding bugs

## Type

🐛 Bug Fix
✅ Test

## Testing(optional)

```
Launching pytest with arguments test_function_utils.py::test_tool_input_can_have_optional_arrays --no-header --no-summary -q in /xxx/langchain-google/libs/genai/tests/unit_tests

============================= test session starts ==============================
collecting ... collected 1 item

test_function_utils.py::test_tool_input_can_have_optional_arrays 

========================= 1 passed, 1 warning in 0.61s =========================
```