### PR TITLE
community: add scope validation for Google Drive API credentials

### DIFF
--- a/libs/community/tests/unit_tests/test_drive.py
+++ b/libs/community/tests/unit_tests/test_drive.py
@@ -1,0 +1,39 @@
+import pytest
+
+from langchain_google_community.drive import GoogleDriveLoader
+
+
+def test_drive_default_scope() -> None:
+    """Test that default scope is set correctly."""
+    loader = GoogleDriveLoader(folder_id="dummy_folder")
+    assert loader.scopes == ["https://www.googleapis.com/auth/drive.file"]
+
+
+def test_drive_custom_scope() -> None:
+    """Test setting custom scope."""
+    custom_scopes = ["https://www.googleapis.com/auth/drive.readonly"]
+    loader = GoogleDriveLoader(folder_id="dummy_folder", scopes=custom_scopes)
+    assert loader.scopes == custom_scopes
+
+
+def test_drive_multiple_scopes() -> None:
+    """Test setting multiple valid scopes."""
+    custom_scopes = [
+        "https://www.googleapis.com/auth/drive.readonly",
+        "https://www.googleapis.com/auth/drive.metadata.readonly",
+    ]
+    loader = GoogleDriveLoader(folder_id="dummy_folder", scopes=custom_scopes)
+    assert loader.scopes == custom_scopes
+
+
+def test_drive_empty_scope_list() -> None:
+    """Test that empty scope list raises error."""
+    with pytest.raises(ValueError, match="At least one scope must be provided"):
+        GoogleDriveLoader(folder_id="dummy_folder", scopes=[])
+
+
+def test_drive_invalid_scope() -> None:
+    """Test that invalid scope raises error."""
+    invalid_scopes = ["https://www.googleapis.com/auth/drive.invalid"]
+    with pytest.raises(ValueError, match="Invalid Google Drive API scope"):
+        GoogleDriveLoader(folder_id="dummy_folder", scopes=invalid_scopes)


### PR DESCRIPTION
## PR Description

This PR makes the Google Drive API scopes configurable in the GoogleDriveLoader class instead of using a hardcoded global constant. This change allows users to specify different scopes based on their needs while maintaining backward compatibility with the default `drive.file` scope.

Currently, the scope is hardcoded to `drive.file` which is restrictive and only allows access to files created by the app. This change enables users to use different scopes like `drive.readonly` for broader read access without modifying the source code.


## Relevant issues

ref: https://github.com/langchain-ai/langchain-google/issues/666

## Type

🐛 Bug Fix

## Changes(optional)

- Added configurable `scopes` parameter to `GoogleDriveLoader` class
- Implemented scope validation with predefined valid scopes
- Maintained backward compatibility by using original scope as default
- Added documentation for available scopes
- Added unittest to verify the scopes

