### PR TITLE
Fix additional_headers fallback in validate_parms_base

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -118,7 +118,7 @@ class _VertexAIBase(BaseModel):
         if values.get("client_cert_source"):
             client_options.client_cert_source = values["client_cert_source"]
         values["client_options"] = client_options
-        additional_headers = values.get("additional_headers", {})
+        additional_headers = values.get("additional_headers") or {}
         values["default_metadata"] = tuple(additional_headers.items())
         return values
 


### PR DESCRIPTION
## PR Title 
Fix additional_headers fallback in validate_parms_base

## PR Description
`additional_headers` can be passed in explicitly as `None` in data dict. being processed by `validate_parms_base` and the `.get` fallback will not return the intended default value of an empty dict.

A specific usecase where this can be observed is when the VertexAI object is being created by LangChains `.configurable_fields`/ `with_config` functionality that allows to specific runtime parameters for steps in the chain.

Example:
```
    llm = VertexAI(model_name="gemini-pro", project="project-ai").configurable_fields(
        temperature=ConfigurableField(
            id="temperature",
            name="LLM Temperature",
            description="The temperature of the LLM",
        )
    )

    qa_chain = create_stuff_documents_chain(
        llm.with_config(configurable={"temperature": 0.9}),
        TEMPLATE,
        document_prompt=DOC_TEMPLATE,
        output_parser=ANSWER_PARSER,
    )
```