### PR TITLE
[genai] Fix tool calling with legacy agent

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -303,7 +303,8 @@ def _convert_to_parts(
 
 def _convert_tool_message_to_part(message: ToolMessage | FunctionMessage) -> Part:
     """Converts a tool or function message to a google part."""
-    name = message.name
+    # Legacy agent stores tool name in message.additional_kwargs instead of message.name
+    name = message.name or message.additional_kwargs.get("name")
     response: Any
     if not isinstance(message.content, str):
         response = message.content

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -28,6 +28,7 @@ from pytest import CaptureFixture
 
 from langchain_google_genai.chat_models import (
     ChatGoogleGenerativeAI,
+    _convert_tool_message_to_part,
     _parse_chat_history,
     _parse_response_candidate,
 )
@@ -622,3 +623,23 @@ def test_serialize() -> None:
     llm.client = None
     llm_loaded.client = None
     assert llm == llm_loaded
+
+
+@pytest.mark.parametrize(
+    "tool_message",
+    [
+        ToolMessage(name="tool_name", content="test_content", tool_call_id="1"),
+        # Legacy agent does not set `name`
+        ToolMessage(
+            additional_kwargs={"name": "tool_name"},
+            content="test_content",
+            tool_call_id="1",
+        ),
+    ],
+)
+def test__convert_tool_message_to_part__sets_tool_name(
+    tool_message: ToolMessage,
+) -> None:
+    part = _convert_tool_message_to_part(tool_message)
+    assert part.function_response.name == "tool_name"
+    assert part.function_response.response == {"output": "test_content"}


### PR DESCRIPTION
## PR Description

Tool calling with Gemini requires the tool name to be returned in the tool response, but `ToolMessage.name` is not being set when [created by a legacy agent](https://github.com/langchain-ai/langchain/blob/dbb6b7b103d9c32cea46d3848839a4c9cbb493c3/libs/langchain/langchain/agents/format_scratchpad/tools.py#L35).

Instead, `ToolMessage.additional_kwargs` is set to: `{"name": "my_tool"}`, but this isn't used when building the message Parts to send to Gemini. 

It appears this issue was caused by this change: https://github.com/langchain-ai/langchain-google/pull/671


## Relevant issues

https://github.com/langchain-ai/langchain-google/issues/711

## Type

🐛 Bug Fix

## Changes(optional)

Use `ToolMessage.additional_kwargs["name"]` when `ToolMessage.name` is not present, for the tool name in the `FunctionResponse`.
