### PR TITLE
genai: fix function_utils to parse object/array json schemas properly

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -301,9 +301,17 @@ def _get_properties_from_schema(schema: Dict) -> Dict[str, Any]:
             continue
         properties_item: Dict[str, Union[str, int, Dict, List]] = {}
         if v.get("type") or v.get("anyOf") or v.get("type_"):
-            properties_item["type_"] = _get_type_from_schema(v)
+            item_type_ = _get_type_from_schema(v)
+            properties_item["type_"] = item_type_
             if _is_nullable_schema(v):
                 properties_item["nullable"] = True
+
+            # Replace `v` with chosen definition for array / object json types
+            any_of_types = v.get("anyOf")
+            if any_of_types and item_type_ in [glm.Type.ARRAY, glm.Type.OBJECT]:
+                json_type_ = "array" if item_type_ == glm.Type.ARRAY else "object"
+                # Use Index -1 for consistency with `_get_nullable_type_from_schema`
+                v = [val for val in any_of_types if val.get("type") == json_type_][-1]
 
         if v.get("enum"):
             properties_item["enum"] = v["enum"]

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -84,11 +84,6 @@ def test_tool_with_array_anyof_nullable_param() -> None:
     # Convert to OpenAI tool
     oai_tool = convert_to_openai_tool(possibly_none_list)
 
-    # Manually assign the 'items' type in the parameters
-    oai_tool["function"]["parameters"]["properties"]["items"]["items"] = {
-        "type": "string"
-    }
-
     # Convert to GenAI, then to dict
     genai_tool = convert_to_genai_function_declarations([oai_tool])
     genai_tool_dict = tool_to_dict(genai_tool)


### PR DESCRIPTION
The existing code tries to handle arrays and objects in anyOf fields of JSON Schema's for tools by picking the last possible non nullable choice in anyOf. But the context of the field is not updated to reflect the selected choice leading to a borked conversion to protobuf that fails with 400 errors.

This fix is just to update the context for arrays and objects.

Please correct me if it is intentional, but there is already a testcase which is supposed to cover this, but it is buggy as it sets an `items` field within an `items` definition for an array, which should not be possible according to the JSON Schema spec. The faulty setting made this bug slip through the tests


