### PR TITLE
vertexai: Preserve `sparse_embeddings` in `data_points_to_batch_update_records`

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/vectorstores/_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/_utils.py
@@ -170,6 +170,15 @@ def data_points_to_batch_update_records(
             ],
         }
 
+        if (
+            hasattr(data_point, "sparse_embedding")
+            and data_point.sparse_embedding is not None
+        ):
+            record["sparse_embedding"] = {
+                "values": [value for value in data_point.sparse_embedding.values],
+                "dimensions": [dim for dim in data_point.sparse_embedding.dimensions],
+            }
+
         records.append(record)
 
     return records


### PR DESCRIPTION
## PR Description

Fix missing `sparse_embeddings` in `vector_store.add_texts_with_embeddings()` for Vertex AI index

This PR ensures that `sparse_embeddings` are correctly stored in the Vertex AI index when using `vector_store.add_texts_with_embeddings()`. Previously, `sparse_embeddings` were not included in the index due to their absence in the `data_points_to_batch_update_records` function. This prevented hybrid search from functioning as expected.

## Relevant Issues
Fixes issue #720 - sparse_embeddings are not stored in Vertex AI index when using add_texts_with_embeddings 

## Type
🐛 Bug Fix

## Changes(optional)
As described in issue #720.

- Modified `data_points_to_batch_update_records` (in `libs/vertexai/langchain_google_vertexai/vectorstores/_utils.py`) to include `sparse_embeddings` in the update records.
- Added a conditional check to ensure `sparse_embeddings` are properly formatted and stored.

## Testing(optional)


## Note(optional)


