### PR TITLE
vertexai: add retry tracing with metadata in ChatAnthropicVertex

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/utils.py
+++ b/libs/vertexai/langchain_google_vertexai/utils.py
@@ -1,7 +1,22 @@
+import asyncio
+import logging
 from datetime import datetime, timedelta
-from typing import List, Optional
+from typing import Any, Callable, List, Optional, Union
 
+from langchain_core.callbacks.manager import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
 from langchain_core.messages import BaseMessage
+from tenacity import (
+    RetryCallState,
+    before_sleep_log,
+    retry,
+    retry_base,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 from vertexai.preview import caching  # type: ignore
 
 from langchain_google_vertexai.chat_models import (
@@ -73,3 +88,70 @@ def create_context_cache(
     )
 
     return cached_content.name
+
+
+def create_base_retry_decorator(
+    error_types: list[type[BaseException]],
+    max_retries: int = 1,
+    run_manager: Optional[
+        Union[AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun]
+    ] = None,
+) -> Callable[[Any], Any]:
+    """Create a retry decorator for a given LLM and provided a list of error types.
+
+    Args:
+        error_types: List of error types to retry on.
+        max_retries: Number of retries. Default is 1.
+        run_manager: Callback manager for the run. Default is None.
+
+    Returns:
+        A retry decorator.
+    """
+    logger = logging.getLogger(__name__)
+    _logging = before_sleep_log(logger, logging.WARNING)
+
+    def _before_sleep(retry_state: RetryCallState) -> None:
+        _logging(retry_state)
+        if run_manager:
+            retry_d: dict[str, Any] = {
+                "slept": retry_state.idle_for,
+                "attempt": retry_state.attempt_number,
+            }
+            if retry_state.outcome is None:
+                retry_d["outcome"] = "N/A"
+            elif retry_state.outcome.failed:
+                retry_d["outcome"] = "failed"
+                exception = retry_state.outcome.exception()
+                retry_d["exception"] = str(exception)
+                retry_d["exception_type"] = exception.__class__.__name__
+            else:
+                retry_d["outcome"] = "success"
+                retry_d["result"] = str(retry_state.outcome.result())
+            if isinstance(run_manager, AsyncCallbackManagerForLLMRun):
+                coro = run_manager.on_retry(retry_state)
+                try:
+                    loop = asyncio.get_event_loop()
+                    if loop.is_running():
+                        loop.create_task(coro)
+                    else:
+                        asyncio.run(coro)
+                except Exception as e:
+                    logger.error(f"Error in on_retry: {e}")
+            else:
+                run_manager.metadata.update({"retry_state": retry_d})
+                run_manager.on_retry(retry_state)
+
+    min_seconds = 4
+    max_seconds = 10
+    # Wait 2^x * 1 second between each retry starting with
+    # 4 seconds, then up to 10 seconds, then 10 seconds afterwards
+    retry_instance: retry_base = retry_if_exception_type(error_types[0])
+    for error in error_types[1:]:
+        retry_instance = retry_instance | retry_if_exception_type(error)
+    return retry(
+        reraise=True,
+        stop=stop_after_attempt(max_retries),
+        wait=wait_exponential(multiplier=1, min=min_seconds, max=max_seconds),
+        retry=retry_instance,
+        before_sleep=_before_sleep,
+    )

--- a/libs/vertexai/tests/unit_tests/test_model_garden_retry.py
+++ b/libs/vertexai/tests/unit_tests/test_model_garden_retry.py
@@ -1,0 +1,80 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from anthropic import APIError
+
+from langchain_google_vertexai.model_garden import (
+    _create_retry_decorator,
+)
+
+
+def create_api_error():
+    """Helper function to create an APIError with required arguments."""
+    mock_request = MagicMock()
+    mock_request.method = "POST"
+    mock_request.url = "test-url"
+    mock_request.headers = {}
+    mock_request.body = None
+    return APIError(
+        message="Test error",
+        request=mock_request,
+        body={"error": {"message": "Test error"}},
+    )
+
+
+def test_retry_on_errors():
+    """Test that the retry decorator works with sync functions."""
+    mock_llm = MagicMock()
+    mock_llm.max_retries = 2
+    mock_function = MagicMock(side_effect=[create_api_error(), "success"])
+
+    decorator = _create_retry_decorator(mock_llm)
+    wrapped_func = decorator(mock_function)
+
+    result = wrapped_func()
+    assert result == "success"
+    assert mock_function.call_count == 2
+
+
+def test_max_retries_exceeded():
+    """Test that the retry decorator fails after max retries."""
+    mock_llm = MagicMock()
+    mock_llm.max_retries = 2
+    mock_function = MagicMock(side_effect=[create_api_error(), create_api_error()])
+
+    decorator = _create_retry_decorator(mock_llm)
+    wrapped_func = decorator(mock_function)
+
+    with pytest.raises(APIError):
+        wrapped_func()
+    assert mock_function.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_retry_on_errors():
+    """Test that the retry decorator works with async functions."""
+    mock_llm = MagicMock()
+    mock_llm.max_retries = 2
+    mock_function = AsyncMock(side_effect=[create_api_error(), "success"])
+
+    decorator = _create_retry_decorator(mock_llm)
+    wrapped_func = decorator(mock_function)
+
+    result = await wrapped_func()
+    assert result == "success"
+    assert mock_function.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_max_retries_exceeded():
+    """Test that the async retry decorator fails after max retries."""
+    mock_llm = MagicMock()
+    mock_llm.max_retries = 2
+    mock_function = AsyncMock(side_effect=[create_api_error(), create_api_error()])
+
+    decorator = _create_retry_decorator(mock_llm)
+    wrapped_func = decorator(mock_function)
+
+    with pytest.raises(APIError):
+        await wrapped_func()
+    assert mock_function.call_count == 2

--- a/libs/vertexai/tests/unit_tests/test_model_garden_retry.py
+++ b/libs/vertexai/tests/unit_tests/test_model_garden_retry.py
@@ -55,11 +55,12 @@ async def test_async_retry_on_errors():
     """Test that the retry decorator works with async functions."""
     mock_llm = MagicMock()
     mock_llm.max_retries = 2
-    mock_function = AsyncMock(side_effect=[create_api_error(), "success"])
-
+    mock_function = AsyncMock()
+    mock_function.side_effect = [create_api_error(), "success"]
+    
     decorator = _create_retry_decorator(mock_llm)
     wrapped_func = decorator(mock_function)
-
+    
     result = await wrapped_func()
     assert result == "success"
     assert mock_function.call_count == 2
@@ -70,11 +71,12 @@ async def test_async_max_retries_exceeded():
     """Test that the async retry decorator fails after max retries."""
     mock_llm = MagicMock()
     mock_llm.max_retries = 2
-    mock_function = AsyncMock(side_effect=[create_api_error(), create_api_error()])
-
+    mock_function = AsyncMock()
+    mock_function.side_effect = [create_api_error(), create_api_error()]
+    
     decorator = _create_retry_decorator(mock_llm)
     wrapped_func = decorator(mock_function)
-
+    
     with pytest.raises(APIError):
         await wrapped_func()
     assert mock_function.call_count == 2


### PR DESCRIPTION
## PR Description

This PR addresses the lack of metadata displayed on LangSmith during retries in ChatAnthropicVertex. Users have reported that while error codes appear on GCP, no corresponding metadata is visible in LangSmith when retries occur. This update aims to improve observability and control over retry behavior.

## Relevant issues

https://github.com/langchain-ai/langchain-google/issues/727

## Type

🆕 New Feature
✅ Test

## Changes

- Custom Retry Decorator:
Implemented a custom retry decorator using tenacity, disabling the default retry behavior in the Anthropic class for better control.
- Enhanced Logging:
Added integration with the `run_manager` (which defaults to LangchainTracer in LangSmith) to log retry events via the on_retry callback.
- Metadata Integration:
Implemented `_get_ls_params` to include additional metadata about the class in the logs sent to LangSmith.

<img width="1231" alt="image" src="https://github.com/user-attachments/assets/c2e13d25-ef72-496c-872f-9df15938a422" />


These changes enhance debugging and monitoring by providing detailed logs and metadata for retry events, facilitating easier tracing and diagnosis of issues related to retries.

Thank you Team!