### PR TITLE
docs: add temp_dataset_name to community.BigQueryVectorStore docs

### DIFF
--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -36,6 +36,9 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
     `batch_search` method.
     Optionally, this class can leverage a Vertex AI Feature Store for online serving
     through the `to_vertex_fs_vector_store` method.
+    Note that the `bigquery.datasets.create permission` is required even if the
+    dataset already exists. This can be avoided by specifying `temp_dataset_name` as
+    the name of an existing dataset.
 
     Attributes:
         embedding: Embedding model for generating and comparing embeddings.
@@ -46,6 +49,8 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         content_field: Name of the column storing document content (default: "content").
         embedding_field: Name of the column storing text embeddings (default:
             "embedding").
+        temp_dataset_name: Name of the BigQuery dataset to be used to upload temporary
+            BQ tables. If None, will default to "{dataset_name}_temp". 
         doc_id_field: Name of the column storing document IDs (default: "doc_id").
         credentials: Optional Google Cloud credentials object.
         embedding_dimension: Dimension of the embedding vectors (inferred if not

--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -50,7 +50,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         embedding_field: Name of the column storing text embeddings (default:
             "embedding").
         temp_dataset_name: Name of the BigQuery dataset to be used to upload temporary
-            BQ tables. If None, will default to "{dataset_name}_temp". 
+            BQ tables. If None, will default to "{dataset_name}_temp".
         doc_id_field: Name of the column storing document IDs (default: "doc_id").
         credentials: Optional Google Cloud credentials object.
         embedding_dimension: Dimension of the embedding vectors (inferred if not


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

Added `temp_dataset_name` to the docstring for `BigQueryVectorStore`, and an explanation about how to use it to avoid needing permission to create datasets in GCP.

This attribute is defined in `BaseBigQueryVectorStore`, albeit without the additional explanation.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
None.
<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation

## Changes(optional)

<!-- List of changes -->

## Testing(optional)

<!-- Test procedure -->
<!-- Test result -->

## Note(optional)

In my environment I'm not allowed to create datasets, so was confused why `BigQueryVectorStore` asked for the `bigquery.datasets.create` permission even though the dataset already existed. Digging into the source code I found the `temp_dataset_name` attribute, and specifying it as the name of a dataset that already existed stopped this class from asking for this permission.

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
