### PR TITLE
docs: update docs for the filter arg in community.BigQueryVectorStore

### DIFF
--- a/libs/community/langchain_google_community/bq_storage_vectorstores/_base.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/_base.py
@@ -364,7 +364,7 @@ class BaseBigQueryVectorStore(VectorStore, BaseModel, ABC):
         **kwargs: Any,
     ) -> Any:
         """Core similarity search function. Handles a list of embedding vectors,
-            optionally returning scores and embeddings.
+        optionally returning scores and embeddings.
 
         Args:
             embeddings: A list of embedding vectors, where each vector is a list of
@@ -468,7 +468,7 @@ class BaseBigQueryVectorStore(VectorStore, BaseModel, ABC):
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Search for top `k` docs most similar to input query, returns both docs and
-            scores.
+        scores.
 
         Args:
             query: search query to search documents with.

--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -452,13 +452,14 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         expire_hours_temp_table: int = 12,
     ) -> List[List[List[Any]]]:
         """Multi-purpose batch search function. Accepts either embeddings or queries
-            but not both. Optionally returns similarity scores and/or matched embeddings
+        but not both. Optionally returns similarity scores and/or matched embeddings
+
         Args:
-        embeddings: A list of embeddings to search with. If provided, each
-            embedding represents a query vector.
-        queries: A list of text queries to search with.  If provided, each
-            query represents a query text.
-        filter: (Optional) A dictionary or a string specifying filter criteria.
+            embeddings: A list of embeddings to search with. If provided, each
+                embedding represents a query vector.
+            queries: A list of text queries to search with.  If provided, each
+                query represents a query text.
+            filter: (Optional) A dictionary or a string specifying filter criteria.
                 - If a dictionary is provided, it should map column names to their
                 corresponding values. The method will generate SQL expressions based
                 on the data types defined in `self.table_schema`. The value is enclosed
@@ -466,10 +467,10 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 which case the value is used directly. E.g., `{"str_property": "foo",
                 "int_property": 123}`.
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
-        k: The number of top results to return per query. Defaults to 5.
-        with_scores: If True, returns the relevance scores of the results along with
-            the documents
-        with_embeddings: If True, returns the embeddings of the results along with
+            k: The number of top results to return per query. Defaults to 5.
+            with_scores: If True, returns the relevance scores of the results along with
+                the documents
+            with_embeddings: If True, returns the embeddings of the results along with
             the documents
         """
         from google.cloud import bigquery  # type: ignore[attr-defined]
@@ -530,7 +531,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         **kwargs: Any,
     ) -> Any:
         """Core similarity search function. Handles a list of embedding vectors,
-            optionally returning scores and embeddings.
+        optionally returning scores and embeddings.
 
         Args:
             embeddings: A list of embedding vectors, where each vector is a list of
@@ -643,7 +644,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Search for top `k` docs most similar to input query, returns both docs and
-            scores.
+        scores.
 
         Args:
             query: search query to search documents with.
@@ -688,12 +689,11 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         return vs_obj
 
     def to_vertex_fs_vector_store(self, **kwargs: Any) -> Any:
-        """
-        Creates and returns a VertexFSVectorStore instance based on configuration.
+        """Creates and returns a VertexFSVectorStore instance based on configuration.
 
         This method merges the base BigQuery vector store configuration with provided
-            keyword arguments,
-        then uses the combined parameters to instantiate a VertexFSVectorStore.
+        keyword arguments, then uses the combined parameters to instantiate a 
+        VertexFSVectorStore.
 
         Args:
             **kwargs: Additional keyword arguments to override or extend the base

--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -80,15 +80,10 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             filter: (Optional) A dictionary or a string specifying filter criteria.
                 - If a dictionary is provided, it should map column names to their
                 corresponding values. The method will generate SQL expressions based
-                on the data types defined in `self.table_schema`:
-                    - For columns of type "INTEGER" or "FLOAT", the value is used
-                    directly.
-                    - For other data types, the value is enclosed in single quotes.
-                Example:
-                    {
-                        "str_property": "foo",
-                        "int_property": 123
-                    }
+                on the data types defined in `self.table_schema`. The value is enclosed
+                in single quotes unless the column is of type "INTEGER" or "FLOAT", in
+                which case the value is used directly. E.g., `{"str_property": "foo",
+                "int_property": 123}`.
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
         Returns:
             List of ids from adding the texts into the vectorstore.
@@ -210,15 +205,10 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             filter: (Optional) A dictionary or a string specifying filter criteria.
                 - If a dictionary is provided, it should map column names to their
                 corresponding values. The method will generate SQL expressions based
-                on the data types defined in `self.table_schema`:
-                    - For columns of type "INTEGER" or "FLOAT", the value is used
-                    directly.
-                    - For other data types, the value is enclosed in single quotes.
-                Example:
-                    {
-                        "str_property": "foo",
-                        "int_property": 123
-                    }
+                on the data types defined in `self.table_schema`. The value is enclosed
+                in single quotes unless the column is of type "INTEGER" or "FLOAT", in
+                which case the value is used directly. E.g., `{"str_property": "foo",
+                "int_property": 123}`.
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: The number of top results to return for each query.
             batch_size: The size of batches to process embeddings.
@@ -263,15 +253,10 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             filter: (Optional) A dictionary or a string specifying filter criteria.
                 - If a dictionary is provided, it should map column names to their
                 corresponding values. The method will generate SQL expressions based
-                on the data types defined in `self.table_schema`:
-                    - For columns of type "INTEGER" or "FLOAT", the value is used
-                    directly.
-                    - For other data types, the value is enclosed in single quotes.
-                Example:
-                    {
-                        "str_property": "foo",
-                        "int_property": 123
-                    }
+                on the data types defined in `self.table_schema`. The value is enclosed
+                in single quotes unless the column is of type "INTEGER" or "FLOAT", in
+                which case the value is used directly. E.g., `{"str_property": "foo",
+                "int_property": 123}`.
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
 
         Returns:
@@ -474,18 +459,13 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         queries: A list of text queries to search with.  If provided, each
             query represents a query text.
         filter: (Optional) A dictionary or a string specifying filter criteria.
-            - If a dictionary is provided, it should map column names to their
-            corresponding values. The method will generate SQL expressions based
-            on the data types defined in `self.table_schema`:
-                - For columns of type "INTEGER" or "FLOAT", the value is used
-                directly.
-                - For other data types, the value is enclosed in single quotes.
-            Example:
-                {
-                    "str_property": "foo",
-                    "int_property": 123
-                }
-            - If a string is provided, it is assumed to be a valid SQL WHERE clause.
+                - If a dictionary is provided, it should map column names to their
+                corresponding values. The method will generate SQL expressions based
+                on the data types defined in `self.table_schema`. The value is enclosed
+                in single quotes unless the column is of type "INTEGER" or "FLOAT", in
+                which case the value is used directly. E.g., `{"str_property": "foo",
+                "int_property": 123}`.
+                - If a string is provided, it is assumed to be a valid SQL WHERE clause.
         k: The number of top results to return per query. Defaults to 5.
         with_scores: If True, returns the relevance scores of the results along with
             the documents
@@ -558,15 +538,10 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             filter: (Optional) A dictionary or a string specifying filter criteria.
                 - If a dictionary is provided, it should map column names to their
                 corresponding values. The method will generate SQL expressions based
-                on the data types defined in `self.table_schema`:
-                    - For columns of type "INTEGER" or "FLOAT", the value is used
-                    directly.
-                    - For other data types, the value is enclosed in single quotes.
-                Example:
-                    {
-                        "str_property": "foo",
-                        "int_property": 123
-                    }
+                on the data types defined in `self.table_schema`. The value is enclosed
+                in single quotes unless the column is of type "INTEGER" or "FLOAT", in
+                which case the value is used directly. E.g., `{"str_property": "foo",
+                "int_property": 123}`.
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
@@ -599,15 +574,10 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             filter: (Optional) A dictionary or a string specifying filter criteria.
                 - If a dictionary is provided, it should map column names to their
                 corresponding values. The method will generate SQL expressions based
-                on the data types defined in `self.table_schema`:
-                    - For columns of type "INTEGER" or "FLOAT", the value is used
-                    directly.
-                    - For other data types, the value is enclosed in single quotes.
-                Example:
-                    {
-                        "str_property": "foo",
-                        "int_property": 123
-                    }
+                on the data types defined in `self.table_schema`. The value is enclosed
+                in single quotes unless the column is of type "INTEGER" or "FLOAT", in
+                which case the value is used directly. E.g., `{"str_property": "foo",
+                "int_property": 123}`.
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
@@ -629,15 +599,10 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             filter: (Optional) A dictionary or a string specifying filter criteria.
                 - If a dictionary is provided, it should map column names to their
                 corresponding values. The method will generate SQL expressions based
-                on the data types defined in `self.table_schema`:
-                    - For columns of type "INTEGER" or "FLOAT", the value is used
-                    directly.
-                    - For other data types, the value is enclosed in single quotes.
-                Example:
-                    {
-                        "str_property": "foo",
-                        "int_property": 123
-                    }
+                on the data types defined in `self.table_schema`. The value is enclosed
+                in single quotes unless the column is of type "INTEGER" or "FLOAT", in
+                which case the value is used directly. E.g., `{"str_property": "foo",
+                "int_property": 123}`.
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
@@ -658,15 +623,10 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             filter: (Optional) A dictionary or a string specifying filter criteria.
                 - If a dictionary is provided, it should map column names to their
                 corresponding values. The method will generate SQL expressions based
-                on the data types defined in `self.table_schema`:
-                    - For columns of type "INTEGER" or "FLOAT", the value is used
-                    directly.
-                    - For other data types, the value is enclosed in single quotes.
-                Example:
-                    {
-                        "str_property": "foo",
-                        "int_property": 123
-                    }
+                on the data types defined in `self.table_schema`. The value is enclosed
+                in single quotes unless the column is of type "INTEGER" or "FLOAT", in
+                which case the value is used directly. E.g., `{"str_property": "foo",
+                "int_property": 123}`.
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
@@ -690,15 +650,10 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             filter: (Optional) A dictionary or a string specifying filter criteria.
                 - If a dictionary is provided, it should map column names to their
                 corresponding values. The method will generate SQL expressions based
-                on the data types defined in `self.table_schema`:
-                    - For columns of type "INTEGER" or "FLOAT", the value is used
-                    directly.
-                    - For other data types, the value is enclosed in single quotes.
-                Example:
-                    {
-                        "str_property": "foo",
-                        "int_property": 123
-                    }
+                on the data types defined in `self.table_schema`. The value is enclosed
+                in single quotes unless the column is of type "INTEGER" or "FLOAT", in
+                which case the value is used directly. E.g., `{"str_property": "foo",
+                "int_property": 123}`.
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.

--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -201,18 +201,16 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 query embedding.
             filter: (Optional) A dictionary or a string specifying filter criteria.
                 - If a dictionary is provided, it should map column names to their
-                corresponding
-                values. The method will generate SQL expressions based on the data
-                types defined
-                in `self.table_schema`:
+                corresponding values. The method will generate SQL expressions based
+                on the data types defined in `self.table_schema`:
                     - For columns of type "INTEGER" or "FLOAT", the value is used
                     directly.
                     - For other data types, the value is enclosed in single quotes.
                 Example:
-                        {
-                            "str_property": "foo",
-                            "int_property": 123
-                        }
+                    {
+                        "str_property": "foo",
+                        "int_property": 123
+                    }
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: The number of top results to return for each query.
             batch_size: The size of batches to process embeddings.
@@ -255,12 +253,11 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
 
         Args:
             filter: (Optional) A dictionary or a string specifying filter criteria.
-                - If a dictionary is provided, it should map column names to
-                their corresponding
-                values. The method will generate SQL expressions based on the
-                data types defined in `self.table_schema`:
-                    - For columns of type "INTEGER" or "FLOAT", the value is
-                    used directly.
+                - If a dictionary is provided, it should map column names to their
+                corresponding values. The method will generate SQL expressions based
+                on the data types defined in `self.table_schema`:
+                    - For columns of type "INTEGER" or "FLOAT", the value is used
+                    directly.
                     - For other data types, the value is enclosed in single quotes.
                 Example:
                     {

--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
 from threading import Lock, Thread
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Type, Union
 
 from google.api_core.exceptions import ClientError
 from langchain_core.documents import Document
@@ -538,6 +538,175 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             k=k,
             num_queries=len(embeddings),
             with_embeddings=False,
+        )
+
+    def similarity_search_by_vectors(
+        self,
+        embeddings: List[List[float]],
+        filter: Optional[Union[Dict[str, Any], str]] = None,
+        k: int = 5,
+        with_scores: bool = False,
+        with_embeddings: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Core similarity search function. Handles a list of embedding vectors,
+            optionally returning scores and embeddings.
+
+        Args:
+            embeddings: A list of embedding vectors, where each vector is a list of
+                floats.
+            filter: (Optional) A dictionary or a string specifying filter criteria.
+                - If a dictionary is provided, it should map column names to their
+                corresponding values. The method will generate SQL expressions based
+                on the data types defined in `self.table_schema`:
+                    - For columns of type "INTEGER" or "FLOAT", the value is used
+                    directly.
+                    - For other data types, the value is enclosed in single quotes.
+                Example:
+                    {
+                        "str_property": "foo",
+                        "int_property": 123
+                    }
+                - If a string is provided, it is assumed to be a valid SQL WHERE clause.
+            k: (Optional) The number of top-ranking similar documents to return per
+                embedding. Defaults to 5.
+            with_scores: (Optional) If True, include similarity scores in the result
+                for each matched document. Defaults to False.
+            with_embeddings: (Optional) If True, include the matched document's
+                embedding vector in the result. Defaults to False.
+        Returns:
+            A list of `k` documents for each embedding in `embeddings`
+        """
+        return super().similarity_search_by_vectors(
+            embeddings=embeddings,
+            filter=filter,
+            k=k,
+            with_scores=with_scores,
+            with_embeddings=with_embeddings,
+            **kwargs,
+        )
+
+    def similarity_search_by_vector(
+        self,
+        embedding: List[float],
+        k: int = 5,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Return docs most similar to embedding vector.
+
+        Args:
+            embedding: Embedding to look up documents similar to.
+            filter: (Optional) A dictionary or a string specifying filter criteria.
+                - If a dictionary is provided, it should map column names to their
+                corresponding values. The method will generate SQL expressions based
+                on the data types defined in `self.table_schema`:
+                    - For columns of type "INTEGER" or "FLOAT", the value is used
+                    directly.
+                    - For other data types, the value is enclosed in single quotes.
+                Example:
+                    {
+                        "str_property": "foo",
+                        "int_property": 123
+                    }
+                - If a string is provided, it is assumed to be a valid SQL WHERE clause.
+            k: (Optional) The number of top-ranking similar documents to return per
+                embedding. Defaults to 5.
+        Returns:
+            Return docs most similar to embedding vector.
+        """
+        return super().similarity_search_by_vector(embedding=embedding, k=k, **kwargs)
+
+    def similarity_search_by_vector_with_score(
+        self,
+        embedding: List[float],
+        filter: Optional[Union[Dict[str, Any], str]] = None,
+        k: int = 5,
+    ) -> List[Tuple[Document, float]]:
+        """Return docs most similar to embedding vector with scores.
+
+        Args:
+            embedding: Embedding to look up documents similar to.
+            filter: (Optional) A dictionary or a string specifying filter criteria.
+                - If a dictionary is provided, it should map column names to their
+                corresponding values. The method will generate SQL expressions based
+                on the data types defined in `self.table_schema`:
+                    - For columns of type "INTEGER" or "FLOAT", the value is used
+                    directly.
+                    - For other data types, the value is enclosed in single quotes.
+                Example:
+                    {
+                        "str_property": "foo",
+                        "int_property": 123
+                    }
+                - If a string is provided, it is assumed to be a valid SQL WHERE clause.
+            k: (Optional) The number of top-ranking similar documents to return per
+                embedding. Defaults to 5.
+        Returns:
+            Return docs most similar to embedding vector.
+        """
+        return super().similarity_search_by_vector_with_score(
+            embedding=embedding, filter=filter, k=k
+        )
+
+    def similarity_search(
+        self, query: str, k: int = 5, **kwargs: Any
+    ) -> List[Document]:
+        """Search for top `k` docs most similar to input query.
+
+        Args:
+            query: search query to search documents with.
+            filter: (Optional) A dictionary or a string specifying filter criteria.
+                - If a dictionary is provided, it should map column names to their
+                corresponding values. The method will generate SQL expressions based
+                on the data types defined in `self.table_schema`:
+                    - For columns of type "INTEGER" or "FLOAT", the value is used
+                    directly.
+                    - For other data types, the value is enclosed in single quotes.
+                Example:
+                    {
+                        "str_property": "foo",
+                        "int_property": 123
+                    }
+                - If a string is provided, it is assumed to be a valid SQL WHERE clause.
+            k: (Optional) The number of top-ranking similar documents to return per
+                embedding. Defaults to 5.
+        Returns:
+            Return docs most similar to input query.
+        """
+        return super().similarity_search(query=query, k=k, **kwargs)
+
+    def similarity_search_with_score(
+        self,
+        query: str,
+        filter: Optional[Union[Dict[str, Any], str]] = None,
+        k: int = 5,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        """Search for top `k` docs most similar to input query, returns both docs and
+            scores.
+
+        Args:
+            query: search query to search documents with.
+            filter: (Optional) A dictionary or a string specifying filter criteria.
+                - If a dictionary is provided, it should map column names to their
+                corresponding values. The method will generate SQL expressions based
+                on the data types defined in `self.table_schema`:
+                    - For columns of type "INTEGER" or "FLOAT", the value is used
+                    directly.
+                    - For other data types, the value is enclosed in single quotes.
+                Example:
+                    {
+                        "str_property": "foo",
+                        "int_property": 123
+                    }
+                - If a string is provided, it is assumed to be a valid SQL WHERE clause.
+            k: (Optional) The number of top-ranking similar documents to return per
+                embedding. Defaults to 5.
+        Returns:
+            Return docs most similar to input query along with scores.
+        """
+        return super().similarity_search_with_score(
+            query=query, filter=filter, k=k, **kwargs
         )
 
     @classmethod

--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -77,11 +77,19 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
 
         Args:
             ids: List of ids of documents to retrieve from the vectorstore.
-            filter: Filter on metadata properties, e.g.
-                            {
-                                "str_property": "foo",
-                                "int_property": 123
-                            }
+            filter: (Optional) A dictionary or a string specifying filter criteria.
+                - If a dictionary is provided, it should map column names to their
+                corresponding values. The method will generate SQL expressions based
+                on the data types defined in `self.table_schema`:
+                    - For columns of type "INTEGER" or "FLOAT", the value is used
+                    directly.
+                    - For other data types, the value is enclosed in single quotes.
+                Example:
+                    {
+                        "str_property": "foo",
+                        "int_property": 123
+                    }
+                - If a string is provided, it is assumed to be a valid SQL WHERE clause.
         Returns:
             List of ids from adding the texts into the vectorstore.
         """
@@ -465,9 +473,19 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             embedding represents a query vector.
         queries: A list of text queries to search with.  If provided, each
             query represents a query text.
-        filter: A dictionary of filters to apply to the search. The keys
-            of the dictionary should be field names, and the values should be the
-                values to filter on. (e.g., {"category": "news"})
+        filter: (Optional) A dictionary or a string specifying filter criteria.
+            - If a dictionary is provided, it should map column names to their
+            corresponding values. The method will generate SQL expressions based
+            on the data types defined in `self.table_schema`:
+                - For columns of type "INTEGER" or "FLOAT", the value is used
+                directly.
+                - For other data types, the value is enclosed in single quotes.
+            Example:
+                {
+                    "str_property": "foo",
+                    "int_property": 123
+                }
+            - If a string is provided, it is assumed to be a valid SQL WHERE clause.
         k: The number of top results to return per query. Defaults to 5.
         with_scores: If True, returns the relevance scores of the results along with
             the documents


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description
In `BigQueryVectorStore`:
- Update docs for the `filter` arg to reflect the fact that it can be a dictionary or a string, and so that the IDE correctly displays them.
- Override the five similarity search methods to update their docs and type hints for the `filter` arg to reflect that fact that it can be a dictionary or a string. These overriding methods all just call the superclass methods.

In `BigQueryVectorStore` and `BaseBigQueryVectorStore` fix the indentation of the docs, so that the IDE correctly displays them.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

None

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring
📖 Documentation

## Changes(optional)

<!-- List of changes -->

## Testing(optional)

<!-- Test procedure -->
<!-- Test result -->

## Note(optional)

There should be no functional changes, only to the documentation and the type hints to reflect functionality that already exists.
<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
