### PR TITLE
genai: Fix required field is ignored when dealing with nested pydantic models

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -184,7 +184,9 @@ def _format_to_gapic_function_declaration(
         ):
             function = cast(dict, tool)
         else:
-            if "parameters" in tool and tool["parameters"].get("properties"):  # type: ignore[index]
+            if (
+                "parameters" in tool and tool["parameters"].get("properties")  # type: ignore[index]
+            ):
                 function = convert_to_openai_tool(cast(dict, tool))["function"]
             else:
                 function = cast(dict, tool)

--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -184,9 +184,7 @@ def _format_to_gapic_function_declaration(
         ):
             function = cast(dict, tool)
         else:
-            if (
-                "parameters" in tool and tool["parameters"].get("properties")  # type: ignore[index]
-            ):
+            if "parameters" in tool and tool["parameters"].get("properties"):  # type: ignore[index]
                 function = convert_to_openai_tool(cast(dict, tool))["function"]
             else:
                 function = cast(dict, tool)
@@ -356,8 +354,8 @@ def _get_items_from_schema(schema: Union[Dict, List, str]) -> Dict[str, Any]:
             )
         if _is_nullable_schema(schema):
             items["nullable"] = True
-        if 'required' in schema:
-            items['required'] = schema['required']
+        if "required" in schema:
+            items["required"] = schema["required"]
     else:
         # str
         items["type_"] = _get_type_from_schema({"type": schema})

--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -356,6 +356,8 @@ def _get_items_from_schema(schema: Union[Dict, List, str]) -> Dict[str, Any]:
             )
         if _is_nullable_schema(schema):
             items["nullable"] = True
+        if 'required' in schema:
+            items['required'] = schema['required']
     else:
         # str
         items["type_"] = _get_type_from_schema({"type": schema})

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -510,6 +510,83 @@ def test_tool_to_dict_pydantic() -> None:
     assert gapic_tool == convert_to_genai_function_declarations([tool_dict])
 
 
+def test_tool_to_dict_pydantic_nested() -> None:
+    class MyModel(BaseModel):
+        name: str
+        age: int
+
+    class Models(BaseModel):
+        models: list[MyModel]
+
+    gapic_tool = convert_to_genai_function_declarations([Models])
+    tool_dict = tool_to_dict(gapic_tool)
+    assert tool_dict == {
+        "function_declarations": [
+            {
+                "description": "",
+                "name": "Models",
+                "parameters": {
+                    "description": "",
+                    "enum": [],
+                    "format_": "",
+                    "max_items": "0",
+                    "min_items": "0",
+                    "nullable": False,
+                    "properties": {
+                        "models": {
+                            "description": "",
+                            "enum": [],
+                            "format_": "",
+                            "items": {
+                                "description": "MyModel",
+                                "enum": [],
+                                "format_": "",
+                                "max_items": "0",
+                                "min_items": "0",
+                                "nullable": False,
+                                "properties": {
+                                    "age": {
+                                        "description": "",
+                                        "enum": [],
+                                        "format_": "",
+                                        "max_items": "0",
+                                        "min_items": "0",
+                                        "nullable": False,
+                                        "properties": {},
+                                        "required": [],
+                                        "type_": 3,
+                                    },
+                                    "name": {
+                                        "description": "",
+                                        "enum": [],
+                                        "format_": "",
+                                        "max_items": "0",
+                                        "min_items": "0",
+                                        "nullable": False,
+                                        "properties": {},
+                                        "required": [],
+                                        "type_": 1,
+                                    },
+                                },
+                                "required": ["name", "age"],
+                                "type_": 6,
+                            },
+                            "max_items": "0",
+                            "min_items": "0",
+                            "nullable": False,
+                            "properties": {},
+                            "required": [],
+                            "type_": 5,
+                        }
+                    },
+                    "required": ["models"],
+                    "type_": 6,
+                },
+            }
+        ]
+    }
+
+
 def test_tool_to_dict_pydantic_without_import(mock_safe_import: MagicMock) -> None:
     class MyModel(BaseModel):
         name: str


### PR DESCRIPTION
## PR Description

Fix missing required field in the tool schema when dealing with nested pydantic models. Following model 

```python
class MyModel(BaseModel):
    name: str
    age: int

class Models(BaseModel):
    models: list[MyModel]
```

Is not populating `required` field for nested `MyModel`

```python
"function_declarations": [
            {
                "description": "",
                "name": "Models",
                         ...
                        "models": {
                            "description": "",
                            "enum": [],
                            "format_": "",
                            "items": {
                                "description": "MyModel",
                                "enum": [],
                            ...
                                    },
                                },
                                "required": [],   # <- Should be "required": ["name", "age"],
                                "type_": 6,
                            },
                            ...
                        }
                    },
                    "required": ["models"],
                    "type_": 6,
                },
            }
        ]
    }
```

## Relevant issues
Fixes #690, 


## Type

🐛 Bug Fix


## Changes(optional)

<!-- List of changes -->

## Testing(optional)

<!-- Test procedure -->
<!-- Test result -->

## Note(optional)

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
