### PR TITLE
genai[patch]: update gemini 1.0 -> 1.5 and 2.0 in tests

### DIFF
--- a/libs/genai/tests/integration_tests/test_callbacks.py
+++ b/libs/genai/tests/integration_tests/test_callbacks.py
@@ -23,7 +23,7 @@ class StreamingLLMCallbackHandler(BaseCallbackHandler):
 def test_streaming_callback() -> None:
     prompt_template = "Tell me details about the Company {name} with 2 bullet point?"
     cb = StreamingLLMCallbackHandler()
-    llm = ChatGoogleGenerativeAI(model="gemini-pro", callbacks=[cb])
+    llm = ChatGoogleGenerativeAI(model="models/gemini-2.0-flash-001", callbacks=[cb])
     llm_chain = PromptTemplate.from_template(prompt_template) | llm
     for t in llm_chain.stream({"name": "Google"}):
         pass

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -22,7 +22,6 @@ from langchain_google_genai import (
     HarmBlockThreshold,
     HarmCategory,
 )
-from langchain_google_genai.chat_models import ChatGoogleGenerativeAIError
 
 _MODEL = "models/gemini-1.5-flash-001"  # TODO: Use nano when it's available.
 _VISION_MODEL = "models/gemini-2.0-flash-001"

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -24,7 +24,7 @@ from langchain_google_genai import (
 )
 from langchain_google_genai.chat_models import ChatGoogleGenerativeAIError
 
-_MODEL = "models/gemini-1.0-pro-001"  # TODO: Use nano when it's available.
+_MODEL = "models/gemini-1.5-flash-001"  # TODO: Use nano when it's available.
 _VISION_MODEL = "models/gemini-2.0-flash-001"
 _B64_string = """iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAABhGlDQ1BJQ0MgUHJvZmlsZQAAeJx9kT1Iw0AcxV8/xCIVQTuIKGSoTi2IijhqFYpQIdQKrTqYXPoFTRqSFBdHwbXg4Mdi1cHFWVcHV0EQ/ABxdXFSdJES/5cUWsR4cNyPd/ced+8Af6PCVDM4DqiaZaSTCSGbWxW6XxHECPoRQ0hipj4niil4jq97+Ph6F+dZ3uf+HL1K3mSATyCeZbphEW8QT29aOud94ggrSQrxOXHMoAsSP3JddvmNc9FhP8+MGJn0PHGEWCh2sNzBrGSoxFPEUUXVKN+fdVnhvMVZrdRY6578heG8trLMdZrDSGIRSxAhQEYNZVRgIU6rRoqJNO0nPPxDjl8kl0yuMhg5FlCFCsnxg//B727NwuSEmxROAF0vtv0xCnTvAs26bX8f23bzBAg8A1da219tADOfpNfbWvQI6NsGLq7bmrwHXO4Ag0+6ZEiOFKDpLxSA9zP6phwwcAv0rLm9tfZx+gBkqKvUDXBwCIwVKXvd492hzt7+PdPq7wdzbXKn5swsVgAAA8lJREFUeJx90dtPHHUUB/Dz+81vZhb2wrDI3soUKBSRcisF21iqqCRNY01NTE0k8aHpi0k18VJfjOFvUF9M44MmGrHFQqSQiKSmFloL5c4CXW6Fhb0vO3ufvczMzweiBGI9+eW8ffI95/yQqqrwv4UxBgCfJ9w/2NfSVB+Nyn6/r+vdLo7H6FkYY6yoABR2PJujj34MSo/d/nHeVLYbydmIp/bEO0fEy/+NMcbTU4/j4Vs6Lr0ccKeYuUKWS4ABVCVHmRdszbfvTgfjR8kz5Jjs+9RREl9Zy2lbVK9wU3/kWLJLCXnqza1bfVe7b9jLbIeTMcYu13Jg/aMiPrCwVFcgtDiMhnxwJ/zXVDwSdVCVMRV7nqzl2i9e/fKrw8mqSp84e2sFj3Oj8/SrF/MaicmyYhAaXu58NPAbeAeyzY0NLecmh2+ODN3BewYBAkAY43giI3kebrnsRmvV9z2D4ciOa3EBAf31Tp9sMgdxMTFm6j74/Ogb70VCYQKAAIDCXkOAIC6pkYBWdwwnpHEdf6L9dJtJKPh95DZhzFKMEWRAGL927XpWTmMA+s8DAOBYAoR483l/iHZ/8bXoODl8b9UfyH72SXepzbyRJNvjFGHKMlhvMBze+cH9+4lEuOOlU2X1tVkFTU7Om03q080NDGXV1cflRpHwaaoiiiildB8jhDLZ7HDfz2Yidba6Vn2L4fhzFrNRKy5OZ2QOZ1U5W8VtqlVH/iUHcM933zZYWS7Wtj66zZr65bzGJQt0glHgudi9XVzEl4vKw2kUPhO020oPYI1qYc+2Xc0bRXFwTLY0VXa2VibD/lBaIXm1UChN5JSRUcQQ1Tk/47Cf3x8bY7y17Y17PVYTG1UkLPBFcqik7Zoa9JcLYoHBqHhXNgd6gS1k9EJ1TQ2l9EDy1saErmQ2kGpwGC2MLOtCM8nZEV1K0tKJtEksSm26J/rHg2zzmabKisq939nHzqUH7efzd4f/nPGW6NP8ybNFrOsWQhpoCuuhnJ4hAnPhFam01K4oQMjBg/mzBjVhuvw2O++KKT+BIVxJKzQECBDLF2qu2WTMmCovtDQ1f8iyoGkUADBCCGPsdnvTW2OtFm01VeB06msvdWlpPZU0wJRG85ns84umU3k+VyxeEcWqvYUBAGsUrbvme4be99HFeisP/pwUOIZaOqQX31ISgrKmZhLHtXNXuJq68orrr5/9mBCglCLAGGPyy81votEbcjlKLrC9E8mhH3wdHRdcyyvjidSlxjftPJpD+o25JYvRHGFoZDdks1mBQhxJu9uxvwEiXuHnHbLd1AAAAABJRU5ErkJggg=="""  # noqa: E501
 
@@ -209,27 +209,6 @@ def test_chat_google_genai_invoke_multimodal_multiple_messages() -> None:
     assert len(response.content.strip()) > 0
 
 
-def test_chat_google_genai_invoke_multimodal_invalid_model() -> None:
-    # need the vision model to support this.
-    messages: list = [
-        HumanMessage(
-            content=[
-                {
-                    "type": "text",
-                    "text": "I'm doing great! Guess what's in this picture!",
-                },
-                {
-                    "type": "image_url",
-                    "image_url": "data:image/png;base64," + _B64_string,
-                },
-            ]
-        ),
-    ]
-    llm = ChatGoogleGenerativeAI(model=_MODEL)
-    with pytest.raises(ChatGoogleGenerativeAIError):
-        llm.invoke(messages)
-
-
 def test_chat_google_genai_single_call_with_history() -> None:
     model = ChatGoogleGenerativeAI(model=_MODEL)
     text_question1, text_answer1 = "How much is 2+2?", "4"
@@ -265,7 +244,7 @@ def test_chat_google_genai_system_message(
 
 
 def test_generativeai_get_num_tokens_gemini() -> None:
-    llm = ChatGoogleGenerativeAI(temperature=0, model="gemini-pro")
+    llm = ChatGoogleGenerativeAI(temperature=0, model=_MODEL)
     output = llm.get_num_tokens("How are you?")
     assert output == 4
 
@@ -275,7 +254,7 @@ def test_safety_settings_gemini() -> None:
         HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_NONE  # type: ignore[dict-item]
     }
     # test with safety filters on bind
-    llm = ChatGoogleGenerativeAI(temperature=0, model="gemini-pro").bind(
+    llm = ChatGoogleGenerativeAI(temperature=0, model=_MODEL).bind(
         safety_settings=safety_settings
     )
     output = llm.invoke("how to make a bomb?")
@@ -292,7 +271,7 @@ def test_safety_settings_gemini() -> None:
 
     # test as init param
     llm = ChatGoogleGenerativeAI(
-        temperature=0, model="gemini-pro", safety_settings=safety_settings
+        temperature=0, model=_MODEL, safety_settings=safety_settings
     )
     out2 = llm.invoke("how to make a bomb")
     assert isinstance(out2, AIMessage)

--- a/libs/genai/tests/integration_tests/test_function_call.py
+++ b/libs/genai/tests/integration_tests/test_function_call.py
@@ -29,7 +29,9 @@ def test_function_call() -> None:
             },
         }
     ]
-    llm = ChatGoogleGenerativeAI(model="gemini-pro").bind(functions=functions)
+    llm = ChatGoogleGenerativeAI(model="models/gemini-2.0-flash-001").bind(
+        functions=functions
+    )
     res = llm.invoke("what weather is today in san francisco?")
     assert res
     assert res.additional_kwargs
@@ -47,7 +49,9 @@ def test_tool_call() -> None:
         """Searches the web for `query` and returns the result."""
         raise NotImplementedError
 
-    llm = ChatGoogleGenerativeAI(model="gemini-pro").bind(functions=[search_tool])
+    llm = ChatGoogleGenerativeAI(model="models/gemini-2.0-flash-001").bind(
+        functions=[search_tool]
+    )
     response = llm.invoke("weather in san francisco")
     assert isinstance(response, AIMessage)
     assert isinstance(response.content, str)
@@ -67,7 +71,9 @@ class MyModel(BaseModel):
 
 
 def test_pydantic_call() -> None:
-    llm = ChatGoogleGenerativeAI(model="gemini-pro").bind(functions=[MyModel])
+    llm = ChatGoogleGenerativeAI(model="models/gemini-2.0-flash-001").bind(
+        functions=[MyModel]
+    )
     response = llm.invoke("my name is Erick and I am 27 years old")
     assert isinstance(response, AIMessage)
     assert isinstance(response.content, str)

--- a/libs/genai/tests/integration_tests/test_llms.py
+++ b/libs/genai/tests/integration_tests/test_llms.py
@@ -47,7 +47,7 @@ def test_google_generativeai_generate(model_name: str) -> None:
 
 
 async def test_google_generativeai_agenerate() -> None:
-    llm = GoogleGenerativeAI(temperature=0, model="gemini-pro")
+    llm = GoogleGenerativeAI(temperature=0, model="models/gemini-2.0-flash-001")
     output = await llm.agenerate(["Please say foo:"])
     assert isinstance(output, LLMResult)
 


### PR DESCRIPTION
Tests failing with
> google.api_core.exceptions.NotFound: 404 models/gemini-1.0-pro-001 is not found for API version v1beta, or is not supported for generateContent. Call ListModels to see the list of available models and their supported methods.

(Unsure why but model is scheduled to be retired in 1-2 months anyway.)