### PR TITLE
community: add support for additional VECTOR_SEARCH options

### DIFF
--- a/libs/community/langchain_google_community/bq_storage_vectorstores/_base.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/_base.py
@@ -115,7 +115,7 @@ class BaseBigQueryVectorStore(VectorStore, BaseModel, ABC):
         filter: Optional[Dict[str, Any]] = None,
         k: int = 5,
         batch_size: Union[int, None] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> List[List[List[Any]]]:
         ...
 

--- a/libs/community/langchain_google_community/bq_storage_vectorstores/_base.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/_base.py
@@ -115,6 +115,7 @@ class BaseBigQueryVectorStore(VectorStore, BaseModel, ABC):
         filter: Optional[Dict[str, Any]] = None,
         k: int = 5,
         batch_size: Union[int, None] = None,
+        **kwargs: Any
     ) -> List[List[List[Any]]]:
         ...
 

--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -562,6 +562,8 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 for each matched document. Defaults to False.
             with_embeddings: (Optional) If True, include the matched document's
                 embedding vector in the result. Defaults to False.
+            options: (Optional) A dictionary representing additional options for 
+                VECTOR_SEARCH.
         Returns:
             A list of `k` documents for each embedding in `embeddings`
         """
@@ -603,6 +605,8 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
+            options: (Optional) A dictionary representing additional options for 
+                VECTOR_SEARCH.
         Returns:
             Return docs most similar to embedding vector.
         """
@@ -615,6 +619,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         embedding: List[float],
         filter: Optional[Union[Dict[str, Any], str]] = None,
         k: int = 5,
+        **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return docs most similar to embedding vector with scores.
 
@@ -630,11 +635,13 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
+            options: (Optional) A dictionary representing additional options for 
+                VECTOR_SEARCH.
         Returns:
             Return docs most similar to embedding vector.
         """
         return self.similarity_search_by_vectors(
-            embeddings=[embedding], filter=filter, k=k, with_scores=True
+            embeddings=[embedding], filter=filter, k=k, with_scores=True, **kwargs
         )[0]
 
     def similarity_search(
@@ -654,6 +661,8 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
+            options: (Optional) A dictionary representing additional options for 
+                VECTOR_SEARCH.
         Returns:
             Return docs most similar to input query.
         """
@@ -684,12 +693,14 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
+            options: (Optional) A dictionary representing additional options for 
+                VECTOR_SEARCH.
         Returns:
             Return docs most similar to input query along with scores.
         """
         embedding = self.embedding.embed_query(query)
         return self.similarity_search_by_vector_with_score(
-            embedding=embedding, filter=filter, k=k
+            embedding=embedding, filter=filter, k=k, **kwargs
         )
 
     @classmethod

--- a/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
+++ b/libs/community/langchain_google_community/bq_storage_vectorstores/bigquery.py
@@ -193,7 +193,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         filter: Optional[Union[Dict[str, Any], str]] = None,
         k: int = 5,
         batch_size: Union[int, None] = 100,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> List[List[List[Any]]]:
         """Performs a similarity search using vector embeddings
 
@@ -214,7 +214,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: The number of top results to return for each query.
             batch_size: The size of batches to process embeddings.
-            options: (Optional) A dictionary representing additional options for 
+            options: (Optional) A dictionary representing additional options for
                 VECTOR_SEARCH.
 
         Returns:
@@ -232,8 +232,12 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
             end = start + batch_size  # type: ignore[operator]
             embs_batch = embeddings[start:end]
             search_results.extend(
-                self._search_embeddings(embeddings=embs_batch, filter=filter, k=k, 
-                                        options=kwargs.get("options", None))
+                self._search_embeddings(
+                    embeddings=embs_batch,
+                    filter=filter,
+                    k=k,
+                    options=kwargs.get("options", None),
+                )
             )
 
         return self._create_langchain_documents(
@@ -362,7 +366,10 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
         from google.cloud import bigquery  # type: ignore[attr-defined]
 
         full_query = self._create_search_query(
-            filter=filter, k=k, num_embeddings=len(embeddings), options=options,
+            filter=filter,
+            k=k,
+            num_embeddings=len(embeddings),
+            options=options,
         )
 
         job_config = bigquery.QueryJobConfig(
@@ -481,7 +488,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 the documents
             with_embeddings: If True, returns the embeddings of the results along with
                 the documents
-            options: (Optional) A dictionary representing additional options for 
+            options: (Optional) A dictionary representing additional options for
                 VECTOR_SEARCH.
         """
         from google.cloud import bigquery  # type: ignore[attr-defined]
@@ -562,7 +569,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 for each matched document. Defaults to False.
             with_embeddings: (Optional) If True, include the matched document's
                 embedding vector in the result. Defaults to False.
-            options: (Optional) A dictionary representing additional options for 
+            options: (Optional) A dictionary representing additional options for
                 VECTOR_SEARCH.
         Returns:
             A list of `k` documents for each embedding in `embeddings`
@@ -605,7 +612,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
-            options: (Optional) A dictionary representing additional options for 
+            options: (Optional) A dictionary representing additional options for
                 VECTOR_SEARCH.
         Returns:
             Return docs most similar to embedding vector.
@@ -635,7 +642,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
-            options: (Optional) A dictionary representing additional options for 
+            options: (Optional) A dictionary representing additional options for
                 VECTOR_SEARCH.
         Returns:
             Return docs most similar to embedding vector.
@@ -661,7 +668,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
-            options: (Optional) A dictionary representing additional options for 
+            options: (Optional) A dictionary representing additional options for
                 VECTOR_SEARCH.
         Returns:
             Return docs most similar to input query.
@@ -693,7 +700,7 @@ class BigQueryVectorStore(BaseBigQueryVectorStore):
                 - If a string is provided, it is assumed to be a valid SQL WHERE clause.
             k: (Optional) The number of top-ranking similar documents to return per
                 embedding. Defaults to 5.
-            options: (Optional) A dictionary representing additional options for 
+            options: (Optional) A dictionary representing additional options for
                 VECTOR_SEARCH.
         Returns:
             Return docs most similar to input query along with scores.


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

Add support for specifying additional options for VECTOR_SEARCH, as described in the [docs for VECTOR_SEARCH](https://cloud.google.com/bigquery/docs/reference/standard-sql/search_functions#:~:text=options%3A%20A%20named%20argument%20with%20a%20JSON%2Dformatted%20STRING%20value.%20options_value%20is%20a%20literal%20that%20specifies%20the%20following%20vector%20search%20options%3A). The current options are `fraction_lists_to_search` and `use_brute_force`

The options are specified as a dict and converted to JSON when the query is created.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

None.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes(optional)

In `BigQueryVectorStore`: 
- Update `_create_search_query()` to add the options parameter to the query.
- Update `_search_embeddings()` and `batch_search()` to accept and pass the options parameter.
- Update `_similarity_search_by_vectors_with_scores_and_embeddings()` to accept kwargs and pass the options parameter.
- Update the five `similarity_search_*` methods to accept and pass kwargs, and add the options parameter to their docs.


In `BaseBigQueryVectorStore` update the abstract `_similarity_search_by_vectors_with_scores_and_embeddings()` to accept kwargs.

<!-- List of changes -->


## Testing(optional)
No formal testing aside from trying this out manually to confirm it works. No tests have been added as this is a very small change. Additionally only integration tests exist for `BigQueryVectorStore` and the README says almost not tests should be integration tests.

<!-- Test procedure -->
<!-- Test result -->

## Note(optional)
The `json` import in `BigQueryVectorStore` is new.
<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
