### PR TITLE
Bug Fix: Make call of literal_eval optional

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -203,6 +203,7 @@ def _parse_chat_history_gemini(
     history: List[BaseMessage],
     imageBytesLoader: ImageBytesLoader,
     convert_system_message_to_human: Optional[bool] = False,
+    perform_literal_eval_on_string_raw_content: Optional[bool] = False,
 ) -> tuple[Content | None, list[Content]]:
     def _convert_to_prompt(part: Union[str, Dict]) -> Optional[Part]:
         if isinstance(part, str):
@@ -258,7 +259,7 @@ def _parse_chat_history_gemini(
         # native type (such as list or dict) so that results can be properly
         # appended to the prompt, otherwise they will all be parsed as Text
         # rather than `inline_data`.
-        if isinstance(raw_content, str):
+        if perform_literal_eval_on_string_raw_content and isinstance(raw_content, str):
             try:
                 raw_content = ast.literal_eval(raw_content)
             except SyntaxError:
@@ -1093,6 +1094,10 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
     """ Optional tag llm calls with metadata to help in tracebility and biling.
     """
 
+    perform_literal_eval_on_string_raw_content: bool = True
+    """Whether to perform literal eval on string raw content.
+    """
+
     def __init__(self, *, model_name: Optional[str] = None, **kwargs: Any) -> None:
         """Needed for mypy typing to recognize model_name as a valid arg."""
         if model_name:
@@ -1351,7 +1356,9 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         **kwargs,
     ) -> GenerateContentRequest:
         system_instruction, contents = _parse_chat_history_gemini(
-            messages, self._image_bytes_loader_client
+            messages,
+            self._image_bytes_loader_client,
+            perform_literal_eval_on_string_raw_content=self.perform_literal_eval_on_string_raw_content,
         )
         formatted_tools = self._tools_gemini(tools=tools, functions=functions)
         if tool_config:
@@ -1475,7 +1482,9 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         if self._is_gemini_model:
             # https://cloud.google.com/vertex-ai/docs/reference/rpc/google.cloud.aiplatform.v1beta1#counttokensrequest
             _, contents = _parse_chat_history_gemini(
-                [HumanMessage(content=text)], self._image_bytes_loader_client
+                [HumanMessage(content=text)],
+                self._image_bytes_loader_client,
+                perform_literal_eval_on_string_raw_content=self.perform_literal_eval_on_string_raw_content,
             )
             response = self.prediction_client.count_tokens(
                 {

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -344,7 +344,9 @@ def test_parse_history_gemini_multimodal_FC():
     expected = [Content(role="user", parts=parts)]
     imageBytesLoader = ImageBytesLoader()
     _, response = _parse_chat_history_gemini(
-        history=history, imageBytesLoader=imageBytesLoader
+        history=history,
+        imageBytesLoader=imageBytesLoader,
+        perform_literal_eval_on_string_raw_content=True,
     )
     assert expected == response
 

--- a/libs/vertexai/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/vertexai/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -16,6 +16,7 @@
       'model_family': '2',
       'model_name': 'gemini-1.5-pro-001',
       'n': 1,
+      'perform_literal_eval_on_string_raw_content': True,
       'project': 'test-proj',
       'request_parallelism': 5,
       'stop': list([

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -1065,6 +1065,42 @@ def test_multiple_fc() -> None:
     assert history == expected
 
 
+def test_parse_chat_history_gemini_with_literal_eval() -> None:
+    instruction = "Describe the attached media in 5 words."
+    text_message = {"type": "text", "text": instruction}
+    message = str([text_message])
+    history = [HumanMessage(content=message)]
+    image_bytes_loader = ImageBytesLoader()
+    _, history = _parse_chat_history_gemini(
+        history=history,
+        imageBytesLoader=image_bytes_loader,
+        perform_literal_eval_on_string_raw_content=True,
+    )
+    parts = [
+        Part(text=instruction),
+    ]
+    expected = [Content(role="user", parts=parts)]
+    assert history == expected
+
+
+def test_parse_chat_history_gemini_without_literal_eval() -> None:
+    instruction = "Describe the attached media in 5 words."
+    text_message = {"type": "text", "text": instruction}
+    message = str([text_message])
+    history = [HumanMessage(content=message)]
+    image_bytes_loader = ImageBytesLoader()
+    _, history = _parse_chat_history_gemini(
+        history=history,
+        imageBytesLoader=image_bytes_loader,
+        perform_literal_eval_on_string_raw_content=False,
+    )
+    parts = [
+        Part(text=message),
+    ]
+    expected = [Content(role="user", parts=parts)]
+    assert history == expected
+
+
 def test_init_client_with_custom_api() -> None:
     config = {
         "model": "gemini-1.5-pro",

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -19,6 +19,7 @@ from google.cloud.aiplatform_v1beta1.types import (
 )
 from langchain_core.messages import (
     AIMessage,
+    BaseMessage,
     FunctionMessage,
     HumanMessage,
     SystemMessage,
@@ -1069,9 +1070,9 @@ def test_parse_chat_history_gemini_with_literal_eval() -> None:
     instruction = "Describe the attached media in 5 words."
     text_message = {"type": "text", "text": instruction}
     message = str([text_message])
-    history = [HumanMessage(content=message)]
+    history: list[BaseMessage] = [HumanMessage(content=message)]
     image_bytes_loader = ImageBytesLoader()
-    _, history = _parse_chat_history_gemini(
+    _, response = _parse_chat_history_gemini(
         history=history,
         imageBytesLoader=image_bytes_loader,
         perform_literal_eval_on_string_raw_content=True,
@@ -1080,16 +1081,16 @@ def test_parse_chat_history_gemini_with_literal_eval() -> None:
         Part(text=instruction),
     ]
     expected = [Content(role="user", parts=parts)]
-    assert history == expected
+    assert expected == response
 
 
 def test_parse_chat_history_gemini_without_literal_eval() -> None:
     instruction = "Describe the attached media in 5 words."
     text_message = {"type": "text", "text": instruction}
     message = str([text_message])
-    history = [HumanMessage(content=message)]
+    history: list[BaseMessage] = [HumanMessage(content=message)]
     image_bytes_loader = ImageBytesLoader()
-    _, history = _parse_chat_history_gemini(
+    _, response = _parse_chat_history_gemini(
         history=history,
         imageBytesLoader=image_bytes_loader,
         perform_literal_eval_on_string_raw_content=False,
@@ -1098,7 +1099,7 @@ def test_parse_chat_history_gemini_without_literal_eval() -> None:
         Part(text=message),
     ]
     expected = [Content(role="user", parts=parts)]
-    assert history == expected
+    assert expected == response
 
 
 def test_init_client_with_custom_api() -> None:


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

Add a flag to make the call of `literal_eval` optional

## Relevant issues

Fixes #710 

## Type

🐛 Bug Fix


## Note(optional)

Hi 👋 

This is my attempt to make the usage of `literal_eval` optional. I added a flag to the ChatModel and set the default to `True` to keep it backwards compatible - however out of a security perspective I would rather suggest setting it to `False`.

In our case (we do not use `ChatPromptTemplate`), the usage of `literal_eval` is not necessary, but even leads to a bug when entering a value that is parseable as a Float ("3.14") into our chat (`TypeError: 'float' object is not iterable`)