### PR TITLE
vertexai: Support for new `tool_choice` format for Gemini models

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/functions_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/functions_utils.py
@@ -451,6 +451,14 @@ def _tool_choice_to_tool_config(
             allowed_function_names = tool_choice["function_calling_config"].get(
                 "allowed_function_names"
             )
+        elif (
+            "type" in tool_choice
+            and tool_choice["type"] == "function"
+            and "function" in tool_choice
+            and "name" in tool_choice["function"]
+        ):
+            mode = gapic.FunctionCallingConfig.Mode.ANY
+            allowed_function_names = [tool_choice["function"]["name"]]
         else:
             raise ValueError(
                 f"Unrecognized tool choice format:\n\n{tool_choice=}\n\nShould match "

--- a/libs/vertexai/tests/unit_tests/test_function_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_function_utils.py
@@ -505,7 +505,10 @@ def test_format_tool_config():
     )
 
 
-@pytest.mark.parametrize("choice", (True, "foo", ["foo"], "any"))
+@pytest.mark.parametrize(
+    "choice",
+    (True, "foo", ["foo"], "any", {"type": "function", "function": {"name": "foo"}}),
+)
 def test__tool_choice_to_tool_config(choice: Any) -> None:
     expected = GapicToolConfig(
         function_calling_config=GapicFunctionCallingConfig(


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

This PR enhances the `_tool_choice_to_tool_config` function within the `vertexai` package to support a new `tool_choice` format. Specifically, it adds functionality to handle tool choice dictionaries that include a `"type": "function"` key, along with a nested `"function"` object containing the `"name"` field, similar to the format used for `OpenAI` models. This change makes the configuration more flexible for handling different types of tool choices in LangChain-Google.

The PR also updates the unit test for `_tool_choice_to_tool_config` to verify that the new format is properly handled.

## Relevant issues

Fixes #697

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

- Modified `_tool_choice_to_tool_config` to support tool added as `tool_choice={"type": "function", "function": {"name": "FuncName"}}`
- Updated unit test `test__tool_choice_to_tool_config` to check the new format.

<!-- ## Testing(optional) -->

<!-- Test procedure -->
<!-- Test result -->

<!-- ## Note(optional) -->

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
