### PR TITLE
fix[genai]: Allow Temperature Values Up to 2.0 for ChatGoogleGenerativeAI

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -831,8 +831,8 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
         """Validates params and passes them to google-generativeai package."""
-        if self.temperature is not None and not 0 <= self.temperature <= 1:
-            raise ValueError("temperature must be in the range [0.0, 1.0]")
+        if self.temperature is not None and not 0 <= self.temperature <= 2.0:
+            raise ValueError("temperature must be in the range [0.0, 2.0]")
 
         if self.top_p is not None and not 0 <= self.top_p <= 1:
             raise ValueError("top_p must be in the range [0.0, 1.0]")

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -646,7 +646,7 @@ def test__convert_tool_message_to_part__sets_tool_name(
     assert part.function_response.response == {"output": "test_content"}
 
 
-def test_temperature_range() -> None:
+def test_temperature_range_pydantic_validation() -> None:
     """Test that temperature is in the range [0.0, 2.0]"""
 
     with pytest.raises(ValidationError):
@@ -669,7 +669,7 @@ def test_temperature_range() -> None:
     }
 
 
-def test_temperature_range_value_error() -> None:
+def test_temperature_range_model_validation() -> None:
     """Test that temperature is in the range [0.0, 2.0]"""
 
     with pytest.raises(ValueError):

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -24,6 +24,7 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import tool_call as create_tool_call
 from pydantic import SecretStr
+from pydantic_core._pydantic_core import ValidationError
 from pytest import CaptureFixture
 
 from langchain_google_genai.chat_models import (
@@ -643,3 +644,26 @@ def test__convert_tool_message_to_part__sets_tool_name(
     part = _convert_tool_message_to_part(tool_message)
     assert part.function_response.name == "tool_name"
     assert part.function_response.response == {"output": "test_content"}
+
+
+def test_temperature_range() -> None:
+    """Test that temperature is in the range [0.0, 2.0]"""
+
+    with pytest.raises(ValidationError):
+        ChatGoogleGenerativeAI(model="gemini-2.0-flash", temperature=2.1)
+
+    with pytest.raises(ValidationError):
+        ChatGoogleGenerativeAI(model="gemini-2.0-flash", temperature=-0.1)
+
+    llm = ChatGoogleGenerativeAI(
+        model="gemini-2.0-flash",
+        google_api_key=SecretStr("..."),  # type: ignore[call-arg]
+        temperature=1.5,
+    )
+    ls_params = llm._get_ls_params()
+    assert ls_params == {
+        "ls_provider": "google_genai",
+        "ls_model_name": "models/gemini-2.0-flash",
+        "ls_model_type": "chat",
+        "ls_temperature": 1.5,
+    }

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -667,3 +667,13 @@ def test_temperature_range() -> None:
         "ls_model_type": "chat",
         "ls_temperature": 1.5,
     }
+
+
+def test_temperature_range_value_error() -> None:
+    """Test that temperature is in the range [0.0, 2.0]"""
+
+    with pytest.raises(ValueError):
+        ChatGoogleGenerativeAI(model="gemini-2.0-flash", temperature=2.5)
+
+    with pytest.raises(ValueError):
+        ChatGoogleGenerativeAI(model="gemini-2.0-flash", temperature=-0.5)


### PR DESCRIPTION
<!--# Thank you for contributing to LangChain-google!-->

<!--

## Change
  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [x] Add Tests and Docs:

## Additional guidelines

- [x] PR title and description are appropriate
- [x] Necessary tests and documentation have been added
- [x] Lint and tests pass successfully
- [x] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

Current temperature validation restricts values to a maximum of 1.0. However, the Gemini API supports values up to 2.0, which allows for more creative and diverse outputs. This discrepancy led to failing code and forces to users to directly use gemini api when we need temperature value >1.

### Changes Made
- Validation Update: Modified the temperature validation logic to accept values within the range [0.0, 2.0] instead of the previous [0.0, 1.0].
- Test Enhancement: Added a new unit test (test_temperature_range) to verify that temperature values above 1.0 up to 2.0 are accepted.
- Compatibility: Ensured that this change aligns our implementation with the Gemini API's supported range, enabling more flexible usage without breaking existing functionality.

## Relevant issues

Fixes #781

## Type

🐛 Bug Fix

## Changes(optional)

- Updated temperature validation to allow values in range [0.0, 2.0] instead of [0.0, 1.0]
- This ensures compatibility with Gemini API's supported temperature range
- Create a new Unit Test that is now passing to check for temperature values in this range

## Testing(optional)

- Added a new test test_temperature_range that now passes correctly
- Verified that temperature values between 0 and 2.0 are properly accepted

<!-- Test procedure -->
<!-- Test result -->

## Note(optional)
This change aligns our code with the Gemini API's capabilities, allowing users to set higher temperature values when needed for more creative outputs.

- [x] No Breaking Changes @lkuligin @SauravP97 
- [x] Necessary tests have been added
- [x] Lint and tests pass successfully