### PR TITLE
Add model_kwargs to ChatAnthropicVertex to enable thinking mode

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/model_garden.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden.py
@@ -193,6 +193,7 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
+    model_kwargs: dict[str, Any] = Field(default_factory=dict)
 
     # Needed so that mypy doesn't flag missing aliased init args.
     def __init__(self, **kwargs: Any) -> None:
@@ -231,13 +232,14 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
 
     @property
     def _default_params(self):
-        return {
+        d = {
             "model": self.model_name,
             "max_tokens": self.max_output_tokens,
             "temperature": self.temperature,
             "top_k": self.top_k,
             "top_p": self.top_p,
         }
+        return {**d, **self.model_kwargs}
 
     def _format_params(
         self,

--- a/libs/vertexai/langchain_google_vertexai/model_garden.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden.py
@@ -232,14 +232,14 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
 
     @property
     def _default_params(self):
-        d = {
+        default_parameters = {
             "model": self.model_name,
             "max_tokens": self.max_output_tokens,
             "temperature": self.temperature,
             "top_k": self.top_k,
             "top_p": self.top_p,
         }
-        return {**d, **self.model_kwargs}
+        return {**default_parameters, **self.model_kwargs}
 
     def _format_params(
         self,

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -1178,6 +1178,18 @@ def test_init_client_with_custom_base_url() -> None:
         assert transport == "rest"
 
 
+def test_init_client_with_custom_model_kwargs() -> None:
+    llm = ChatAnthropicVertex(
+        project="test-project",
+        location="test-location",
+        model_kwargs={"thinking": {"type": "enabled", "budget_tokens": 1024}},
+    )
+    assert llm.model_kwargs == {"thinking": {"type": "enabled", "budget_tokens": 1024}}
+
+    default_params = llm._default_params
+    assert default_params["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+
+
 def test_anthropic_format_output() -> None:
     """Test format output handles different content structures correctly."""
 


### PR DESCRIPTION
Add a `model_kwargs` field to `ChatAnthropicVertex` that can hold `thinking` params.

I tried using the Claude 3.7 thinking mode via vertex and could not find a way to enable it. I then stumbled over the comment in https://github.com/langchain-ai/langchain-google/issues/764#issuecomment-2694399270 which suggested a `model_kwargs` param which is also what the [anthropic community model](https://github.com/langchain-ai/langchain/blob/d8145dda95d5a3d7c3e9feea1ff30eef25b14f00/libs/community/langchain_community/llms/anthropic.py#L67) does.

However I am not really sure if this is the desired or approach or if I am overseeing an existing solution here - I assume that https://github.com/langchain-ai/langchain-google/pull/790 already required a solution for this?
