### PR TITLE
(community): Handle non utf-8 encoding

### DIFF
--- a/libs/community/langchain_google_community/gmail/search.py
+++ b/libs/community/langchain_google_community/gmail/search.py
@@ -106,7 +106,12 @@ class GmailSearch(GmailBaseTool):
                             )
                         break
             else:
-                message_body = email_msg.get_payload(decode=True).decode("utf-8")  # type: ignore[union-attr]
+                try:
+                    message_body = email_msg.get_payload(decode=True).decode("utf-8")  # type: ignore[union-attr]
+                except UnicodeDecodeError:
+                    message_body = email_msg.get_payload(decode=True).decode( # type: ignore[union-attr]
+                        "latin-1"
+                    )  
 
             body = clean_email_body(message_body)
 


### PR DESCRIPTION
fixes: #726

### PR
Fix UnicodeDecodeError when parsing ISO-8859-1 encoded emails

#### Description
Added fallback to Latin-1 encoding for non-multipart emails

🐛 Bug Fix
