### PR TITLE
(community) : Fix GitHub Actions lint failure

### DIFF
--- a/libs/community/Makefile
+++ b/libs/community/Makefile
@@ -37,7 +37,7 @@ lint lint_diff lint_package lint_tests:
 	poetry run ruff check .
 	poetry run ruff format $(PYTHON_FILES) --diff
 	poetry run ruff check --select I $(PYTHON_FILES)
-	mkdir $(MYPY_CACHE); poetry run mypy $(PYTHON_FILES) --cache-dir $(MYPY_CACHE)
+	mkdir -p $(MYPY_CACHE); poetry run mypy $(PYTHON_FILES) --cache-dir $(MYPY_CACHE)
 
 format format_diff:
 	poetry run ruff format $(PYTHON_FILES)


### PR DESCRIPTION
The GitHub Actions CI workflow was failing during the testing of this pr : #805
```make: *** [Makefile:38: lint_package] Error 1```

This failure occurred because the `mkdir $(MYPY_CACHE)` command returns a non-zero exit code when the directory already exists. While this behavior is silently ignored in local development environments
![image](https://github.com/user-attachments/assets/075e3947-eb99-45bc-bf14-1d34fb8cdb46)

but  GitHub Actions treats  it  as a failure and stops the workflow.

## Solution
Added the `-p` flag to the `mkdir` command:

🐛 Bug Fix




