### PR TITLE
vertexai[patch]: remove warning emitted during parallel tool calls

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -538,16 +538,8 @@ def _parse_response_candidate(
                 raise Exception("Unexpected content type")
 
         if part.function_call:
-            if "function_call" in additional_kwargs:
-                logger.warning(
-                    (
-                        "This model can reply with multiple "
-                        "function calls in one response. "
-                        "Please don't rely on `additional_kwargs.function_call` "
-                        "as only the last one will be saved."
-                        "Use `tool_calls` instead."
-                    )
-                )
+            # For backward compatibility we store a function call in additional_kwargs,
+            # but in general the full set of function calls is stored in tool_calls.
             function_call = {"name": part.function_call.name}
             # dump to match other function calling llm for now
             function_call_args_dict = proto.Message.to_dict(part.function_call)["args"]


### PR DESCRIPTION
ChatVertexAI stores a function call in `additional_kwargs`. This is retained for backwards compatibility, but isn't structured to hold multiple tool calls. The `.tool_calls` attribute is used for this purpose, and all documentation uses it over `additional_kwargs["function_call"]`.

We currently emit a warning about this whenever parallel tool calls are generated. This leads to confusion from users, who look for ways to suppress or fix the warning even if they are working with tool calls as-intended. See for example https://github.com/langchain-ai/langgraph-supervisor-py/issues/48.

Here we remove the warning, as use of `.tool_calls` has been the documented norm for some time.