### PR TITLE
genai[patch]: remove warning emitted during structured output

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -112,9 +112,6 @@ from langchain_google_genai._image_utils import (
 
 from . import _genai_extension as genaix
 
-WARNED_STRUCTURED_OUTPUT_JSON_MODE = False
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -1404,14 +1401,6 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 tools=[schema], first_tool_only=True
             )
         else:
-            global WARNED_STRUCTURED_OUTPUT_JSON_MODE
-            warnings.warn(
-                "ChatGoogleGenerativeAI.with_structured_output with dict schema has "
-                "changed recently to align with behavior of other LangChain chat "
-                "models. More context: "
-                "https://github.com/langchain-ai/langchain-google/pull/772"
-            )
-            WARNED_STRUCTURED_OUTPUT_JSON_MODE = True
             parser = JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
         tool_choice = tool_name if self._supports_tool_choice else None
         try:


### PR DESCRIPTION
Remove warning associated with change in behavior from https://github.com/langchain-ai/langchain-google/pull/772.

It's undesirable to emit warnings for users following intended usage patterns as it can lead to confusion.

I don't feel strongly about when we remove the warning, in case we want to keep it around for N more weeks. But I'm also OK to remove at this point.