### PR TITLE
[vertexai] docs: Fix incorrect import statement in `ChatVertexAI` documentation

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -822,7 +822,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
     Use Search with Gemini 2:
         .. code-block:: python
 
-            import google.cloud.aiplatform_v1beta1.types import Tool as VertexTool
+            from google.cloud.aiplatform_v1beta1.types import Tool as VertexTool
             llm = ChatVertexAI(model="gemini-2.0-flash-exp")
             resp = llm.invoke(
                 "When is the next total solar eclipse in US?",


### PR DESCRIPTION
## PR Description

This PR fixes an incorrect import statement in the documentation for `ChatVertexAI` in the `langchain-google-vertexai` package. The current example in `libs/vertexai/langchain_google_vertexai/chat_models.py` uses `import google.cloud.aiplatform_v1beta1.types import Tool as VertexTool`, which is syntactically incorrect and will raise a `SyntaxError`. The correct import statement is `from google.cloud.aiplatform_v1beta1.types import Tool as VertexTool`.

## Relevant issues

Fixes #814 

## Type

📖 Documentation

## Changes

- Updated the import statement in the "Use Search with Gemini 2" example in `libs/vertexai/langchain_google_vertexai/chat_models.py` from `import google.cloud.aiplatform_v1beta1.types import Tool as VertexTool` to `from google.cloud.aiplatform_v1beta1.types import Tool as VertexTool`.

## Testing

This is a documentation change, so no additional tests were added.