### PR TITLE
[genai, vertexai]: Add warnings for invalid kwargs

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -5,6 +5,7 @@ import json
 import logging
 import uuid
 import warnings
+from difflib import get_close_matches
 from operator import itemgetter
 from typing import (
     Any,
@@ -890,6 +891,26 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     (e.g. what content to cache) and enjoy guaranteed cost savings. Format: 
     ``cachedContents/{cachedContent}``.
     """
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Needed for arg validation."""
+        # Get all valid field names, including aliases
+        valid_fields = set()
+        for field_name, field_info in self.model_fields.items():
+            valid_fields.add(field_name)
+            if hasattr(field_info, "alias") and field_info.alias is not None:
+                valid_fields.add(field_info.alias)
+
+        # Check for unrecognized arguments
+        for arg in kwargs:
+            if arg not in valid_fields:
+                suggestions = get_close_matches(arg, valid_fields, n=1)
+                suggestion = f" Did you mean '{suggestions[0]}'?" if suggestions else ""
+                logger.warning(
+                    f"Unexpected argument '{arg}' "
+                    f"provided to ChatGoogleGenerativeAI.{suggestion}"
+                )
+        super().__init__(**kwargs)
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -905,7 +905,9 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         for arg in kwargs:
             if arg not in valid_fields:
                 suggestions = get_close_matches(arg, valid_fields, n=1)
-                suggestion = f" Did you mean '{suggestions[0]}'?" if suggestions else ""
+                suggestion = (
+                    f" Did you mean: '{suggestions[0]}'?" if suggestions else ""
+                )
                 logger.warning(
                     f"Unexpected argument '{arg}' "
                     f"provided to ChatGoogleGenerativeAI.{suggestion}"

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -76,6 +76,21 @@ def test_integration_initialization() -> None:
         temperature=0.7,
     )
 
+    # test initialization with an invalid argument to check warning
+    with patch("langchain_google_genai.chat_models.logger.warning") as mock_warning:
+        llm = ChatGoogleGenerativeAI(
+            model="gemini-nano",
+            google_api_key=SecretStr("..."),  # type: ignore[call-arg]
+            safety_setting={
+                "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
+            },  # Invalid arg
+        )
+        assert llm.model == "models/gemini-nano"
+        mock_warning.assert_called_once()
+        call_args = mock_warning.call_args[0][0]
+        assert "Unexpected argument 'safety_setting'" in call_args
+        assert "Did you mean 'safety_settings'?" in call_args
+
 
 def test_initialization_inside_threadpool() -> None:
     # new threads don't have a running event loop,

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -89,7 +89,7 @@ def test_integration_initialization() -> None:
         mock_warning.assert_called_once()
         call_args = mock_warning.call_args[0][0]
         assert "Unexpected argument 'safety_setting'" in call_args
-        assert "Did you mean 'safety_settings'?" in call_args
+        assert "Did you mean: 'safety_settings'?" in call_args
 
 
 def test_initialization_inside_threadpool() -> None:

--- a/libs/genai/tests/unit_tests/test_llms.py
+++ b/libs/genai/tests/unit_tests/test_llms.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from langchain_google_genai.llms import GoogleGenerativeAI
 
 
@@ -26,3 +28,20 @@ def test_tracing_params() -> None:
         "ls_temperature": 0.1,
         "ls_max_tokens": 10,
     }
+
+    # Test initialization with an invalid argument to check warning
+    with patch("langchain_google_genai.llms.logger.warning") as mock_warning:
+        llm = GoogleGenerativeAI(
+            model="gemini-pro",
+            google_api_key="foo",  # type: ignore[call-arg]
+            safety_setting={
+                "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
+            },  # Invalid arg
+        )
+        assert llm.model == "gemini-pro"
+        ls_params = llm._get_ls_params()
+        assert ls_params["ls_model_name"] == "gemini-pro"
+        mock_warning.assert_called_once()
+        call_args = mock_warning.call_args[0][0]
+        assert "Unexpected argument 'safety_setting'" in call_args
+        assert "Did you mean: 'safety_settings'?" in call_args

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -1142,7 +1142,9 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         for arg in kwargs:
             if arg not in valid_fields:
                 suggestions = get_close_matches(arg, valid_fields, n=1)
-                suggestion = f" Did you mean '{suggestions[0]}'?" if suggestions else ""
+                suggestion = (
+                    f" Did you mean: '{suggestions[0]}'?" if suggestions else ""
+                )
                 logger.warning(
                     f"Unexpected argument '{arg}' "
                     f"provided to ChatVertexAI.{suggestion}"

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -80,6 +80,22 @@ def test_init() -> None:
             "ls_stop": ["bar"],
         }
 
+    # test initialization with an invalid argument to check warning
+    with patch("langchain_google_vertexai.chat_models.logger.warning") as mock_warning:
+        llm = ChatVertexAI(
+            model_name="gemini-pro",
+            project="test-project",
+            safety_setting={
+                "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
+            },  # Invalid arg
+        )
+        assert llm.model_name == "gemini-pro"
+        assert llm.project == "test-project"
+        mock_warning.assert_called_once()
+        call_args = mock_warning.call_args[0][0]
+        assert "Unexpected argument 'safety_setting'" in call_args
+        assert "Did you mean 'safety_settings'?" in call_args
+
 
 @pytest.mark.parametrize(
     "model,location",

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -94,7 +94,7 @@ def test_init() -> None:
         mock_warning.assert_called_once()
         call_args = mock_warning.call_args[0][0]
         assert "Unexpected argument 'safety_setting'" in call_args
-        assert "Did you mean 'safety_settings'?" in call_args
+        assert "Did you mean: 'safety_settings'?" in call_args
 
 
 @pytest.mark.parametrize(

--- a/libs/vertexai/tests/unit_tests/test_llm.py
+++ b/libs/vertexai/tests/unit_tests/test_llm.py
@@ -23,6 +23,22 @@ def test_model_name() -> None:
         assert llm.model_name == "gemini-pro"
         assert llm.max_output_tokens == 10
 
+    # Test initialization with an invalid argument to check warning
+    with patch("langchain_google_vertexai.llms.logger.warning") as mock_warning:
+        llm = VertexAI(
+            model_name="gemini-pro",
+            project="test-project",
+            safety_setting={
+                "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
+            },  # Invalid arg
+        )
+        assert llm.model_name == "gemini-pro"
+        assert llm.project == "test-project"
+        mock_warning.assert_called_once()
+        call_args = mock_warning.call_args[0][0]
+        assert "Unexpected argument 'safety_setting'" in call_args
+        assert "Did you mean: 'safety_settings'?" in call_args
+
 
 def test_tuned_model_name() -> None:
     llm = VertexAI(


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

Add warnings for invalid keyword arguments during initialization of `ChatGoogleGenerativeAI`, `ChatVertexAI`, `GoogleGenerativeAI`, and `VertexAI`. This prevents silent failures when users provide incorrect arguments (e.g `safety_setting` instead of `safety_settings`). Improves usability and debugging across both chat and LLM models in the `genai` and `vertexai` packages.

## Relevant issues

Fixes #556

## Type

🐛 Bug Fix
✅ Test

## Changes

- `genai/langchain_google_genai/chat_models.py`: Added `__init__` with argument validation for `ChatGoogleGenerativeAI`.
- `genai/langchain_google_genai/llms.py`: Added `__init__` with argument validation for `GoogleGenerativeAI`.
- `vertexai/langchain_google_vertexai/chat_models.py`: Modified `__init__` in `ChatVertexAI` to include validation.
- `vertexai/langchain_google_vertexai/llms.py`: Modified `__init__` in `VertexAI` to include validation.
- `genai/tests/unit_tests/test_chat_models.py`: Updated `test_integration_initialization()` to test warnings for `ChatGoogleGenerativeAI`.
- `genai/tests/unit_tests/test_llms.py`: Updated `test_tracing_params()` to test warnings for `GoogleGenerativeAI`.
- `vertexai/tests/unit_tests/test_chat_models.py`: Updated `test_init()` to test warnings for `ChatVertexAI`.
- `vertexai/tests/unit_tests/test_llm.py`: Updated `test_model_name()` to test warnings for `VertexAI`.

All changes use `logger.warning` with `get_close_matches` to suggest valid arguments based on `self.model_fields`.

## Testing

- **Test Procedure**:
  - Added unit tests in `test_integration_initialization()`, `test_tracing_params()`, `test_init()`, and `test_model_name()` to verify warnings for invalid arguments (e.g `safety_setting`).
  - Used `unittest.mock.patch` to mock `logger.warning` and assert message content.
- **Test Result**:
  - Tests confirm initialization succeeds and warnings are logged with correct suggestions (e.g "Did you mean: 'safety_settings'?").
  - Run corresponding tests to validate.

## Note
Results with VertexAI and ChatVertexAI

```python
from langchain_google_vertexai import VertexAI, ChatVertexAI, HarmCategory, HarmBlockThreshold

gemini_safety_settings = {
    HarmCategory.HARM_CATEGORY_UNSPECIFIED: HarmBlockThreshold.BLOCK_NONE,
    HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_NONE,
}
GEMINI = VertexAI(
    model_name="gemini-1.5-pro-002",
    temperature=0,
    safety_setting=gemini_safety_settings,
)

GEMINI2 = ChatVertexAI(
    model_name="gemini-1.5-pro-002",
    temperature=0,
    safety_setting=gemini_safety_settings,
)
```

Output
```
Unexpected argument 'safety_setting' provided to VertexAI. Did you mean: 'safety_settings'?
Unexpected argument 'safety_setting' provided to ChatVertexAI. Did you mean: 'safety_settings'?
```

Results with GoogleGenerativeAI and ChatGoogleGenerativeAI

```python
from langchain_google_genai import GoogleGenerativeAI, ChatGoogleGenerativeAI, HarmCategory, HarmBlockThreshold

gemini_safety_settings = {
    HarmCategory.HARM_CATEGORY_UNSPECIFIED: HarmBlockThreshold.BLOCK_NONE,
    HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_NONE,
}

GEMINI = GoogleGenerativeAI(
    model="gemini-1.5-pro-002",
    temperature=0,
    sdhshkds=gemini_safety_settings,
)

GEMINI2 = ChatGoogleGenerativeAI(
    model="gemini-1.5-pro-002",
    temperature=0,
    dskdksjdsk=gemini_safety_settings,
)
```

Output
```
Unexpected argument 'sdhshkds' provided to GoogleGenerativeAI.
Unexpected argument 'dskdksjdsk' provided to ChatGoogleGenerativeAI.
```


