### PR TITLE
vertexai: Fixed content coercion while streaming Claude thinking response

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
@@ -404,3 +404,20 @@ def _tools_in_params(params: dict) -> bool:
     return "tools" in params or (
         "extra_body" in params and params["extra_body"].get("tools")
     )
+
+
+def _thinking_in_params(params: dict) -> bool:
+    return params.get("thinking", {}).get("type") == "enabled"
+
+
+def _documents_in_params(params: dict) -> bool:
+    for message in params.get("messages", []):
+        if isinstance(message.get("content"), list):
+            for block in message["content"]:
+                if (
+                    isinstance(block, dict)
+                    and block.get("type") == "document"
+                    and block.get("citations", {}).get("enabled")
+                ):
+                    return True
+    return False

--- a/libs/vertexai/langchain_google_vertexai/model_garden.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden.py
@@ -55,8 +55,10 @@ from langchain_google_vertexai._anthropic_parsers import (
     _extract_tool_calls,
 )
 from langchain_google_vertexai._anthropic_utils import (
+    _documents_in_params,
     _format_messages_anthropic,
     _make_message_chunk_from_anthropic_event,
+    _thinking_in_params,
     _tools_in_params,
     convert_to_anthropic_tool,
 )
@@ -378,7 +380,11 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
             return self.client.messages.create(**params, stream=True)
 
         stream = _stream_with_retry(**params)
-        coerce_content_to_string = not _tools_in_params(params)
+        coerce_content_to_string = (
+            not _tools_in_params(params)
+            and not _documents_in_params(params)
+            and not _thinking_in_params(params)
+        )
         for event in stream:
             msg = _make_message_chunk_from_anthropic_event(
                 event,
@@ -414,7 +420,11 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
             return await self.async_client.messages.create(**params, stream=True)
 
         stream = await _astream_with_retry(**params)
-        coerce_content_to_string = not _tools_in_params(params)
+        coerce_content_to_string = (
+            not _tools_in_params(params)
+            and not _documents_in_params(params)
+            and not _thinking_in_params(params)
+        )
         async for event in stream:
             msg = _make_message_chunk_from_anthropic_event(
                 event,

--- a/libs/vertexai/tests/integration_tests/test_model_garden.py
+++ b/libs/vertexai/tests/integration_tests/test_model_garden.py
@@ -143,6 +143,30 @@ def test_anthropic_stream() -> None:
 
 
 @pytest.mark.extended
+def test_anthropic_thinking_stream() -> None:
+    project = os.environ["PROJECT_ID"]
+    location = "us-east5"
+    model = ChatAnthropicVertex(
+        project=project,
+        location=location,
+        model_kwargs={
+            "thinking": {
+                "type": "enabled",
+                "budget_tokens": 1024 # budget tokens >= 1024
+            },
+        },
+        max_tokens=2048, # max_tokens must be greater than budget_tokens
+    )
+    question = (
+        "Hello, could you recommend a good movie for me to watch this evening, please?"
+    )
+    message = HumanMessage(content=question)
+    sync_response = model.stream([message], model="claude-3-7-sonnet@20250219")
+    for chunk in sync_response:
+        assert isinstance(chunk, AIMessageChunk)
+
+
+@pytest.mark.extended
 async def test_anthropic_async() -> None:
     project = os.environ["PROJECT_ID"]
     location = "us-central1"

--- a/libs/vertexai/tests/integration_tests/test_model_garden.py
+++ b/libs/vertexai/tests/integration_tests/test_model_garden.py
@@ -152,10 +152,10 @@ def test_anthropic_thinking_stream() -> None:
         model_kwargs={
             "thinking": {
                 "type": "enabled",
-                "budget_tokens": 1024 # budget tokens >= 1024
+                "budget_tokens": 1024,  # budget tokens >= 1024
             },
         },
-        max_tokens=2048, # max_tokens must be greater than budget_tokens
+        max_tokens=2048,  # max_tokens must be greater than budget_tokens
     )
     question = (
         "Hello, could you recommend a good movie for me to watch this evening, please?"

--- a/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
@@ -16,9 +16,11 @@ from langchain_core.messages import (
 from langchain_core.messages.tool import tool_call as create_tool_call
 
 from langchain_google_vertexai._anthropic_utils import (
+    _documents_in_params,
     _format_message_anthropic,
     _format_messages_anthropic,
     _make_message_chunk_from_anthropic_event,
+    _thinking_in_params,
 )
 
 
@@ -872,3 +874,83 @@ def test_make_thinking_message_chunk_from_anthropic_event() -> None:
     )
     assert isinstance(thinking_chunk, AIMessageChunk)
     assert isinstance(signature_chunk, AIMessageChunk)
+
+def test_thinking_in_params_true() -> None:
+    """Test _thinking_in_params when thinking.type is 'enabled'."""
+    params = {
+        "thinking": {
+            "type": "enabled",
+            "budget_tokens": 1024
+        }
+    }
+
+    assert _thinking_in_params(params)
+
+def test_thinking_in_params_false_different_type() -> None:
+    """Test _thinking_in_params when thinking.type is 'disabled'."""
+    params = {
+        "thinking": {
+            "type": "disabled",
+            "budget_tokens": 1024
+        }
+    }
+
+    assert not _thinking_in_params(params)
+
+def test_documents_in_params_true() -> None:
+    """Test _documents_in_params when document with citations is enabled."""
+    params = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "document",
+                        "citations": {
+                            "enabled": True
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+    assert _documents_in_params(params)
+
+def test_documents_in_params_false_citations_disabled() -> None:
+    """Test _documents_in_params when citations are not enabled."""
+    params = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "document",
+                        "citations": {
+                            "enabled": False
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+    assert not _documents_in_params(params)
+
+def test_documents_in_params_false_no_document() -> None:
+    """Test _documents_in_params when there are no documents."""
+    params = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Hello"
+                    }
+                ]
+            }
+        ]
+    }
+
+    assert not _documents_in_params(params)

--- a/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
@@ -875,27 +875,20 @@ def test_make_thinking_message_chunk_from_anthropic_event() -> None:
     assert isinstance(thinking_chunk, AIMessageChunk)
     assert isinstance(signature_chunk, AIMessageChunk)
 
+
 def test_thinking_in_params_true() -> None:
     """Test _thinking_in_params when thinking.type is 'enabled'."""
-    params = {
-        "thinking": {
-            "type": "enabled",
-            "budget_tokens": 1024
-        }
-    }
+    params = {"thinking": {"type": "enabled", "budget_tokens": 1024}}
 
     assert _thinking_in_params(params)
 
+
 def test_thinking_in_params_false_different_type() -> None:
     """Test _thinking_in_params when thinking.type is 'disabled'."""
-    params = {
-        "thinking": {
-            "type": "disabled",
-            "budget_tokens": 1024
-        }
-    }
+    params = {"thinking": {"type": "disabled", "budget_tokens": 1024}}
 
     assert not _thinking_in_params(params)
+
 
 def test_documents_in_params_true() -> None:
     """Test _documents_in_params when document with citations is enabled."""
@@ -903,19 +896,13 @@ def test_documents_in_params_true() -> None:
         "messages": [
             {
                 "role": "user",
-                "content": [
-                    {
-                        "type": "document",
-                        "citations": {
-                            "enabled": True
-                        }
-                    }
-                ]
+                "content": [{"type": "document", "citations": {"enabled": True}}],
             }
         ]
     }
 
     assert _documents_in_params(params)
+
 
 def test_documents_in_params_false_citations_disabled() -> None:
     """Test _documents_in_params when citations are not enabled."""
@@ -923,34 +910,18 @@ def test_documents_in_params_false_citations_disabled() -> None:
         "messages": [
             {
                 "role": "user",
-                "content": [
-                    {
-                        "type": "document",
-                        "citations": {
-                            "enabled": False
-                        }
-                    }
-                ]
+                "content": [{"type": "document", "citations": {"enabled": False}}],
             }
         ]
     }
 
     assert not _documents_in_params(params)
 
+
 def test_documents_in_params_false_no_document() -> None:
     """Test _documents_in_params when there are no documents."""
     params = {
-        "messages": [
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": "Hello"
-                    }
-                ]
-            }
-        ]
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
     }
 
     assert not _documents_in_params(params)


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->


## PR Description

<!-- e.g. "Implement user authentication feature" -->
While streaming Claude 3.7 Thinking mode responses, langchain-core throws the following error when attempting to merge the chunks:
```
content='' additional_kwargs={} response_metadata={} id='xyz' usage_metadata={'input_tokens': 50, 'output_tokens': 0, 'total_tokens': 50}
content=[{'thinking': 'I', 'type': 'thinking', 'index': 0}] additional_kwargs={} response_metadata={} id='xyz'
content=[{'thinking': ' need to solve for x in the equation 3', 'type': 'thinking', 'index': 0}] additional_kwargs={} response_metadata={} id='xyz'
Traceback (most recent call last):
  File "claude_3_vertex.py", line 75, in <module>
    for chunk in llm.stream(input=[HumanMessage(content=chat_text)]):
  File ".env/lib64/python3.11/site-packages/langchain_core/language_models/chat_models.py", line 439, in stream
    generation += chunk
  File ".env/lib64/python3.11/site-packages/langchain_core/outputs/chat_generation.py", line 105, in __add__
    message=self.message + other.message,
            ~~~~~~~~~~~~~^~~~~~~~~~~~~~~
  File ".env/lib64/python3.11/site-packages/langchain_core/messages/ai.py", line 398, in __add__
    return add_ai_message_chunks(self, other)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".env/lib64/python3.11/site-packages/langchain_core/messages/ai.py", line 415, in add_ai_message_chunks
    content = merge_content(left.content, *(o.content for o in others))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".env/lib64/python3.11/site-packages/langchain_core/messages/base.py", line 169, in merge_content
    merged = merge_lists(cast(list, merged), content)  # type: ignore
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".env/lib64/python3.11/site-packages/langchain_core/utils/_merge.py", line 92, in merge_lists
    to_merge = [
               ^
  File ".env/lib64/python3.11/site-packages/langchain_core/utils/_merge.py", line 95, in <listcomp>
    if e_left["index"] == e["index"]
       ~~~~~~^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```

This occurs because `coerce_content_to_string` is `False`, even though Thinking mode is enabled. Copying over the implementation from [langchain-anthropic](https://github.com/langchain-ai/langchain/blob/9d3262c7aa9738494c684aac05248eb7e3a7a683/libs/partners/anthropic/langchain_anthropic/chat_models.py#L1589-L1603), this PR aims to resolve the error.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes(optional)

<!-- List of changes -->

## Testing(optional)

<!-- Test procedure -->
<!-- Test result -->

## Note(optional)

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
