### PR TITLE
genai: remove automatic 'models/' prefix addition for tuned type models

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -927,7 +927,9 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         if self.top_k is not None and self.top_k <= 0:
             raise ValueError("top_k must be positive")
 
-        if not self.model.startswith("models/"):
+        if not any(
+            self.model.startswith(prefix) for prefix in ("models/", "tunedModels/")
+        ):
             self.model = f"models/{self.model}"
 
         additional_headers = self.additional_headers or {}


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

<!-- e.g. "Implement user authentication feature" -->
Fine tuned Gemini models (created by following [this tutorial](https://ai.google.dev/gemini-api/docs/model-tuning/tutorial?lang=python)) could be loaded and called via the Python Genai SDK but could not via ChatGoogleGenerativeAI before this fix, so they could not be used with Langchain. Now they can. 

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #631 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Testing

Test script:
```
from google import genai
from google.genai import types
from langchain_google_genai import ChatGoogleGenerativeAI

client = genai.Client()

def call_tuned_model_langchain(model, input_text):
    model=client.models.get(model=model)
    print(model.name)
    llm = ChatGoogleGenerativeAI(model=model.name)
    response = llm.invoke(input_text)
    print(response.content)

call_tuned_model_langchain("tunedModels/nextnumberseries-model-cuka8h2kv06n", "seven") 
```

Error trace before:
```
Traceback (most recent call last):
  File "C:\Users\Ratish Panda\dev\GoogleGenAI_open_source\langchain-google\temporary.py", line 112, in <module>
    call_tuned_model_langchain("tunedModels/nextnumberseries-model-cuka8h2kv06n", "seven")
  File "C:\Users\Ratish Panda\dev\GoogleGenAI_open_source\langchain-google\temporary.py", line 109, in call_tuned_model_langchain
    response = llm.invoke(input_text)
  File "C:\Users\Ratish Panda\dev\GoogleGenAI_open_source\langchain-google\libs\genai\langchain_google_genai\chat_models.py", line 1029, in invoke
    return super().invoke(input, config, stop=stop, **kwargs)
  File "C:\Users\Ratish Panda\.conda\envs\langchain\lib\site-packages\langchain_core\language_models\chat_models.py", line 307, in invoke
    self.generate_prompt(
  File "C:\Users\Ratish Panda\.conda\envs\langchain\lib\site-packages\langchain_core\language_models\chat_models.py", line 843, in generate_prompt
    return self.generate(prompt_messages, stop=stop, callbacks=callbacks, **kwargs)
  File "C:\Users\Ratish Panda\.conda\envs\langchain\lib\site-packages\langchain_core\language_models\chat_models.py", line 683, in generate
    self._generate_with_cache(
  File "C:\Users\Ratish Panda\.conda\envs\langchain\lib\site-packages\langchain_core\language_models\chat_models.py", line 908, in _generate_with_cache
    result = self._generate(
  File "C:\Users\Ratish Panda\dev\GoogleGenAI_open_source\langchain-google\libs\genai\langchain_google_genai\chat_models.py", line 1096, in _generate
    response: GenerateContentResponse = _chat_with_retry(
  File "C:\Users\Ratish Panda\dev\GoogleGenAI_open_source\langchain-google\libs\genai\langchain_google_genai\chat_models.py", line 206, in _chat_with_retry
    return _chat_with_retry(**kwargs)
  File "C:\Users\Ratish Panda\.conda\envs\langchain\lib\site-packages\tenacity\__init__.py", line 336, in wrapped_f
    return copy(f, *args, **kw)
  File "C:\Users\Ratish Panda\.conda\envs\langchain\lib\site-packages\tenacity\__init__.py", line 475, in __call__
    do = self.iter(retry_state=retry_state)
  File "C:\Users\Ratish Panda\.conda\envs\langchain\lib\site-packages\tenacity\__init__.py", line 376, in iter
    result = action(retry_state)
  File "C:\Users\Ratish Panda\.conda\envs\langchain\lib\site-packages\tenacity\__init__.py", line 398, in <lambda>
    self._add_action_func(lambda rs: rs.outcome.result())
  File "C:\Users\Ratish Panda\.conda\envs\langchain\lib\concurrent\futures\_base.py", line 439, in result
    return self.__get_result()
  File "C:\Users\Ratish Panda\.conda\envs\langchain\lib\concurrent\futures\_base.py", line 391, in __get_result
    raise self._exception
  File "C:\Users\Ratish Panda\.conda\envs\langchain\lib\site-packages\tenacity\__init__.py", line 478, in __call__
    result = fn(*args, **kwargs)
  File "C:\Users\Ratish Panda\dev\GoogleGenAI_open_source\langchain-google\libs\genai\langchain_google_genai\chat_models.py", line 200, in _chat_with_retry
    raise ChatGoogleGenerativeAIError(
langchain_google_genai.chat_models.ChatGoogleGenerativeAIError: Invalid argument provided to Gemini: 400 * GenerateContentRequest.model: unexpected model name format
```

Output after:
```
tunedModels/nextnumberseries-model-cuka8h2kv06n
eight
```



<!-- Test procedure -->
<!-- Test result -->
