### PR TITLE
vertexai: Fix resolving of references in ChatVertexAI.with_structured_output

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/functions_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/functions_utils.py
@@ -112,7 +112,7 @@ def _format_json_schema_to_gapic(
     """Format a JSON schema from a Pydantic V2 BaseModel to gapic."""
     converted_schema: Dict[str, Any] = {}
     for key, value in schema.items():
-        if key == "definitions":
+        if key == "$defs":
             continue
         elif key == "items":
             converted_schema["items"] = _format_json_schema_to_gapic(
@@ -157,7 +157,10 @@ def _format_json_schema_to_gapic(
 def _dict_to_gapic_schema(
     schema: Dict[str, Any], pydantic_version: str = "v1"
 ) -> gapic.Schema:
+    # Resolve refs in schema because $refs and $defs are not supported
+    # by the Gemini API.
     dereferenced_schema = dereference_refs(schema)
+
     if pydantic_version == "v1":
         formatted_schema = _format_json_schema_to_gapic_v1(dereferenced_schema)
     else:


### PR DESCRIPTION
## PR Description

When using a JSON schema with references, the method `langchain_google_vertexai.chat_models.ChatVertexAI.with_structured_output` logs a warning, stating that the key `'$defs’` is not supported. This holds if the JSON schema is passed as a dictionary or a typed dict type, or if it is passed as a Pydantic model with the (default) keyword argument `method = None`. (The case of a Pydantic model with the keyword argument `method="json_mode"` is already handled.)

## Relevant issues

Fixes [#659](https://github.com/langchain-ai/langchain-google/issues/659).

## Type

🐛 Bug Fix

## Changes(optional)

- The implementation of the method `langchain_google_vertexai.chat_models.ChatVertexAI.with_structured_output` is changed such that in the case `method="json_mode"`, the helper function `langchain_google_vertexai._utils.replace_defs_in_schema` is called in all cases for the type of the parameter `schema` (not only if it is a Pydantic model).
- ~The implementation of the helper function `langchain_google_vertexai.function_utils._dict_to_gapic_schema` is changed such that an item for the key `"$defs"` in the parameter `schema` is deleted if it exists after resolving references.~ The implementation of the helper function `langchain_google_vertexai.function_utils._format_json_schema_to_gapic` is fixed such that the key `"$defs"` in the parameter `schema` is silently ignored (instead of `"definitions“`, which is the Pydantic v1 variant). (Remark: This covers the case `method=None` in `langchain_google_vertexai.chat_models.ChatVertexAI.with_structured_output`.)
- The method `langchain_google_vertexai.chat_models.ChatVertexAI.with_structured_output` is changed such that a value error is raised if the parameter `schema` is neither a dictionary nor a Pydantic model.