### PR TITLE
doc(vertexai): typo in doc

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/__init__.py
+++ b/libs/vertexai/langchain_google_vertexai/__init__.py
@@ -4,7 +4,7 @@ This module contains the LangChain integrations for Vertex AI service - Google f
 
 **Supported integrations**
 
-1. Google's founational models: Gemini family, Codey, embeddings - `ChatVertexAI`, `VertexAI`, `VertexAIEmbeddings`.
+1. Google's foundational models: Gemini family, Codey, embeddings - `ChatVertexAI`, `VertexAI`, `VertexAIEmbeddings`.
 2. Other Google's foundational models: Imagen - `VertexAIImageCaptioning`, `VertexAIImageCaptioningChat`, `VertexAIImageEditorChat`, `VertexAIImageGeneratorChat`, `VertexAIVisualQnAChat`.
 3. Third-party foundational models available as a an API (mdel-as-a-service) on Vertex Model Garden (Mistral, Llama, Anthropic) - `model_garden.ChatAnthropicVertex`, `model_garden_maas.VertexModelGardenLlama`, `model_garden_maas.VertexModelGardenMistral`.
 4. Third-party foundational models deployed on Vertex AI endpoints from Vertex Model Garden or Hugginface - `VertexAIModelGarden`.


### PR DESCRIPTION
## PR Description

📖 Documentation: fix typo in `libs/vertexai/langchain_google_vertexai/__init__.py` — corrected "foundational" spelling

## Relevant issues

N/A

## Type

📖 Documentation

## Changes (optional)

- Fixed a typo in the word “foundational” under the Supported Integrations section.

## Testing (optional)

N/A — typo fix only, no code changes.

## Note (optional)

No functional changes introduced.