### PR TITLE
vertexai: fix handling of single string in add_texts

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/vectorstores/vectorstores.py
+++ b/libs/vertexai/langchain_google_vertexai/vectorstores/vectorstores.py
@@ -281,7 +281,11 @@ class _BaseVertexAIVectorStore(VectorStore):
 
         # Makes sure is a list and can get the length, should we support iterables?
         # metadata is a list so probably not?
-        texts = list(texts)
+        if isinstance(texts, str):
+            texts = [texts]
+        else:
+            texts = list(texts)
+
         embeddings = self._embeddings.embed_documents(texts)
 
         return self.add_texts_with_embeddings(

--- a/libs/vertexai/tests/unit_tests/test_vectorstores.py
+++ b/libs/vertexai/tests/unit_tests/test_vectorstores.py
@@ -88,6 +88,20 @@ def test_add_texts_with_custom_ids(mocker):
         VectorStore.add_texts(texts=texts, ids=["Id1", "Id2", "Id2"])
 
 
+def test_add_texts_with_single_string():
+    """Test that a single string input is properly handled as one document."""
+    single_string = "This is a single string"
+
+    VectorStore = object.__new__(_BaseVertexAIVectorStore)
+    VectorStore._document_storage = MagicMock()
+    VectorStore._embeddings = MagicMock()
+    VectorStore._searcher = MagicMock()
+
+    VectorStore.add_texts(texts=single_string)
+
+    VectorStore._embeddings.embed_documents.assert_called_once_with([single_string])
+
+
 def test_add_texts_with_embeddings():
     texts = ["Text1", "Text2"]
     embeddings = [[0.1, 0.2, 1.0], [1.0, 0.0, 1.0]]


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

<!-- e.g. "Implement user authentication feature" -->
Fix an issue where passing a single string to `add_texts` would split it into individual characters instead of treating it as a single document. This happens because Python strings are iterable, so `list(texts)` would convert a string like "hello" into `["h", "e", "l", "l", "o"]`. Added a check to automatically wrap a single string in a list.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
✅ Test

## Changes(optional)

<!-- List of changes -->
- Added type checking in `add_texts` to detect single strings and wrap them in a list
- Added unit test to verify the fix works as expected

## Testing(optional)

<!-- Test procedure -->
Added a new unit test `test_add_texts_with_single_string` that verifies a single string gets properly wrapped in a list before being processed.
<!-- Test result -->

## Note(optional)

<!-- Information about the errors fixed by PR -->
This bug would cause quiet failures where users passing a single string would get unexpected results - the string would be split into individual characters and each character would be embedded as a separate document. The fix ensures a more intuitive API behavior where strings are handled as single documents.
<!-- Remaining issue or something -->
<!-- Other information about PR -->
