### PR TITLE
fix(genai): Fix nested array schema conversion for function calling

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -384,6 +384,8 @@ def _get_items_from_schema(schema: Union[Dict, List, str]) -> Dict[str, Any]:
         items["type_"] = _get_type_from_schema(schema)
         if items["type_"] == glm.Type.OBJECT and "properties" in schema:
             items["properties"] = _get_properties_from_schema_any(schema["properties"])
+        if items["type_"] == glm.Type.ARRAY and "items" in schema:
+            items["items"] = _format_json_schema_to_gapic(schema["items"])
         if "title" in schema or "description" in schema:
             items["description"] = (
                 schema.get("description") or schema.get("title") or ""


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

Fixes a bug in function calling schema generation where parameters with doubly nested lists (e.g., `List[List[str]]` or `List[List[Any]]`) resulted in an invalid GAPIC schema, causing a `400 Invalid argument` error from the Gemini API.

The error message typically indicated a missing field deep within the nested structure: `...properties[<param>].items.properties[<nested_param>].items.items: missing field.`

The root cause was traced to the `_get_items_from_schema` helper function. When processing the schema for an array item (`type: ARRAY`), it did not correctly handle cases where the item's schema (`items` definition) was *itself* an array. It failed to recursively apply the main formatting logic (`_format_json_schema_to_gapic`) to the nested `items` definition.

This PR modifies `_get_items_from_schema` to specifically check if an item is an array and has its own `items` definition. If so, it now correctly calls `_format_json_schema_to_gapic` on the nested `items` schema, ensuring the proper GAPIC structure is generated for doubly (and potentially deeper) nested lists.

## Relevant issues

Fixes #881 

## Type

🐛 Bug Fix

## Changes

- Modified `_get_items_from_schema` in `langchain_google_genai._function_utils` to correctly format the schema for nested array items by recursively calling `_format_json_schema_to_gapic`.
- Added `test_tool_with_doubly_nested_list_param` to `tests/unit_tests/test_function_utils.py` to cover this specific scenario.

## Testing(optional)

- All existing tests in `tests/unit_tests/test_function_utils.py` pass after the fix.
- The new test `test_tool_with_doubly_nested_list_param` specifically validates the fix for `List[List[str]]` parameters and passes.
- Ran `make format`, `make lint`, `make test` in the `libs/genai` directory successfully.


