### PR TITLE
genai, vertexai[patch]: support model_kwargs

### DIFF
--- a/libs/genai/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/genai/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -19,6 +19,10 @@
       'max_output_tokens': 100,
       'max_retries': 2,
       'model': 'models/gemini-1.0-pro-001',
+      'model_kwargs': dict({
+        'stop': list([
+        ]),
+      }),
       'n': 1,
       'temperature': 0.0,
       'timeout': 60.0,
@@ -48,6 +52,10 @@
       'max_output_tokens': 100,
       'max_retries': 2,
       'model': 'models/gemini-1.5-pro-001',
+      'model_kwargs': dict({
+        'stop': list([
+        ]),
+      }),
       'n': 1,
       'temperature': 0.0,
       'timeout': 60.0,

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -749,3 +749,25 @@ def test_temperature_range_model_validation() -> None:
 
     with pytest.raises(ValueError):
         ChatGoogleGenerativeAI(model="gemini-2.0-flash", temperature=-0.5)
+
+
+def test_model_kwargs() -> None:
+    """Test we can transfer unknown params to model_kwargs."""
+    llm = ChatGoogleGenerativeAI(
+        model="my-model",
+        convert_system_message_to_human=True,
+        model_kwargs={"foo": "bar"},
+    )
+    assert llm.model == "models/my-model"
+    assert llm.convert_system_message_to_human is True
+    assert llm.model_kwargs == {"foo": "bar"}
+
+    with pytest.warns(match="transferred to model_kwargs"):
+        llm = ChatGoogleGenerativeAI(
+            model="my-model",
+            convert_system_message_to_human=True,
+            foo="bar",
+        )
+    assert llm.model == "models/my-model"
+    assert llm.convert_system_message_to_human is True
+    assert llm.model_kwargs == {"foo": "bar"}

--- a/libs/vertexai/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/vertexai/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -15,6 +15,10 @@
       'max_output_tokens': 100,
       'max_retries': 2,
       'model_family': '2',
+      'model_kwargs': dict({
+        'api_key': 'test',
+        'timeout': 60,
+      }),
       'model_name': 'gemini-1.5-pro-001',
       'n': 1,
       'perform_literal_eval_on_string_raw_content': True,

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -1206,6 +1206,28 @@ def test_init_client_with_custom_model_kwargs() -> None:
     assert default_params["thinking"] == {"type": "enabled", "budget_tokens": 1024}
 
 
+def test_model_kwargs_chat_vertex() -> None:
+    """Test we can transfer unknown params to model_kwargs."""
+    llm = ChatVertexAI(
+        model="my-model",
+        convert_system_message_to_human=True,
+        model_kwargs={"foo": "bar"},
+    )
+    assert llm.model_name == "my-model"
+    assert llm.convert_system_message_to_human is True
+    assert llm.model_kwargs == {"foo": "bar"}
+
+    with pytest.warns(match="transferred to model_kwargs"):
+        llm = ChatVertexAI(
+            model="my-model",
+            convert_system_message_to_human=True,
+            foo="bar",
+        )
+    assert llm.model_name == "my-model"
+    assert llm.convert_system_message_to_human is True
+    assert llm.model_kwargs == {"foo": "bar"}
+
+
 def test_anthropic_format_output() -> None:
     """Test format output handles different content structures correctly."""
 


### PR DESCRIPTION
Catch params on init that are invalid according to Pydantic and store in model_kwargs.