### PR TITLE
genai: fix issue where newlines were stripped during streaming

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -463,7 +463,7 @@ def _parse_response_candidate(
         try:
             text: Optional[str] = part.text
             # Remove erroneous newline character if present
-            if text is not None:
+            if not streaming and text is not None:
                 text = text.rstrip("\n")
         except AttributeError:
             text = None


### PR DESCRIPTION
## PR Description

Do not remove erroneous newline characters in streaming mode.
If I generate python code, then removing new line in the end of chunk will cause invalid code

## Type

🐛 Bug Fix
