### PR TITLE
fix: Trace model name without `models/` prefix

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1193,9 +1193,11 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         """Get standard params for tracing."""
         params = self._get_invocation_params(stop=stop, **kwargs)
         models_prefix = "models/"
-        ls_model_name = self.model[len(models_prefix):]
+        ls_model_name = (
+            self.model[len(models_prefix) :]
             if self.model and self.model.startswith(models_prefix)
             else self.model
+        )
         ls_params = LangSmithParams(
             ls_provider="google_genai",
             ls_model_name=ls_model_name,

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1192,9 +1192,13 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     ) -> LangSmithParams:
         """Get standard params for tracing."""
         params = self._get_invocation_params(stop=stop, **kwargs)
+        models_prefix = "models/"
+        ls_model_name = self.model[len(models_prefix):]
+            if self.model and self.model.startswith(models_prefix)
+            else self.model
         ls_params = LangSmithParams(
             ls_provider="google_genai",
-            ls_model_name=self.model,
+            ls_model_name=ls_model_name,
             ls_model_type="chat",
             ls_temperature=params.get("temperature", self.temperature),
         )

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -49,7 +49,7 @@ def test_integration_initialization() -> None:
     ls_params = llm._get_ls_params()
     assert ls_params == {
         "ls_provider": "google_genai",
-        "ls_model_name": "models/gemini-nano",
+        "ls_model_name": "gemini-nano",
         "ls_model_type": "chat",
         "ls_temperature": 0.7,
     }
@@ -62,7 +62,7 @@ def test_integration_initialization() -> None:
     ls_params = llm._get_ls_params()
     assert ls_params == {
         "ls_provider": "google_genai",
-        "ls_model_name": "models/gemini-nano",
+        "ls_model_name": "gemini-nano",
         "ls_model_type": "chat",
         "ls_temperature": 0.7,
         "ls_max_tokens": 10,
@@ -735,7 +735,7 @@ def test_temperature_range_pydantic_validation() -> None:
     ls_params = llm._get_ls_params()
     assert ls_params == {
         "ls_provider": "google_genai",
-        "ls_model_name": "models/gemini-2.0-flash",
+        "ls_model_name": "gemini-2.0-flash",
         "ls_model_type": "chat",
         "ls_temperature": 1.5,
     }


### PR DESCRIPTION
Makes the traced value the same as Vertex