### PR TITLE
community: Unify google service authentications and move to parent's _utils file

### DIFF
--- a/libs/community/langchain_google_community/_utils.py
+++ b/libs/community/langchain_google_community/_utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime
 from importlib import metadata
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
@@ -18,7 +17,6 @@ if TYPE_CHECKING:
     from google.oauth2.credentials import Credentials
     from google.oauth2.service_account import Credentials as ServiceCredentials
     from google_auth_oauthlib.flow import InstalledAppFlow
-    from googleapiclient.discovery import Resource
     from googleapiclient.discovery import build as build_resource
 
 logger = logging.getLogger(__name__)

--- a/libs/community/langchain_google_community/_utils.py
+++ b/libs/community/langchain_google_community/_utils.py
@@ -1,9 +1,8 @@
 """Utilities to init Vertex AI."""
-
+from __future__ import annotations
 import os
 from importlib import metadata
 from typing import Optional, Tuple
-from __future__ import annotations
 
 import logging
 import os

--- a/libs/community/langchain_google_community/_utils.py
+++ b/libs/community/langchain_google_community/_utils.py
@@ -96,3 +96,13 @@ def import_installed_app_flow() -> InstalledAppFlow:
         module_name="google_auth_oauthlib.flow", pip_name="google-auth-oauthlib"
     ).InstalledAppFlow
 
+
+def import_googleapiclient_resource_builder() -> build_resource:
+    """Import googleapiclient.discovery.build function.
+
+    Returns:
+        build_resource: googleapiclient.discovery.build function.
+    """
+    return guard_import(
+        module_name="googleapiclient.discovery", pip_name="google-api-python-client"
+    ).build

--- a/libs/community/langchain_google_community/_utils.py
+++ b/libs/community/langchain_google_community/_utils.py
@@ -64,3 +64,23 @@ def get_client_info(module: Optional[str] = None) -> "ClientInfo":
         client_library_version=client_library_version,
         user_agent=user_agent,
     )
+
+
+def import_google() -> Tuple[Request, Credentials, ServiceCredentials]:
+    """Import google libraries.
+
+    Returns:
+        Tuple[Request, Credentials]: Request and Credentials classes.
+    """
+    return (
+        guard_import(
+            module_name="google.auth.transport.requests",
+            pip_name="google-auth",
+        ).Request,
+        guard_import(
+            module_name="google.oauth2.credentials", pip_name="google-auth"
+        ).Credentials,
+        guard_import(
+            module_name="google.oauth2.service_account", pip_name="google-auth"
+        ).ServiceCredentials
+    )

--- a/libs/community/langchain_google_community/_utils.py
+++ b/libs/community/langchain_google_community/_utils.py
@@ -84,3 +84,15 @@ def import_google() -> Tuple[Request, Credentials, ServiceCredentials]:
             module_name="google.oauth2.service_account", pip_name="google-auth"
         ).ServiceCredentials
     )
+
+
+def import_installed_app_flow() -> InstalledAppFlow:
+    """Import InstalledAppFlow class.
+
+    Returns:
+        InstalledAppFlow: InstalledAppFlow class.
+    """
+    return guard_import(
+        module_name="google_auth_oauthlib.flow", pip_name="google-auth-oauthlib"
+    ).InstalledAppFlow
+

--- a/libs/community/langchain_google_community/_utils.py
+++ b/libs/community/langchain_google_community/_utils.py
@@ -108,27 +108,23 @@ def import_googleapiclient_resource_builder() -> build_resource:
     ).build
 
 
-DEFAULT_SCOPES = ["https://www.googleapis.com/auth/calendar",
-                  "https://mail.google.com/"]
 DEFAULT_CREDS_TOKEN_FILE = "token.json"
 DEFAULT_CLIENT_SECRETS_FILE = "credentials.json"
 DEFAULT_SERVICE_ACCOUNT_FILE = "service_account.json"
-DEFAULT_SERVICE_SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
 
 
 def get_google_credentials(
+    scopes: List[str],
     token_file: Optional[str] = None,
     client_secrets_file: Optional[str] = None,
     service_account_file: Optional[str] = None,
-    scopes: Optional[List[str]] = None,
     use_domain_wide: bool = False,
     delegated_user: Optional[str] = None,
 ) -> Credentials:
     """Get credentials."""
     if use_domain_wide:
         _, _, ServiceCredentials = import_google()
-        service_account_file = service_account_file
-        scopes = scopes
+        service_account_file = service_account_file or DEFAULT_SERVICE_ACCOUNT_FILE
         credentials = ServiceCredentials.from_service_account_file(
             service_account_file, scopes=scopes
         )
@@ -141,7 +137,6 @@ def get_google_credentials(
         Request, Credentials, ServiceCredentials = import_google()
         InstalledAppFlow = import_installed_app_flow()
         creds = None
-        scopes = scopes
         token_file = token_file or DEFAULT_CREDS_TOKEN_FILE
         client_secrets_file = client_secrets_file or DEFAULT_CLIENT_SECRETS_FILE
         # The file token.json stores the user's access and refresh tokens, and is

--- a/libs/community/langchain_google_community/_utils.py
+++ b/libs/community/langchain_google_community/_utils.py
@@ -3,12 +3,28 @@
 import os
 from importlib import metadata
 from typing import Optional, Tuple
+from __future__ import annotations
 
+import logging
+import os
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+from langchain_core.utils import guard_import
 from google.api_core.gapic_v1.client_info import ClientInfo
 
 _TELEMETRY_TAG = "remote_reasoning_engine"
 _TELEMETRY_ENV_VARIABLE_NAME = "GOOGLE_CLOUD_AGENT_ENGINE_ID"
 
+if TYPE_CHECKING:
+    from google.auth.transport.requests import Request
+    from google.oauth2.credentials import Credentials
+    from google.oauth2.service_account import Credentials as ServiceCredentials
+    from google_auth_oauthlib.flow import InstalledAppFlow
+    from googleapiclient.discovery import Resource
+    from googleapiclient.discovery import build as build_resource
+
+logger = logging.getLogger(__name__)
 
 def get_user_agent(module: Optional[str] = None) -> Tuple[str, str]:
     r"""Returns a custom user agent header.

--- a/libs/community/langchain_google_community/_utils.py
+++ b/libs/community/langchain_google_community/_utils.py
@@ -1,16 +1,14 @@
 """Utilities to init Vertex AI."""
 from __future__ import annotations
-import os
-from importlib import metadata
-from typing import Optional, Tuple
 
 import logging
 import os
 from datetime import datetime
+from importlib import metadata
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
-from langchain_core.utils import guard_import
 from google.api_core.gapic_v1.client_info import ClientInfo
+from langchain_core.utils import guard_import
 
 _TELEMETRY_TAG = "remote_reasoning_engine"
 _TELEMETRY_ENV_VARIABLE_NAME = "GOOGLE_CLOUD_AGENT_ENGINE_ID"
@@ -24,6 +22,7 @@ if TYPE_CHECKING:
     from googleapiclient.discovery import build as build_resource
 
 logger = logging.getLogger(__name__)
+
 
 def get_user_agent(module: Optional[str] = None) -> Tuple[str, str]:
     r"""Returns a custom user agent header.
@@ -81,7 +80,7 @@ def import_google() -> Tuple[Request, Credentials, ServiceCredentials]:
         ).Credentials,
         guard_import(
             module_name="google.oauth2.service_account", pip_name="google-auth"
-        ).ServiceCredentials
+        ).ServiceCredentials,
     )
 
 

--- a/libs/community/langchain_google_community/calendar/base.py
+++ b/libs/community/langchain_google_community/calendar/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from langchain_core.tools import BaseTool
 from pydantic import Field
 
-from langchain_google_community.calendar.utils import build_resource_service
+from langchain_google_community.calendar.utils import build_calendar_service
 
 if TYPE_CHECKING:
     # This is for linting and IDE typehints
@@ -23,7 +23,7 @@ else:
 class CalendarBaseTool(BaseTool):  # type: ignore[override]
     """Base class for Google Calendar tools."""
 
-    api_resource: Resource = Field(default_factory=build_resource_service)
+    api_resource: Resource = Field(default_factory=build_calendar_service)
 
     @classmethod
     def from_api_resource(cls, api_resource: Resource) -> "CalendarBaseTool":

--- a/libs/community/langchain_google_community/calendar/toolkit.py
+++ b/libs/community/langchain_google_community/calendar/toolkit.py
@@ -13,7 +13,7 @@ from langchain_google_community.calendar.get_calendars_info import GetCalendarsI
 from langchain_google_community.calendar.move_event import CalendarMoveEvent
 from langchain_google_community.calendar.search_events import CalendarSearchEvents
 from langchain_google_community.calendar.update_event import CalendarUpdateEvent
-from langchain_google_community.calendar.utils import build_resource_service
+from langchain_google_community.calendar.utils import build_calendar_service
 
 if TYPE_CHECKING:
     # This is for linting and IDE typehints
@@ -42,7 +42,7 @@ class CalendarToolkit(BaseToolkit):
         See https://python.langchain.com/docs/security for more information.
     """
 
-    api_resource: Resource = Field(default_factory=build_resource_service)
+    api_resource: Resource = Field(default_factory=build_calendar_service)
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,

--- a/libs/community/langchain_google_community/calendar/utils.py
+++ b/libs/community/langchain_google_community/calendar/utils.py
@@ -19,16 +19,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def import_googleapiclient_resource_builder() -> build_resource:
-    """Import googleapiclient.discovery.build function.
-
-    Returns:
-        build_resource: googleapiclient.discovery.build function.
-    """
-    return guard_import(
-        module_name="googleapiclient.discovery", pip_name="google-api-python-client"
-    ).build
-
 
 DEFAULT_SCOPES = ["https://www.googleapis.com/auth/calendar"]
 DEFAULT_CREDS_TOKEN_FILE = "token.json"

--- a/libs/community/langchain_google_community/calendar/utils.py
+++ b/libs/community/langchain_google_community/calendar/utils.py
@@ -19,22 +19,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def import_google() -> Tuple[Request, Credentials]:
-    """Import google libraries.
-
-    Returns:
-        Tuple[Request, Credentials]: Request and Credentials classes.
-    """
-    return (
-        guard_import(
-            module_name="google.auth.transport.requests",
-            pip_name="google-auth",
-        ).Request,
-        guard_import(
-            module_name="google.oauth2.credentials", pip_name="google-auth"
-        ).Credentials,
-    )
-
 
 def import_installed_app_flow() -> InstalledAppFlow:
     """Import InstalledAppFlow class.

--- a/libs/community/langchain_google_community/calendar/utils.py
+++ b/libs/community/langchain_google_community/calendar/utils.py
@@ -21,42 +21,6 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_SCOPES = ["https://www.googleapis.com/auth/calendar"]
-DEFAULT_CREDS_TOKEN_FILE = "token.json"
-DEFAULT_CLIENT_SECRETS_FILE = "credentials.json"
-
-
-def get_google_credentials(
-    token_file: Optional[str] = None,
-    client_secrets_file: Optional[str] = None,
-    scopes: Optional[List[str]] = None,
-) -> Credentials:
-    """Get credentials."""
-    # From https://developers.google.com/calendar/api/quickstart/python
-    Request, Credentials = import_google()
-    InstalledAppFlow = import_installed_app_flow()
-    creds = None
-    scopes = scopes or DEFAULT_SCOPES
-    token_file = token_file or DEFAULT_CREDS_TOKEN_FILE
-    client_secrets_file = client_secrets_file or DEFAULT_CLIENT_SECRETS_FILE
-    # The file token.json stores the user's access and refresh tokens, and is
-    # created automatically when the authorization flow completes for the first
-    # time.
-    if os.path.exists(token_file):
-        creds = Credentials.from_authorized_user_file(token_file, scopes)
-    # If there are no (valid) credentials available, let the user log in.
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())  # type: ignore[call-arg]
-        else:
-            # https://developers.google.com/calendar/api/quickstart/python#authorize_credentials_for_a_desktop_application # noqa
-            flow = InstalledAppFlow.from_client_secrets_file(
-                client_secrets_file, scopes
-            )
-            creds = flow.run_local_server(port=0)
-        # Save the credentials for the next run
-        with open(token_file, "w") as token:
-            token.write(creds.to_json())
-    return creds
 
 
 def build_resource_service(

--- a/libs/community/langchain_google_community/calendar/utils.py
+++ b/libs/community/langchain_google_community/calendar/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
@@ -36,6 +37,20 @@ def build_calendar_service(
     credentials = credentials or get_google_credentials(scopes=DEFAULT_SCOPES)
     builder = import_googleapiclient_resource_builder()
     return builder(service_name, service_version, credentials=credentials)
+
+
+def build_resouce_service(
+    credentials: Optional[Credentials] = None,
+    service_name: str = "calendar",
+    service_version: str = "v3",
+) -> Resource:
+    warnings.warn(
+        "build_resource_service is deprecated and will be removed in a future version."
+        "Use build_calendar_service instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return build_calendar_service(credentials, service_name, service_version)
 
 
 def is_all_day_event(start_datetime: str, end_datetime: str) -> bool:

--- a/libs/community/langchain_google_community/calendar/utils.py
+++ b/libs/community/langchain_google_community/calendar/utils.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 import logging
-import os
 import warnings
 from datetime import datetime
-from typing import TYPE_CHECKING, List, Optional, Tuple
-
-from langchain_core.utils import guard_import
+from typing import TYPE_CHECKING, Optional
 
 from langchain_google_community._utils import (
     get_google_credentials,
@@ -16,11 +13,8 @@ from langchain_google_community._utils import (
 )
 
 if TYPE_CHECKING:
-    from google.auth.transport.requests import Request
     from google.oauth2.credentials import Credentials
-    from google_auth_oauthlib.flow import InstalledAppFlow
     from googleapiclient.discovery import Resource
-    from googleapiclient.discovery import build as build_resource
 
 logger = logging.getLogger(__name__)
 

--- a/libs/community/langchain_google_community/calendar/utils.py
+++ b/libs/community/langchain_google_community/calendar/utils.py
@@ -6,11 +6,13 @@ import logging
 import os
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional, Tuple
-from langchain_google_community._utils import (
-    import_googleapiclient_resource_builder,
-    get_google_credentials,
-)
+
 from langchain_core.utils import guard_import
+
+from langchain_google_community._utils import (
+    get_google_credentials,
+    import_googleapiclient_resource_builder,
+)
 
 if TYPE_CHECKING:
     from google.auth.transport.requests import Request
@@ -20,7 +22,6 @@ if TYPE_CHECKING:
     from googleapiclient.discovery import build as build_resource
 
 logger = logging.getLogger(__name__)
-
 
 
 DEFAULT_SCOPES = ["https://www.googleapis.com/auth/calendar"]

--- a/libs/community/langchain_google_community/calendar/utils.py
+++ b/libs/community/langchain_google_community/calendar/utils.py
@@ -6,7 +6,10 @@ import logging
 import os
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional, Tuple
-
+from langchain_google_community._utils import (
+    import_googleapiclient_resource_builder,
+    get_google_credentials,
+)
 from langchain_core.utils import guard_import
 
 if TYPE_CHECKING:
@@ -23,13 +26,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_SCOPES = ["https://www.googleapis.com/auth/calendar"]
 
 
-def build_resource_service(
+def build_calendar_service(
     credentials: Optional[Credentials] = None,
     service_name: str = "calendar",
     service_version: str = "v3",
 ) -> Resource:
     """Build a Google Calendar service."""
-    credentials = credentials or get_google_credentials()
+    credentials = credentials or get_google_credentials(scopes=DEFAULT_SCOPES)
     builder = import_googleapiclient_resource_builder()
     return builder(service_name, service_version, credentials=credentials)
 

--- a/libs/community/langchain_google_community/calendar/utils.py
+++ b/libs/community/langchain_google_community/calendar/utils.py
@@ -19,18 +19,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-
-def import_installed_app_flow() -> InstalledAppFlow:
-    """Import InstalledAppFlow class.
-
-    Returns:
-        InstalledAppFlow: InstalledAppFlow class.
-    """
-    return guard_import(
-        module_name="google_auth_oauthlib.flow", pip_name="google-auth-oauthlib"
-    ).InstalledAppFlow
-
-
 def import_googleapiclient_resource_builder() -> build_resource:
     """Import googleapiclient.discovery.build function.
 

--- a/libs/community/langchain_google_community/gmail/base.py
+++ b/libs/community/langchain_google_community/gmail/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from langchain_core.tools import BaseTool
 from pydantic import Field
 
-from langchain_google_community.gmail.utils import build_resource_service
+from langchain_google_community.gmail.utils import build_gmail_service
 
 if TYPE_CHECKING:
     # This is for linting and IDE typehints
@@ -23,7 +23,7 @@ else:
 class GmailBaseTool(BaseTool):
     """Base class for Gmail tools."""
 
-    api_resource: Resource = Field(default_factory=build_resource_service)
+    api_resource: Resource = Field(default_factory=build_gmail_service)
 
     @classmethod
     def from_api_resource(cls, api_resource: Resource) -> "GmailBaseTool":

--- a/libs/community/langchain_google_community/gmail/toolkit.py
+++ b/libs/community/langchain_google_community/gmail/toolkit.py
@@ -11,7 +11,7 @@ from langchain_google_community.gmail.get_message import GmailGetMessage
 from langchain_google_community.gmail.get_thread import GmailGetThread
 from langchain_google_community.gmail.search import GmailSearch
 from langchain_google_community.gmail.send_message import GmailSendMessage
-from langchain_google_community.gmail.utils import build_resource_service
+from langchain_google_community.gmail.utils import build_gmail_service
 
 if TYPE_CHECKING:
     # This is for linting and IDE typehints
@@ -40,7 +40,7 @@ class GmailToolkit(BaseToolkit):
         See https://python.langchain.com/docs/security for more information.
     """
 
-    api_resource: Resource = Field(default_factory=build_resource_service)
+    api_resource: Resource = Field(default_factory=build_gmail_service)
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,

--- a/libs/community/langchain_google_community/gmail/utils.py
+++ b/libs/community/langchain_google_community/gmail/utils.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import logging
-import os
 import warnings
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional
 
 from langchain_google_community._utils import (
     get_google_credentials,
@@ -13,12 +12,8 @@ from langchain_google_community._utils import (
 )
 
 if TYPE_CHECKING:
-    from google.auth.transport.requests import Request  # type: ignore[import]
     from google.oauth2.credentials import Credentials  # type: ignore[import]
-    from google.oauth2.service_account import Credentials as ServiceCredentials
-    from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore[import]
     from googleapiclient.discovery import Resource  # type: ignore[import]
-    from googleapiclient.discovery import build as build_resource
 
 logger = logging.getLogger(__name__)
 

--- a/libs/community/langchain_google_community/gmail/utils.py
+++ b/libs/community/langchain_google_community/gmail/utils.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import logging
 import os
 from typing import TYPE_CHECKING, List, Optional, Tuple
+from langchain_google_community._utils import (
+    import_googleapiclient_resource_builder,
+    get_google_credentials,
+)
 
 if TYPE_CHECKING:
     from google.auth.transport.requests import Request  # type: ignore[import]
@@ -19,12 +23,9 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_SCOPES = ["https://mail.google.com/"]
 DEFAULT_SERVICE_SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
-DEFAULT_CREDS_TOKEN_FILE = "token.json"
-DEFAULT_CLIENT_SECRETS_FILE = "credentials.json"
-DEFAULT_SERVICE_ACCOUNT_FILE = "service_account.json"
 
 
-def build_resource_service(
+def build_gmail_service(
     credentials: Optional[Credentials] = None,
     service_name: str = "gmail",
     service_version: str = "v1",
@@ -34,12 +35,20 @@ def build_resource_service(
     scopes: Optional[List[str]] = None,
 ) -> Resource:
     """Build a Gmail service."""
-    credentials = credentials or get_gmail_credentials(
-        use_domain_wide=use_domain_wide,
-        delegated_user=delegated_user,
-        service_account_file=service_account_file,
-        scopes=scopes,
-    )
+    if use_domain_wide:
+        credentials = credentials or get_google_credentials(
+            scopes=scopes or DEFAULT_SERVICE_SCOPES,
+            use_domain_wide=use_domain_wide,
+            delegated_user=delegated_user,
+            service_account_file=service_account_file,
+        )
+    else:
+        credentials = credentials or get_google_credentials(
+            scopes=scopes or DEFAULT_SCOPES,
+            use_domain_wide=use_domain_wide,
+            delegated_user=delegated_user,
+            service_account_file=service_account_file,
+        )
     builder = import_googleapiclient_resource_builder()
     return builder(service_name, service_version, credentials=credentials)
 

--- a/libs/community/langchain_google_community/gmail/utils.py
+++ b/libs/community/langchain_google_community/gmail/utils.py
@@ -17,25 +17,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-
-
-def import_installed_app_flow() -> InstalledAppFlow:
-    """Import InstalledAppFlow class.
-
-    Returns:
-        InstalledAppFlow: InstalledAppFlow class.
-    """
-    try:
-        from google_auth_oauthlib.flow import InstalledAppFlow
-    except ImportError:
-        raise ImportError(
-            "You need to install gmail dependencies to use this toolkit. "
-            "Please, install bigquery dependency group: "
-            "`pip install langchain-google-community[gmail]`"
-        )
-    return InstalledAppFlow
-
-
 def import_googleapiclient_resource_builder() -> build_resource:
     """Import googleapiclient.discovery.build function.
 

--- a/libs/community/langchain_google_community/gmail/utils.py
+++ b/libs/community/langchain_google_community/gmail/utils.py
@@ -24,58 +24,6 @@ DEFAULT_CLIENT_SECRETS_FILE = "credentials.json"
 DEFAULT_SERVICE_ACCOUNT_FILE = "service_account.json"
 
 
-def get_gmail_credentials(
-    token_file: Optional[str] = None,
-    client_secrets_file: Optional[str] = None,
-    service_account_file: Optional[str] = None,
-    scopes: Optional[List[str]] = None,
-    use_domain_wide: bool = False,
-    delegated_user: Optional[str] = None,
-) -> Credentials:
-    """Get credentials."""
-    if use_domain_wide:
-        _, _, ServiceCredentials = import_google()
-        service_account_file = service_account_file or DEFAULT_SERVICE_ACCOUNT_FILE
-        scopes = scopes or DEFAULT_SERVICE_SCOPES
-        credentials = ServiceCredentials.from_service_account_file(
-            service_account_file, scopes=scopes
-        )
-
-        if delegated_user:
-            credentials = credentials.with_subject(delegated_user)
-
-        return credentials
-    else:
-        # From https://developers.google.com/gmail/api/quickstart/python
-        Request, Credentials, _ = import_google()
-        InstalledAppFlow = import_installed_app_flow()
-        creds = None
-        scopes = scopes or DEFAULT_SCOPES
-        token_file = token_file or DEFAULT_CREDS_TOKEN_FILE
-        client_secrets_file = client_secrets_file or DEFAULT_CLIENT_SECRETS_FILE
-        # The file token.json stores the user's access and refresh tokens, and is
-        # created automatically when the authorization flow completes for the first
-        # time.
-
-        if os.path.exists(token_file):
-            creds = Credentials.from_authorized_user_file(token_file, scopes)
-
-        if not creds or not creds.valid:
-            if creds and creds.expired and creds.refresh_token:
-                creds.refresh(Request())  # type: ignore[call-arg]
-            else:
-                # https://developers.google.com/gmail/api/quickstart/python#authorize_credentials_for_a_desktop_application # noqa
-                flow = InstalledAppFlow.from_client_secrets_file(
-                    client_secrets_file, scopes
-                )
-                creds = flow.run_local_server(port=0)
-
-            with open(token_file, "w") as token:
-                token.write(creds.to_json())
-
-        return creds
-
-
 def build_resource_service(
     credentials: Optional[Credentials] = None,
     service_name: str = "gmail",

--- a/libs/community/langchain_google_community/gmail/utils.py
+++ b/libs/community/langchain_google_community/gmail/utils.py
@@ -17,22 +17,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def import_googleapiclient_resource_builder() -> build_resource:
-    """Import googleapiclient.discovery.build function.
-
-    Returns:
-        build_resource: googleapiclient.discovery.build function.
-    """
-    try:
-        from googleapiclient.discovery import build
-    except ImportError:
-        raise ImportError(
-            "You need to install all dependencies to use this toolkit. "
-            "Try running pip install langchain-google-community"
-        )
-    return build
-
-
 DEFAULT_SCOPES = ["https://mail.google.com/"]
 DEFAULT_SERVICE_SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
 DEFAULT_CREDS_TOKEN_FILE = "token.json"

--- a/libs/community/langchain_google_community/gmail/utils.py
+++ b/libs/community/langchain_google_community/gmail/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import warnings
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from langchain_google_community._utils import (
@@ -26,6 +27,36 @@ DEFAULT_SCOPES = ["https://mail.google.com/"]
 DEFAULT_SERVICE_SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
 
 
+def get_gmail_credentials(
+    token_file: Optional[str] = None,
+    client_sercret_file: Optional[str] = None,
+    service_account_file: Optional[str] = None,
+    scopes: Optional[List[str]] = None,
+    use_domain_wide: bool = False,
+    delegated_user: Optional[str] = None,
+) -> Credentials:
+    """Get Gmail credentials."""
+    warnings.warn(
+        "get_gmail_credentials is deprecated and will be removed in a future version."
+        "Use get_google_credentials instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if use_domain_wide:
+        scopes = scopes or DEFAULT_SERVICE_SCOPES
+    else:
+        scopes = scopes or DEFAULT_SCOPES
+
+    return get_google_credentials(
+        scopes=scopes,
+        token_file=token_file,
+        client_secrets_file=client_sercret_file,
+        service_account_file=service_account_file,
+        use_domain_wide=use_domain_wide,
+        delegated_user=delegated_user,
+    )
+
+
 def build_gmail_service(
     credentials: Optional[Credentials] = None,
     service_name: str = "gmail",
@@ -37,21 +68,45 @@ def build_gmail_service(
 ) -> Resource:
     """Build a Gmail service."""
     if use_domain_wide:
-        credentials = credentials or get_google_credentials(
-            scopes=scopes or DEFAULT_SERVICE_SCOPES,
-            use_domain_wide=use_domain_wide,
-            delegated_user=delegated_user,
-            service_account_file=service_account_file,
-        )
+        scopes = scopes or DEFAULT_SERVICE_SCOPES
     else:
-        credentials = credentials or get_google_credentials(
-            scopes=scopes or DEFAULT_SCOPES,
-            use_domain_wide=use_domain_wide,
-            delegated_user=delegated_user,
-            service_account_file=service_account_file,
-        )
+        scopes = scopes or DEFAULT_SCOPES
+
+    credentials = credentials or get_google_credentials(
+        scopes=scopes,
+        use_domain_wide=use_domain_wide,
+        delegated_user=delegated_user,
+        service_account_file=service_account_file,
+    )
     builder = import_googleapiclient_resource_builder()
     return builder(service_name, service_version, credentials=credentials)
+
+
+def build_resource_service(
+    credentials: Optional[Credentials] = None,
+    service_name: str = "gmail",
+    service_version: str = "v1",
+    use_domain_wide: bool = False,
+    delegated_user: Optional[str] = None,
+    service_account_file: Optional[str] = None,
+    scopes: Optional[List[str]] = None,
+) -> Resource:
+    """Build a Gmail resource service."""
+    warnings.warn(
+        "build_resource_service is deprecated and will be removed in a future version."
+        "Use build_gmail_service instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return build_gmail_service(
+        credentials=credentials,
+        service_name=service_name,
+        service_version=service_version,
+        use_domain_wide=use_domain_wide,
+        delegated_user=delegated_user,
+        service_account_file=service_account_file,
+        scopes=scopes,
+    )
 
 
 def clean_email_body(body: str) -> str:

--- a/libs/community/langchain_google_community/gmail/utils.py
+++ b/libs/community/langchain_google_community/gmail/utils.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import logging
 import os
 from typing import TYPE_CHECKING, List, Optional, Tuple
+
 from langchain_google_community._utils import (
-    import_googleapiclient_resource_builder,
     get_google_credentials,
+    import_googleapiclient_resource_builder,
 )
 
 if TYPE_CHECKING:

--- a/libs/community/langchain_google_community/gmail/utils.py
+++ b/libs/community/langchain_google_community/gmail/utils.py
@@ -17,22 +17,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def import_google() -> Tuple[Request, Credentials, ServiceCredentials]:
-    """Import google libraries.
-
-    Returns:
-        Tuple[Request, Credentials]: Request and Credentials classes.
-    """
-    try:
-        from google.auth.transport.requests import Request  # noqa: F401
-        from google.oauth2.credentials import Credentials  # noqa: F401
-        from google.oauth2.service_account import Credentials as ServiceCredentials
-    except ImportError:
-        raise ImportError(
-            "You need to install gmail dependencies to use this toolkit. "
-            "Try running poetry install --with gmail"
-        )
-    return Request, Credentials, ServiceCredentials  # type: ignore[return-value]
 
 
 def import_installed_app_flow() -> InstalledAppFlow:


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation


- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

## PR Description

There is some redundancy in creating google api resources for gmail and google calendar. To avoid duplicate code and smoother service building for future APIs, Some of the authentication is moved to the _utils file in the parent directory

## Relevant issues

Fixes #890

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes(optional)

<!-- List of changes -->

## Testing(optional)

<!-- Test procedure -->
<!-- Test result -->

## Note(optional)

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
