### PR TITLE
genai[patch]: support image parts in tool responses

### DIFF
--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -34,6 +34,10 @@ class TestGeminiAI2Standard(ChatModelIntegrationTests):
         return True
 
     @property
+    def supports_image_tool_message(self) -> bool:
+        return True
+
+    @property
     def supports_pdf_inputs(self) -> bool:
         return True
 

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -30,7 +30,7 @@ from pytest import CaptureFixture
 
 from langchain_google_genai.chat_models import (
     ChatGoogleGenerativeAI,
-    _convert_tool_message_to_part,
+    _convert_tool_message_to_parts,
     _parse_chat_history,
     _parse_response_candidate,
 )
@@ -710,10 +710,12 @@ def test_serialize() -> None:
         ),
     ],
 )
-def test__convert_tool_message_to_part__sets_tool_name(
+def test__convert_tool_message_to_parts__sets_tool_name(
     tool_message: ToolMessage,
 ) -> None:
-    part = _convert_tool_message_to_part(tool_message)
+    parts = _convert_tool_message_to_parts(tool_message)
+    assert len(parts) == 1
+    part = parts[0]
     assert part.function_response.name == "tool_name"
     assert part.function_response.response == {"output": "test_content"}
 


### PR DESCRIPTION
Unclear to me if images should be structured into a `FunctionResponse`. I found reasonable behavior if they are formatted as distinct parts.