### PR TITLE
genai: fix update model_fields access for Pydantic v2.11+ compatibility

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1068,7 +1068,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         """Needed for arg validation."""
         # Get all valid field names, including aliases
         valid_fields = set()
-        for field_name, field_info in self.model_fields.items():
+        for field_name, field_info in self.__class__.model_fields.items():
             valid_fields.add(field_name)
             if hasattr(field_info, "alias") and field_info.alias is not None:
                 valid_fields.add(field_info.alias)


### PR DESCRIPTION
## PR Description
Fix deprecation warning in langchain_google_genai due to Pydantic v2.11+

## Relevant issues
Fixes #917

## Type
🐛 Bug Fix

## Changes
- Update `chat_models.py` to access `model_fields` through the class instead of the instance
- This addresses the Pydantic v2.11+ deprecation warning: "Accessing the 'model_fields' attribute on the instance is deprecated"

## Testing
- Verified the warning no longer appears when using ChatGoogleGenerativeAI with structured output as Pydantic object
- Tested with Pydantic 2.11.4 and langchain-google-genai 2.1.4
- All existing tests pass with the change

## Note
This is a small fix that ensures compatibility with the upcoming Pydantic v3.0 by following the recommended pattern of accessing model fields through the class rather than instance.