### PR TITLE
vertexai: handle messages that evaluate to a literal float

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -308,6 +308,8 @@ def _parse_chat_history_gemini(
         # error.
         if isinstance(raw_content, int):  # type: ignore
             raw_content = str(raw_content)  # type: ignore
+        if isinstance(raw_content, float):
+            raw_content = str(raw_content)
         if isinstance(raw_content, str):
             raw_content = [raw_content]
         result = []


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

the function [`_convert_to_parts(message: BaseMessage)`](https://github.com/langchain-ai/langchain-google/blob/24ce2fd6aecf7e06c4f524a60e0bb1671e6516c2/libs/vertexai/langchain_google_vertexai/chat_models.py#L290-L318) throws an error when the message passed gets evaluated to a float.  Example error:

```
...

  File "/XXX/.venv/lib/python3.10/site-packages/langchain_google_vertexai/chat_models.py", line 313, in _parse_chat_history_gemini                                             
    parts = _convert_to_parts(message)                                                                                                                                                                             
            │                 └ HumanMessage(content='3.5', additional_kwargs={}, response_metadata={})                                                                                                            
            └ <function _parse_chat_history_gemini.<locals>._convert_to_parts at 0x167677d90>                                                                                                                      
  File "/XXX/.venv/lib/python3.10/site-packages/langchain_google_vertexai/chat_models.py", line 280, in _convert_to_parts                                                      
    for raw_part in raw_content:                                                                                                                                                                                   
                    └ 3.5   

TypeError: 'float' object is not iterable
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

None

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
