### PR TITLE
[community]: [remove arbitrary return in google results]

### DIFF
--- a/libs/community/langchain_google_community/search.py
+++ b/libs/community/langchain_google_community/search.py
@@ -125,8 +125,6 @@ class GoogleSearchAPIWrapper(BaseModel):
         results = self._google_search_results(
             query, num=num_results, **(search_params or {})
         )
-        if len(results) == 0:
-            return [{"Result": "No good Google Search Result was found"}]
         for result in results:
             metadata_result = {
                 "title": result["title"],


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

This PR fixes the implementation to match the documented behavior of [this method](https://github.com/langchain-ai/langchain-google/blob/main/libs/community/langchain_google_community/search.py#L105).

Method's documentation clearly states that:

```
        Returns:
            A list of dictionaries with the following keys:
                snippet - The description of the result.
                title - The title of the result.
                link - The link to the result.
```

Much to my demise, there's a strange early return

```
        if len(results) == 0:
            return [{"Result": "No good Google Search Result was found"}]
```

if no results were found.

There's no need to represent the "emptiness" of results, an empty list takes care of that. In any case, if we need to represent the absence, this is not a sensible null pattern implementation, since the returned object is not even polymorphic wit h what the documentation says. 

This PR removes that early return and considers that an empty list correctly represents the absence of results

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring
📖 Documentation

## Changes(optional)

<!-- List of changes -->

## Testing(optional)

<!-- Test procedure -->
<!-- Test result -->

## Note(optional)

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
