### PR TITLE
genai: Add grounding_metadata support to `ChatGoogleGenerativeAI` response

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -692,6 +692,13 @@ def _response_to_result(
             proto.Message.to_dict(safety_rating, use_integers_for_enums=False)
             for safety_rating in candidate.safety_ratings
         ]
+        try:
+            if candidate.grounding_metadata:
+                generation_info["grounding_metadata"] = proto.Message.to_dict(
+                    candidate.grounding_metadata
+                )
+        except AttributeError:
+            pass
         message = _parse_response_candidate(candidate, streaming=stream)
         message.usage_metadata = lc_usage
         if stream:


### PR DESCRIPTION
## PR Description

This PR adds support for including `grounding_metadata` in the response of `ChatGoogleGenerativeAI` when using tools like `google_search`, addressing the missing metadata issue reported in #907 and #825. The change ensures that `grounding_metadata` (e.g `grounding_chunks`, `grounding_supports`, `web_search_queries`) is included in `response_metadata`, enabling source citations for responses.

## Relevant issues

- Fixes #907
- Fixes #825

## Type

🐛 Bug Fix
✅ Test

## Changes
- Modified `_response_to_result` in `libs/genai/langchain_google_genai/chat_models.py` to include `grounding_metadata` from `GenerateContentResponse` candidates in the `generation_info` dictionary.
- Added a unit test `test_response_to_result_grounding_metadata` in `tests/unit_tests/test_chat_models.py` to verify that `grounding_metadata` is correctly included when present and handled as an empty dictionary when absent.

## Testing
- **Unit Test Procedure**:
  - Added a parameterized unit test `test_response_to_result_grounding_metadata` with two cases:
    1. A response with `grounding_metadata` (including `grounding_chunks`, `grounding_supports`, and `web_search_queries`).
    2. A response without `grounding_metadata`, expecting an empty dictionary.
  - The test verifies that `ChatResult.generations` contains the correct content and that `generation_info["grounding_metadata"]` matches the expected output.
  - Ran `make format`, `make lint`, and `make test` to ensure no linting errors and that all tests pass.

- **Unit Test Result**:
  - All tests in `tests/unit_tests/test_chat_models.py` pass, including the new test.

## Verification
To further verify, tested the `ChatGoogleGenerativeAI` model with the `google_search` tool using the following code:
```python
from google.ai.generativelanguage_v1beta.types import Tool as GenAITool
from langchain_google_genai import ChatGoogleGenerativeAI

llm = ChatGoogleGenerativeAI(
    model="gemini-2.0-flash",
)
resp = llm.invoke(
    "When is the next total solar eclipse in US?",
    tools=[GenAITool(google_search={})],
)
print(resp)
```

**Output**:
```python
content='The next total solar eclipse that will be visible from the contiguous United States is on August 23, 2044. The eclipse will begin in Greenland and pass through Canada before ending around sunset in Montana, North Dakota, and South Dakota.\n\nAnother total solar eclipse will occur on August 12, 2045, with a path of totality that crosses the US from coast to coast.'
additional_kwargs={}
response_metadata={
    'prompt_feedback': {'block_reason': 0, 'safety_ratings': []},
    'finish_reason': 'STOP',
    'model_name': 'gemini-2.0-flash',
    'safety_ratings': [],
    'grounding_metadata': {
        'search_entry_point': {
            'rendered_content': '<style>\n.container {\n  align-items: center;\n  border-radius: 8px;\n  display: flex;\n  font-family: Google Sans, Roboto, sans-serif;\n  font-size: 14px;\n  line-height: 20px;\n  padding: 8px 12px;\n}\n.chip {\n  display: inline-block;\n  border: solid 1px;\n  border-radius: 16px;\n  min-width: 14px;\n  padding: 5px 16px;\n  text-align: center;\n  user-select: none;\n  margin: 0 8px;\n  -webkit-tap-highlight-color: transparent;\n}\n.carousel {\n  overflow: auto;\n  scrollbar-width: none;\n  white-space: nowrap;\n  margin-right: -12px;\n}\n.headline {\n  display: flex;\n  margin-right: 4px;\n}\n.gradient-container {\n  position: relative;\n}\n.gradient {\n  position: absolute;\n  transform: translate(3px, -9px);\n  height: 36px;\n  width: 9px;\n}\n@media (prefers-color-scheme: light) {\n  .container {\n    background-color: #fafafa;\n    box-shadow: 0 0 0 1px #0000000f;\n  }\n  .headline-label {\n    color: #1f1f1f;\n  }\n  .chip {\n    background-color: #ffffff;\n    border-color: #d2d2d2;\n    color: #5e5e5e;\n    text-decoration: none;\n  }\n  .chip:hover {\n    background-color: #f2f2f2;\n  }\n  .chip:focus {\n    background-color: #f2f2f2;\n  }\n  .chip:active {\n    background-color: #d8d8d8;\n    border-color: #b6b6b6;\n  }\n  .logo-dark {\n    display: none;\n  }\n  .gradient {\n    background: linear-gradient(90deg, #fafafa 15%, #fafafa00 100%);\n  }\n}\n@media (prefers-color-scheme: dark) {\n  .container {\n    background-color: #1f1f1f;\n    box-shadow: 0 0 0 1px #ffffff26;\n  }\n  .headline-label {\n    color: #fff;\n  }\n  .chip {\n    background-color: #2c2c2c;\n    border-color: #3c4043;\n    color: #fff;\n    text-decoration: none;\n  }\n  .chip:hover {\n    background-color: #353536;\n  }\n  .chip:focus {\n    background-color: #353536;\n  }\n  .chip:active {\n    background-color: #464849;\n    border-color: #53575b;\n  }\n  .logo-light {\n    display: none;\n  }\n  .gradient {\n    background: linear-gradient(90deg, #1f1f1f 15%, #1f1f1f00 100%);\n  }\n}\n</style>\n<div class="container">\n  <div class="headline">\n    <svg class="logo-light" width="18" height="18" viewBox="9 9 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">\n      <path fill-rule="evenodd" clip-rule="evenodd" d="M42.8622 27.0064C42.8622 25.7839 42.7525 24.6084 42.5487 23.4799H26.3109V30.1568H35.5897C35.1821 32.3041 33.9596 34.1222 32.1258 35.3448V39.6864H37.7213C40.9814 36.677 42.8622 32.2571 42.8622 27.0064V27.0064Z" fill="#4285F4"/>\n      <path fill-rule="evenodd" clip-rule="evenodd" d="M26.3109 43.8555C30.9659 43.8555 34.8687 42.3195 37.7213 39.6863L32.1258 35.3447C30.5898 36.3792 28.6306 37.0061 26.3109 37.0061C21.8282 37.0061 18.0195 33.9811 16.6559 29.906H10.9194V34.3573C13.7563 39.9841 19.5712 43.8555 26.3109 43.8555V43.8555Z" fill="#34A853"/>\n      <path fill-rule="evenodd" clip-rule="evenodd" d="M16.6559 29.8904C16.3111 28.8559 16.1074 27.7588 16.1074 26.6146C16.1074 25.4704 16.3111 24.3733 16.6559 23.3388V18.8875H10.9194C9.74388 21.2072 9.06992 23.8247 9.06992 26.6146C9.06992 29.4045 9.74388 32.022 10.9194 34.3417L15.3864 30.8621L16.6559 29.8904V29.8904Z" fill="#FBBC05"/>\n      <path fill-rule="evenodd" clip-rule="evenodd" d="M26.3109 16.2386C28.85 16.2386 31.107 17.1164 32.9095 18.8091L37.8466 13.8719C34.853 11.082 30.9659 9.3736 26.3109 9.3736C19.5712 9.3736 13.7563 13.245 10.9194 18.8875L16.6559 23.3388C18.0195 19.2636 21.8282 16.2386 26.3109 16.2386V16.2386Z" fill="#EA4335"/>\n    </svg>\n    <svg class="logo-dark" width="18" height="18" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">\n      <circle cx="24" cy="23" fill="#FFF" r="22"/>\n      <path d="M33.76 34.26c2.75-2.56 4.49-6.37 4.49-11.26 0-.89-.08-1.84-.29-3H24.01v5.99h8.03c-.4 2.02-1.5 3.56-3.07 4.56v.75l3.91 2.97h.88z" fill="#4285F4"/>\n      <path d="M15.58 25.77A8.845 8.845 0 0 0 24 31.86c1.92 0 3.62-.46 4.97-1.31l4.79 3.71C31.14 36.7 27.65 38 24 38c-5.93 0-11.01-3.4-13.45-8.36l.17-1.01 4.06-2.85h.8z" fill="#34A853"/>\n      <path d="M15.59 20.21a8.864 8.864 0 0 0 0 5.58l-5.03 3.86c-.98-2-1.53-4.25-1.53-6.64 0-2.39.55-4.64 1.53-6.64l1-.22 3.81 2.98.22 1.08z" fill="#FBBC05"/>\n      <path d="M24 14.14c2.11 0 4.02.75 5.52 1.98l4.36-4.36C31.22 9.43 27.81 8 24 8c-5.93 0-11.01 3.4-13.45 8.36l5.03 3.85A8.86 8.86 0 0 1 24 14.14z" fill="#EA4335"/>\n    </svg>\n    <div class="gradient-container"><div class="gradient"></div></div>\n  </div>\n  <div class="carousel">\n    <a class="chip" href="https://vertexaisearch.cloud.google.com/grounding-api-redirect/AbF9wXGF6YOyFKrkCRACXXbSJEMo6gy_gPy_OOICK-wJmnB7_QkvSBL3jjD_LcLJpF4qdK4uHeLETZdpOqGm-3NR2msilyLl7dWoulGzyQD1thmoSVtQEDUjR40EMpGDE-KQO2AXPAp-n6GdeMkV2crwKpRD3Y-sPvY-zh-t6GMguzI6Bje4c2QI905QvYkOvxC2YpkaCOlXqIojPw-yR8qcrEWzcg==">next total solar eclipse in US</a>\n  </div>\n</div>\n', 
            'sdk_blob': ''
        },
        'grounding_chunks': [
            {'web': {'uri': 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/AbF9wXGDF89juqmDA6gM2d0MVlpnhL7D4j_q5onKEZ-I7PNyalfs-TlOg2kWezVuRWZKVB5tAne1bNxd6-wBT9dpBtWiwcernb97xRE3Xb9vB-emaRAHX2Ci6Cjngtp_HJBmsRlIJru06dC0CTTh3Bjy_mtTW1RuKnzcug==', 'title': 'wikipedia.org'}},
            {'web': {'uri': 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/AbF9wXE-uErEujZG-56bVGzId3Gw9muRRyCm4h76na46FZrqJQ2DGQThvIUH9vT-h4cA-kQtvPSi271NMI-oln8CaLswIrz8NKBTWKleNfChv3yTCCAw-xk9dteVabyzdNziGUcZ4gUEzOb_zt8gXiyLk4WirPfamJEV8Fa9ZHk=', 'title': 'cbsnews.com'}},
            {'web': {'uri': 'https://vertexaisearch.cloud.google.com/grounding-api-redirect/AbF9wXFpOnoE4ZmQH7EgaurB76rF65irNgHfgKYZuf3fE6z12AOaJYQR-z78-LBWNuoBx88Gp7IuhPDI1fY57D_SZ-3MVWlv5siKlHDbC_gLnSUw-zhZwKM32Ckrk7nFXd9WRD54TNMoLbETObZ8lmx5UQv7jmbiQ2sWbzlk_Q==', 'title': 'nasa.gov'}}
        ],
        'grounding_supports': [
            {
                'segment': {
                    'end_index': 106,
                    'text': 'The next total solar eclipse that will be visible from the contiguous United States is on August 23, 2044.',
                    'part_index': 0,
                    'start_index': 0
                },
                'grounding_chunk_indices': [0, 1, 2],
                'confidence_scores': [0.9694024, 0.88265264, 0.9873964]
            },
            {
                'segment': {
                    'start_index': 107,
                    'end_index': 238,
                    'text': 'The eclipse will begin in Greenland and pass through Canada before ending around sunset in Montana, North Dakota, and South Dakota.',
                    'part_index': 0
                },
                'grounding_chunk_indices': [1],
                'confidence_scores': [0.9308082]
            },
            {
                'segment': {
                    'start_index': 240,
                    'end_index': 363,
                    'text': 'Another total solar eclipse will occur on August 12, 2045, with a path of totality that crosses the US from coast to coast.',
                    'part_index': 0
                },
                'grounding_chunk_indices': [0],
                'confidence_scores': [0.8836873]
            }
        ],
        'retrieval_metadata': {'google_search_dynamic_retrieval_score': 0.0},
        'web_search_queries': ['next total solar eclipse in US']
    }
}
id='run--8f03859c-11d8-49ab-81b5-c745320c04bb-0'
usage_metadata={
    'input_tokens': 10,
    'output_tokens': 85,
    'total_tokens': 95,
    'input_token_details': {'cache_read': 0}
}
```
  - The output confirms that `grounding_metadata` is included in `response_metadata`, with `grounding_chunks`, `grounding_supports`, and `web_search_queries` correctly populated, matching the expected behavior for the `google_search` tool.

## Note
- The change mirrors the `vertexai` integration’s handling of `grounding_metadata` in `get_generation_info`, but includes a dedicated unit test for `genai` to ensure reliability.
- No new dependencies were added, and the change is backwards compatible.
- The PR is limited to the `genai` package and does not affect other packages (`vertexai`, `community`).