### PR TITLE
vertexai: add support for gemini-embedding-001

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/embeddings.py
+++ b/libs/vertexai/langchain_google_vertexai/embeddings.py
@@ -66,6 +66,8 @@ class GoogleEmbeddingModelType(str, Enum):
     def _missing_(cls, value: Any) -> Optional["GoogleEmbeddingModelType"]:
         if value.lower().startswith("text"):
             return GoogleEmbeddingModelType.TEXT
+        if value.lower().startswith("gemini"):
+            return GoogleEmbeddingModelType.TEXT
         if "multimodalembedding" in value.lower():
             return GoogleEmbeddingModelType.MULTIMODAL
         return None
@@ -77,6 +79,7 @@ class GoogleEmbeddingModelVersion(str, Enum):
     EMBEDDINGS_DEC_2023 = auto()
     EMBEDDINGS_MAY_2024 = auto()
     EMBEDDINGS_NOV_2024 = auto()
+    EMBEDDINGS_MAY_2025 = auto()
 
     @classmethod
     def _missing_(cls, value: Any) -> "GoogleEmbeddingModelVersion":
@@ -99,6 +102,9 @@ class GoogleEmbeddingModelVersion(str, Enum):
         if "text-embedding-005" in value.lower():
             return GoogleEmbeddingModelVersion.EMBEDDINGS_NOV_2024
 
+        if "gemini-embedding-001" in value.lower():
+            return GoogleEmbeddingModelVersion.EMBEDDINGS_MAY_2025
+
         return GoogleEmbeddingModelVersion.EMBEDDINGS_JUNE_2023
 
     @property
@@ -113,7 +119,11 @@ class GoogleEmbeddingModelVersion(str, Enum):
         """
         Checks if the model generation supports output dimensionality.
         """
-        return self == GoogleEmbeddingModelVersion.EMBEDDINGS_MAY_2024
+        supported = [
+            GoogleEmbeddingModelVersion.EMBEDDINGS_MAY_2024,
+            GoogleEmbeddingModelVersion.EMBEDDINGS_MAY_2025,
+        ]
+        return self in supported
 
 
 class VertexAIEmbeddings(_VertexAICommon, Embeddings):

--- a/libs/vertexai/tests/unit_tests/test_embeddings.py
+++ b/libs/vertexai/tests/unit_tests/test_embeddings.py
@@ -11,6 +11,9 @@ from langchain_google_vertexai.embeddings import (
     GoogleEmbeddingModelType,
 )
 
+def test_langchain_google_vertexai_supports_gemini_embedding_model() -> None:
+    mock_embeddings = MockVertexAIEmbeddings("gemini-embedding-001")
+    assert mock_embeddings.model_type == GoogleEmbeddingModelType.TEXT
 
 def test_langchain_google_vertexai_embed_image_multimodal_only() -> None:
     mock_embeddings = MockVertexAIEmbeddings("textembedding-gecko@001")

--- a/libs/vertexai/tests/unit_tests/test_embeddings.py
+++ b/libs/vertexai/tests/unit_tests/test_embeddings.py
@@ -11,9 +11,11 @@ from langchain_google_vertexai.embeddings import (
     GoogleEmbeddingModelType,
 )
 
+
 def test_langchain_google_vertexai_supports_gemini_embedding_model() -> None:
     mock_embeddings = MockVertexAIEmbeddings("gemini-embedding-001")
     assert mock_embeddings.model_type == GoogleEmbeddingModelType.TEXT
+
 
 def test_langchain_google_vertexai_embed_image_multimodal_only() -> None:
     mock_embeddings = MockVertexAIEmbeddings("textembedding-gecko@001")


### PR DESCRIPTION
## PR Description
Addresses issue https://github.com/langchain-ai/langchain-google/issues/954 

Adds relevant enums to support the latest `gemini-embedding-001` model for text embedding, and adds it to the list of models that support variable dimensionality

## Relevant issues

Addresses issue https://github.com/langchain-ai/langchain-google/issues/954   

## Type
🆕 New Feature

## Testing
Adds a unit test showing that the Embedding Model type can be constructed with `gemini-embedding-001`
