### PR TITLE
vertexai[patch]: support code_execution

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -956,14 +956,28 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
 
         See ``ChatVertexAI.bind_tools()`` method for more.
 
-    Use Search with Gemini 2:
+    Built-in search:
         .. code-block:: python
 
             from google.cloud.aiplatform_v1beta1.types import Tool as VertexTool
+            from langchain_google_vertexai import ChatVertexAI
+
             llm = ChatVertexAI(model="gemini-2.0-flash-exp")
             resp = llm.invoke(
                 "When is the next total solar eclipse in US?",
                 tools=[VertexTool(google_search={})],
+            )
+
+    Built-in code execution:
+        .. code-block:: python
+
+            from google.cloud.aiplatform_v1beta1.types import Tool as VertexTool
+            from langchain_google_vertexai import ChatVertexAI
+
+            llm = ChatVertexAI(model="gemini-2.0-flash-exp")
+            resp = llm.invoke(
+                "What is 3^3?",
+                tools=[VertexTool(code_execution={})],
             )
 
     Structured output:

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -255,14 +255,14 @@ def _parse_chat_history_gemini(
                 )
             )
         if part["type"] == "code_execution_result":
-            if "output" not in part or "outcome" not in part:
+            if "code_execution_result" not in part or "outcome" not in part:
                 raise ValueError(
-                    "Code execution result part must have 'output' and 'outcome' keys, "
-                    f"got {part}"
+                    "Code execution result part must have 'code_execution_result' and "
+                    f"'outcome' keys, got {part}"
                 )
             return Part(
                 code_execution_result=CodeExecutionResult(
-                    output=part["output"], outcome=part["outcome"]
+                    output=part["code_execution_result"], outcome=part["outcome"]
                 )
             )
 
@@ -655,7 +655,9 @@ def _parse_response_candidate(
             if part.code_execution_result.output and part.code_execution_result.outcome:
                 execution_result = {
                     "type": "code_execution_result",
-                    "output": part.code_execution_result.output,
+                    # Name output -> code_execution_result for consistency with
+                    # langchain-google-genai
+                    "code_execution_result": part.code_execution_result.output,
                     "outcome": part.code_execution_result.outcome,
                 }
 

--- a/libs/vertexai/langchain_google_vertexai/functions_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/functions_utils.py
@@ -32,6 +32,7 @@ from langchain_core.utils.function_calling import (
 )
 from langchain_core.utils.json_schema import dereference_refs
 from pydantic import BaseModel
+from typing_extensions import NotRequired
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,7 @@ _GoogleSearchRetrievalLike = Union[
 ]
 _GoogleSearchLike = Union[gapic.Tool.GoogleSearch, Dict[str, Any]]
 _RetrievalLike = Union[gapic.Retrieval, Dict[str, Any]]
+_CodeExecutionLike = Union[gapic.Tool.CodeExecution, Dict[str, Any]]
 
 
 class _ToolDictLike(TypedDict):
@@ -56,6 +58,7 @@ class _ToolDictLike(TypedDict):
     google_search_retrieval: Optional[_GoogleSearchRetrievalLike]
     google_search: Optional[_GoogleSearchLike]
     retrieval: Optional[_RetrievalLike]
+    code_execution: NotRequired[_CodeExecutionLike]
 
 
 _ToolType = Union[gapic.Tool, vertexai.Tool, _ToolDictLike, _FunctionDeclarationLike]
@@ -306,6 +309,8 @@ def _format_to_gapic_tool(tools: _ToolsType) -> gapic.Tool:
                 gapic_tool.function_declarations.extend(rt.function_declarations)
             if "google_search" in rt:
                 gapic_tool.google_search = rt.google_search
+            if "code_execution" in rt:
+                gapic_tool.code_execution = rt.code_execution
         elif isinstance(tool, dict):
             # not _ToolDictLike
             if not any(
@@ -315,6 +320,7 @@ def _format_to_gapic_tool(tools: _ToolsType) -> gapic.Tool:
                     "google_search_retrieval",
                     "google_search",
                     "retrieval",
+                    "code_execution",
                 ]
             ):
                 fd = _format_to_gapic_function_declaration(tool)
@@ -345,6 +351,10 @@ def _format_to_gapic_tool(tools: _ToolsType) -> gapic.Tool:
                 )
             if "retrieval" in tool:
                 gapic_tool.retrieval = gapic.Retrieval(tool["retrieval"])
+            if "code_execution" in tool:
+                gapic_tool.code_execution = gapic.Tool.CodeExecution(
+                    tool["code_execution"]
+                )
         else:
             fd = _format_to_gapic_function_declaration(tool)
             gapic_tool.function_declarations.append(fd)

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -1394,33 +1394,53 @@ def test_nested_bind_tools():
 
 def test_search_builtin() -> None:
     llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME).bind_tools([{"google_search": {}}])
-    query = "What is today's news?"
-    response = llm.invoke(query)
+    input_message = {
+        "role": "user",
+        "content": "What is today's news?",
+    }
+    response = llm.invoke([input_message])
     assert "grounding_metadata" in response.response_metadata
 
     # Test streaming
     full: Optional[BaseMessageChunk] = None
-    for chunk in llm.stream(query):
+    for chunk in llm.stream([input_message]):
         assert isinstance(chunk, AIMessageChunk)
         full = chunk if full is None else full + chunk
     assert isinstance(full, AIMessageChunk)
     assert "grounding_metadata" in full.response_metadata
 
+    # Test we can process chat history
+    next_message = {
+        "role": "user",
+        "content": "Tell me more about that last story.",
+    }
+    _ = llm.invoke([input_message, full, next_message])
+
 
 def test_code_execution_builtin() -> None:
     llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME).bind_tools([{"code_execution": {}}])
-    query = "What is 3^3?"
-    response = llm.invoke(query)
+    input_message = {
+        "role": "user",
+        "content": "What is 3^3?",
+    }
+    response = llm.invoke([input_message])
     content_blocks = [block for block in response.content if isinstance(block, dict)]
     expected_block_types = {"executable_code", "code_execution_result"}
     assert set(block.get("type") for block in content_blocks) == expected_block_types
 
     # Test streaming
     full: Optional[BaseMessageChunk] = None
-    for chunk in llm.stream(query):
+    for chunk in llm.stream([input_message]):
         assert isinstance(chunk, AIMessageChunk)
         full = chunk if full is None else full + chunk
     assert isinstance(full, AIMessageChunk)
     content_blocks = [block for block in full.content if isinstance(block, dict)]
     expected_block_types = {"executable_code", "code_execution_result"}
     assert set(block.get("type") for block in content_blocks) == expected_block_types
+
+    # Test we can process chat history
+    next_message = {
+        "role": "user",
+        "content": "Can you add some comments to the code?",
+    }
+    _ = llm.invoke([input_message, full, next_message])

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -1390,3 +1390,37 @@ def test_nested_bind_tools():
     response = llm_with_tools.invoke("Chester, no hair color provided.")
     assert isinstance(response, AIMessage)
     assert response.tool_calls[0]["name"] == "People"
+
+
+def test_search_builtin() -> None:
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME).bind_tools([{"google_search": {}}])
+    query = "What is today's news?"
+    response = llm.invoke(query)
+    assert "grounding_metadata" in response.response_metadata
+
+    # Test streaming
+    full: Optional[BaseMessageChunk] = None
+    for chunk in llm.stream(query):
+        assert isinstance(chunk, AIMessageChunk)
+        full = chunk if full is None else full + chunk
+    assert isinstance(full, AIMessageChunk)
+    assert "grounding_metadata" in full.response_metadata
+
+
+def test_code_execution_builtin() -> None:
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME).bind_tools([{"code_execution": {}}])
+    query = "What is 3^3?"
+    response = llm.invoke(query)
+    content_blocks = [block for block in response.content if isinstance(block, dict)]
+    expected_block_types = {"executable_code", "code_execution_result"}
+    assert set(block.get("type") for block in content_blocks) == expected_block_types
+
+    # Test streaming
+    full: Optional[BaseMessageChunk] = None
+    for chunk in llm.stream(query):
+        assert isinstance(chunk, AIMessageChunk)
+        full = chunk if full is None else full + chunk
+    assert isinstance(full, AIMessageChunk)
+    content_blocks = [block for block in full.content if isinstance(block, dict)]
+    expected_block_types = {"executable_code", "code_execution_result"}
+    assert set(block.get("type") for block in content_blocks) == expected_block_types


### PR DESCRIPTION
ChatVertexAI already supports grounding / search via `bind_tools([{"google_search": {}}])`.

Here we do the same for the `code_execution` tool.