### PR TITLE
[community]: Adding optional timeout parameter to Vertex Reranker

### DIFF
--- a/libs/community/langchain_google_community/vertex_rank.py
+++ b/libs/community/langchain_google_community/vertex_rank.py
@@ -52,6 +52,7 @@ class VertexAIRank(BaseDocumentCompressor):
         credentials (Optional[Credentials]): Google Cloud credentials object.
         credentials_path (Optional[str]): Path to the Google Cloud service
         account credentials file.
+        timeout (Optional[int]): Timeout for API calls in seconds.
     """
 
     project_id: str = Field(default=None)  # type: ignore

--- a/libs/community/langchain_google_community/vertex_rank.py
+++ b/libs/community/langchain_google_community/vertex_rank.py
@@ -64,6 +64,7 @@ class VertexAIRank(BaseDocumentCompressor):
     title_field: Optional[str] = Field(default=None)
     credentials: Optional[Credentials] = Field(default=None)
     credentials_path: Optional[str] = Field(default=None)
+    timeout: Optional[int] = Field(default=None)
     client: Any = None
 
     def __init__(self, **kwargs: Any):
@@ -152,7 +153,7 @@ class VertexAIRank(BaseDocumentCompressor):
         )
 
         try:
-            response = self.client.rank(request=request)
+            response = self.client.rank(request=request, timeout=self.timeout)
         except core_exceptions.GoogleAPICallError as e:
             print(f"Error in Vertex AI Ranking API call: {str(e)}")
             raise RuntimeError(f"Error in Vertex AI Ranking API call: {str(e)}") from e

--- a/libs/community/tests/unit_tests/test_rank.py
+++ b/libs/community/tests/unit_tests/test_rank.py
@@ -44,11 +44,13 @@ def test_vertex_ai_ranker_initialization(mock_rank_service_client: Mock) -> None
         ranking_config="test-config",
         title_field="source",
         client=mock_rank_service_client,
+        timeout=5,
     )
     assert ranker.project_id == "test-project"
     assert ranker.location_id == "test-location"
     assert ranker.ranking_config == "test-config"
     assert ranker.title_field == "source"
+    assert ranker.timeout == 5
 
 
 @patch("google.cloud.discoveryengine_v1alpha.RankServiceClient")


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [x] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [x] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [x] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [x] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [x] PR title and description are appropriate
- [x] Necessary tests and documentation have been added
- [x] Lint and tests pass successfully
- [x] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

For productive use of the rerank api, I need to be able to set a timeout to end the request after a certain time so that I can continue with my workflow.
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature


## Changes(optional)

<!-- List of changes -->

## Testing(optional)
* Timeout has been added to unit test.
<!-- Test procedure -->
<!-- Test result -->

## Note(optional)

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
