### PR TITLE
[genai]: add missing transport argument

### DIFF
--- a/libs/genai/langchain_google_genai/embeddings.py
+++ b/libs/genai/langchain_google_genai/embeddings.py
@@ -98,6 +98,7 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
             api_key=google_api_key,
             client_info=client_info,
             client_options=self.client_options,
+            transport=self.transport,
         )
         return self
 


### PR DESCRIPTION
## PR Description

 I spotted that the `transport` argument was not being passed down correctly in `GoogleGenerativeAIEmbeddings` which was causing my calls to fail in a proxy environnement. 

## Type

🐛 Bug Fix