### PR TITLE
[genai]: Quick fix for "Unknown field for Part: thought"

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -504,7 +504,7 @@ def _parse_response_candidate(
         except AttributeError:
             text = None
 
-        if hasattr(part, 'thought') and part.thought:
+        if hasattr(part, "thought") and part.thought:
             thinking_message = {
                 "type": "thinking",
                 "thinking": part.text,

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -504,7 +504,7 @@ def _parse_response_candidate(
         except AttributeError:
             text = None
 
-        if part.thought:
+        if hasattr(part, 'thought') and part.thought:
             thinking_message = {
                 "type": "thinking",
                 "thinking": part.text,


### PR DESCRIPTION
## PR Description
Fix AttributeError when accessing undefined 'thought' field implementing defensive attribute checking.

## Relevant issues
Fixes #956

## Type
🐛 Bug Fix

## Changes
- Replace direct attribute access `part.thought` with safe attribute checking using `hasattr(part, 'thought') and part.thought`
- Prevent AttributeError when processing Part objects without 'thought' field
- Maintain backwards compatibility with existing Part objects