### PR TITLE
vertexai[patch]: cache prediction client

### DIFF
--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -30,6 +30,7 @@ from langchain_core.output_parsers.openai_tools import (
     PydanticToolsParser,
 )
 from pydantic import BaseModel
+from pytest_benchmark.fixture import BenchmarkFixture  # type: ignore[import-untyped]
 from vertexai.generative_models import (  # type: ignore
     SafetySetting as VertexSafetySetting,
 )
@@ -1378,3 +1379,15 @@ def test_anthropic_format_output_with_chain_of_thoughts() -> None:
         "cache_creation_input_tokens": 1,
         "cache_read_input_tokens": 1,
     }
+
+
+@pytest.mark.benchmark
+def test_init_time_with_client(benchmark: BenchmarkFixture) -> None:
+    """Test time to instantiate ChatVertexAI and its prediction client."""
+
+    def _init_in_loop() -> None:
+        for _ in range(10):
+            llm = ChatVertexAI(model="gemini-2.0-flash-001")
+            _ = llm.prediction_client  # client is instantiated lazily
+
+    benchmark(_init_in_loop)

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -38,6 +38,7 @@ from vertexai.language_models import (  # type: ignore
     InputOutputTextPair,
 )
 
+from langchain_google_vertexai._base import _get_prediction_client
 from langchain_google_vertexai._image_utils import ImageBytesLoader
 from langchain_google_vertexai.chat_models import (
     ChatVertexAI,
@@ -47,6 +48,13 @@ from langchain_google_vertexai.chat_models import (
     _parse_response_candidate,
 )
 from langchain_google_vertexai.model_garden import ChatAnthropicVertex
+
+
+@pytest.fixture
+def clear_prediction_client_cache() -> None:
+    # Clear the prediction client cache so we can mock varied calls to
+    # PredictionServiceClient
+    _get_prediction_client.cache_clear()
 
 
 def test_init() -> None:
@@ -141,7 +149,9 @@ def test_init_client(model: str, location: str) -> None:
         ),
     ],
 )
-def test_model_name_presence_in_chat_results(model: str, location: str) -> None:
+def test_model_name_presence_in_chat_results(
+    model: str, location: str, clear_prediction_client_cache: Any
+) -> None:
     config = {"model": model, "location": location}
     llm = ChatVertexAI(
         **{k: v for k, v in config.items() if v is not None}, project="test-proj"
@@ -1183,7 +1193,7 @@ def test_init_client_with_custom_api_endpoint() -> None:
         assert transport == "rest"
 
 
-def test_init_client_with_custom_base_url() -> None:
+def test_init_client_with_custom_base_url(clear_prediction_client_cache: Any) -> None:
     config = {
         "model": "gemini-1.5-pro",
         "base_url": "https://example.com",

--- a/libs/vertexai/tests/unit_tests/test_llm.py
+++ b/libs/vertexai/tests/unit_tests/test_llm.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
+import pytest
 from google.cloud.aiplatform_v1beta1.types import (
     Candidate,
     Content,
@@ -11,8 +12,18 @@ from google.cloud.aiplatform_v1beta1.types import (
 from pydantic import model_validator
 from typing_extensions import Self
 
-from langchain_google_vertexai._base import _BaseVertexAIModelGarden
+from langchain_google_vertexai._base import (
+    _BaseVertexAIModelGarden,
+    _get_prediction_client,
+)
 from langchain_google_vertexai.llms import VertexAI
+
+
+@pytest.fixture
+def clear_prediction_client_cache() -> None:
+    # Clear the prediction client cache so we can mock varied calls to
+    # PredictionServiceClient
+    _get_prediction_client.cache_clear()
 
 
 def test_model_name() -> None:
@@ -54,7 +65,7 @@ def test_tuned_model_name() -> None:
     )
 
 
-def test_vertexai_args_passed() -> None:
+def test_vertexai_args_passed(clear_prediction_client_cache: Any) -> None:
     response_text = "Goodbye"
     user_prompt = "Hello"
     prompt_params: Dict[str, Any] = {


### PR DESCRIPTION
Before:
```
------------------------------------------------ benchmark: 1 tests -----------------------------------------------
Name (time in s)                  Min     Max    Mean  StdDev  Median     IQR  Outliers     OPS  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------
test_init_time_with_client     3.3915  3.4748  3.4339  0.0347  3.4483  0.0554       2;0  0.2912       5           1
-------------------------------------------------------------------------------------------------------------------
```
After:
```
------------------------------------------------- benchmark: 1 tests ------------------------------------------------
Name (time in ms)                 Min     Max    Mean  StdDev  Median     IQR  Outliers       OPS  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------
test_init_time_with_client     1.8416  2.0143  1.9460  0.0774  1.9784  0.1342       1;0  513.8746       5           1
---------------------------------------------------------------------------------------------------------------------
```
Mean improves from 3 s to 2 ms.

Test:
```python
for _ in range(10):
    llm = ChatVertexAI(model="gemini-2.0-flash-001")
    _ = llm.prediction_client  # client is instantiated lazily
```