### PR TITLE
community: fix operation precedence VertexAIRank when credentails are provided…

### DIFF
--- a/libs/community/langchain_google_community/vertex_rank.py
+++ b/libs/community/langchain_google_community/vertex_rank.py
@@ -95,9 +95,9 @@ class VertexAIRank(BaseDocumentCompressor):
                 "`pip install langchain-google-community[vertexaisearch]`"
             ) from exc
         return discoveryengine_v1alpha.RankServiceClient(
-            credentials=(
-                self.credentials
-                or Credentials.from_service_account_file(self.credentials_path)  # type: ignore[attr-defined]
+            credentials=self.credentials
+            or (
+                Credentials.from_service_account_file(self.credentials_path)  # type: ignore[attr-defined]
                 if self.credentials_path
                 else None
             ),


### PR DESCRIPTION
## PR DESCRIPTION

  - Fix operation precedence when credentials are provided. Right now the code only admits credentials_path. 

## Relevant issues

  - Current approach does not allow users to provide the credentials json directly. 

## Type 

🐛 Bug Fix
