### PR TITLE
[vertexai]: fix IndexError when a tool returns an empty list

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -451,8 +451,10 @@ def _parse_chat_history_gemini(
                         "Merging values together"
                     )
                     content = {k: "".join(v) for k, v in merged_content.items()}
-                else:
+                elif len(parsed_content) == 1:
                     content = parsed_content[0]
+                else:
+                    content = {"content": ""}
             else:
                 content = _parse_content(message.content)
 

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -318,6 +318,7 @@ def test_parse_history_gemini_converted_message() -> None:
     assert history[1].role == "model"
     assert history[1].parts[0].text == text_answer1
 
+
 def test_parse_history_gemini_function_empty_list() -> None:
     system_input = "You're supposed to answer math questions."
     text_question1 = "Solve the following equation. x^2+16=0"

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -318,6 +318,55 @@ def test_parse_history_gemini_converted_message() -> None:
     assert history[1].role == "model"
     assert history[1].parts[0].text == text_answer1
 
+def test_parse_history_gemini_function_empty_list() -> None:
+    system_input = "You're supposed to answer math questions."
+    text_question1 = "Solve the following equation. x^2+16=0"
+    fn_name_1 = "root"
+
+    tool_call_1 = create_tool_call(
+        name=fn_name_1,
+        id="1",
+        args={
+            "arg1": "-10",
+            "arg2": "10",
+        },
+    )
+
+    system_message = SystemMessage(content=system_input)
+    message1 = HumanMessage(content=text_question1)
+    message2 = AIMessage(
+        content="",
+        tool_calls=[
+            tool_call_1,
+        ],
+    )
+    message3 = ToolMessage(content=[], tool_call_id="1")
+    messages = [
+        system_message,
+        message1,
+        message2,
+        message3,
+    ]
+    image_bytes_loader = ImageBytesLoader()
+    system_instructions, history = _parse_chat_history_gemini(
+        messages, image_bytes_loader
+    )
+    assert len(history) == 3
+    assert system_instructions and system_instructions.parts[0].text == system_input
+    assert history[0].role == "user"
+    assert history[0].parts[0].text == text_question1
+
+    assert history[1].role == "model"
+    assert history[1].parts[0].function_call == FunctionCall(
+        name=tool_call_1["name"], args=tool_call_1["args"]
+    )
+
+    assert history[2].role == "function"
+    assert history[2].parts[0].function_response == FunctionResponse(
+        name=fn_name_1,
+        response={"content": ""},
+    )
+
 
 def test_parse_history_gemini_function() -> None:
     system_input = "You're supposed to answer math questions."


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

<!-- e.g. "Implement user authentication feature" -->
It is possible that a tool returns an empty list, which is a valid response. Currently, `_parse_chat_history_gemini` didn't check if the list is empty and tries to take the first element and return it as content.

## Type

🐛 Bug Fix

## Changes(optional)

- check if `parsed_content` is an empty list and if so assign empty string as content
