### PR TITLE
vertexai: strip nullable anyOf when using dedicated structured output feature

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_utils.py
@@ -363,3 +363,47 @@ def _get_def_key_from_schema_path(schema_path: str) -> str:
         raise ValueError(error_message)
 
     return parts[-1]
+
+
+def _strip_nullable_anyof(schema: dict[str, Any]) -> dict[str, Any]:
+    """Collapse ``anyOf([{...}, {"type": "null"}])``` into the non-null schema,
+    leave the rest of the keywords alone, and make the property optional.
+    Works in place.
+    """
+
+    def walk(node):
+        if not isinstance(node, dict):
+            return
+
+        props = node.get("properties", {})
+        for prop_name, prop_schema in list(props.items()):
+
+            any_of = prop_schema.get("anyOf")
+            if any_of and len(any_of) == 2:
+                null_branch  = next((b for b in any_of if b.get("type") == "null"), None)
+                other_branch = next((b for b in any_of if b is not null_branch), None)
+
+                if null_branch and other_branch:
+                    # remove the anyOf *only*
+                    prop_schema.pop("anyOf")
+                    # and overlay the surviving branch
+                    prop_schema.update(other_branch)
+
+                    # make the property optional
+                    req = node.get("required", [])
+                    if prop_name in req:
+                        req.remove(prop_name)
+                        if not req:
+                            node.pop("required")
+
+            walk(prop_schema)
+
+        if "items" in node:
+            walk(node["items"])
+
+        for combiner in ("allOf", "anyOf", "oneOf"):
+            for sub in node.get(combiner, []):
+                walk(sub)
+
+    walk(schema)
+    return schema

--- a/libs/vertexai/langchain_google_vertexai/_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_utils.py
@@ -377,10 +377,9 @@ def _strip_nullable_anyof(schema: dict[str, Any]) -> dict[str, Any]:
 
         props = node.get("properties", {})
         for prop_name, prop_schema in list(props.items()):
-
             any_of = prop_schema.get("anyOf")
             if any_of and len(any_of) == 2:
-                null_branch  = next((b for b in any_of if b.get("type") == "null"), None)
+                null_branch = next((b for b in any_of if b.get("type") == "null"), None)
                 other_branch = next((b for b in any_of if b is not null_branch), None)
 
                 if null_branch and other_branch:

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -135,6 +135,7 @@ from langchain_google_vertexai._utils import (
     _format_model_name,
     is_gemini_model,
     replace_defs_in_schema,
+    _strip_nullable_anyof,
 )
 from langchain_google_vertexai.functions_utils import (
     _format_tool_config,
@@ -2086,6 +2087,9 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             # Resolve refs in schema because they are not supported
             # by the Gemini API.
             schema_json = replace_defs_in_schema(schema_json)
+
+            # API does not support anyOf.
+            schema_json = _strip_nullable_anyof(schema_json)
 
             llm = self.bind(
                 response_mime_type="application/json",


### PR DESCRIPTION
```python
from typing import Optional
from pydantic import BaseModel
from langchain_google_vertexai import ChatVertexAI


class Fruit(BaseModel):
    name: str
    color: Optional[str]


class FruitList(BaseModel):
    fruits: list[Fruit]


llm = ChatVertexAI(
    model="gemini-2.5-flash-preview-05-20",
).with_structured_output(FruitList, method="json_mode")


res = llm.invoke("Give me 5 fruits")
```
> ValueError: Protocol message Schema has no "anyOf" field.