### PR TITLE
Fix issue with thought_signature introduced in 1.96.0

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -1619,7 +1619,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
                 v1_parts = []
                 for part in content.parts:
                     raw_part = proto.Message.to_dict(part)
-                    # Removing these fields because in v1beta Part they are added by default
+                    # Removing these fields they are in v1beta with text field
                     # But in v1 they are exclusive to the text field
                     raw_part.pop("thought", None)
                     raw_part.pop("thought_signature", None)

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -560,13 +560,15 @@ def _get_question(messages: List[BaseMessage]) -> HumanMessage:
 @overload
 def _parse_response_candidate(
     response_candidate: "Candidate", streaming: Literal[False] = False
-) -> AIMessage: ...
+) -> AIMessage:
+    ...
 
 
 @overload
 def _parse_response_candidate(
     response_candidate: "Candidate", streaming: Literal[True]
-) -> AIMessageChunk: ...
+) -> AIMessageChunk:
+    ...
 
 
 def _parse_response_candidate(
@@ -2341,13 +2343,10 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             # is_blocked is part of "safety_ratings" list
             # but if it's True/False then chunks can't be marged
             generation_info.pop("is_blocked", None)
-        return (
-            ChatGenerationChunk(
-                message=message,
-                generation_info=generation_info,
-            ),
-            total_lc_usage,
-        )
+        return ChatGenerationChunk(
+            message=message,
+            generation_info=generation_info,
+        ), total_lc_usage
 
 
 def _get_usage_metadata_gemini(raw_metadata: dict) -> Optional[UsageMetadata]:


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [x] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [x] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

In https://github.com/googleapis/python-aiplatform/pull/5380, Google introduced a new field called thought_signature.
We need to exclude thought_signature similar to thought because v1Beta and v1 protobuf are defined differently.

In v1Beta, thought_signature field can co-exist with text field, but in v1 they are exclusive to each other.


## Relevant issues

None

## Type
🐛 Bug Fix

## Changes(optional)


## Testing(optional)


## Note(optional)
This issue will occur when google-cloud-aiplatform>=1.96.0 is installed.
