### PR TITLE
genai[patch]: fix totals in usage metadata and refactor

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -72,7 +72,7 @@ from langchain_core.messages import (
     ToolMessage,
     is_data_content_block,
 )
-from langchain_core.messages.ai import UsageMetadata
+from langchain_core.messages.ai import UsageMetadata, add_usage, subtract_usage
 from langchain_core.messages.tool import invalid_tool_call, tool_call, tool_call_chunk
 from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.base import OutputParserLike
@@ -716,35 +716,32 @@ def _response_to_result(
     """Converts a PaLM API response into a LangChain ChatResult."""
     llm_output = {"prompt_feedback": proto.Message.to_dict(response.prompt_feedback)}
 
-    # previous usage metadata needs to be subtracted because gemini api returns
-    # already-accumulated token counts with each chunk
-    prev_input_tokens = prev_usage["input_tokens"] if prev_usage else 0
-    prev_output_tokens = prev_usage["output_tokens"] if prev_usage else 0
-    prev_total_tokens = prev_usage["total_tokens"] if prev_usage else 0
-
     # Get usage metadata
     try:
         input_tokens = response.usage_metadata.prompt_token_count
-        output_tokens = response.usage_metadata.candidates_token_count
-        total_tokens = response.usage_metadata.total_token_count
         thought_tokens = response.usage_metadata.thoughts_token_count
+        output_tokens = response.usage_metadata.candidates_token_count + thought_tokens
+        total_tokens = response.usage_metadata.total_token_count
         cache_read_tokens = response.usage_metadata.cached_content_token_count
         if input_tokens + output_tokens + cache_read_tokens + total_tokens > 0:
             if thought_tokens > 0:
-                lc_usage = UsageMetadata(
-                    input_tokens=input_tokens - prev_input_tokens,
-                    output_tokens=output_tokens - prev_output_tokens,
-                    total_tokens=total_tokens - prev_total_tokens,
+                cumulative_usage = UsageMetadata(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    total_tokens=total_tokens,
                     input_token_details={"cache_read": cache_read_tokens},
                     output_token_details={"reasoning": thought_tokens},
                 )
             else:
-                lc_usage = UsageMetadata(
-                    input_tokens=input_tokens - prev_input_tokens,
-                    output_tokens=output_tokens - prev_output_tokens,
-                    total_tokens=total_tokens - prev_total_tokens,
+                cumulative_usage = UsageMetadata(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    total_tokens=total_tokens,
                     input_token_details={"cache_read": cache_read_tokens},
                 )
+            # previous usage metadata needs to be subtracted because gemini api returns
+            # already-accumulated token counts with each chunk
+            lc_usage = subtract_usage(cumulative_usage, prev_usage)
         else:
             lc_usage = None
     except AttributeError:
@@ -1522,7 +1519,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             metadata=self.default_metadata,
         )
 
-        prev_usage_metadata: UsageMetadata | None = None
+        prev_usage_metadata: UsageMetadata | None = None  # cumulative usage
         for chunk in response:
             _chat_result = _response_to_result(
                 chunk, stream=True, prev_usage=prev_usage_metadata
@@ -1530,21 +1527,10 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             gen = cast(ChatGenerationChunk, _chat_result.generations[0])
             message = cast(AIMessageChunk, gen.message)
 
-            curr_usage_metadata: UsageMetadata | dict[str, int] = (
-                message.usage_metadata or {}
-            )
-
             prev_usage_metadata = (
                 message.usage_metadata
                 if prev_usage_metadata is None
-                else UsageMetadata(
-                    input_tokens=prev_usage_metadata.get("input_tokens", 0)
-                    + curr_usage_metadata.get("input_tokens", 0),
-                    output_tokens=prev_usage_metadata.get("output_tokens", 0)
-                    + curr_usage_metadata.get("output_tokens", 0),
-                    total_tokens=prev_usage_metadata.get("total_tokens", 0)
-                    + curr_usage_metadata.get("total_tokens", 0),
-                )
+                else add_usage(prev_usage_metadata, message.usage_metadata)
             )
 
             if run_manager:
@@ -1594,7 +1580,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 tool_choice=tool_choice,
                 **kwargs,
             )
-            prev_usage_metadata: UsageMetadata | None = None
+            prev_usage_metadata: UsageMetadata | None = None  # cumulative usage
             async for chunk in await _achat_with_retry(
                 request=request,
                 generation_method=self.async_client.stream_generate_content,
@@ -1607,21 +1593,10 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 gen = cast(ChatGenerationChunk, _chat_result.generations[0])
                 message = cast(AIMessageChunk, gen.message)
 
-                curr_usage_metadata: UsageMetadata | dict[str, int] = (
-                    message.usage_metadata or {}
-                )
-
                 prev_usage_metadata = (
                     message.usage_metadata
                     if prev_usage_metadata is None
-                    else UsageMetadata(
-                        input_tokens=prev_usage_metadata.get("input_tokens", 0)
-                        + curr_usage_metadata.get("input_tokens", 0),
-                        output_tokens=prev_usage_metadata.get("output_tokens", 0)
-                        + curr_usage_metadata.get("output_tokens", 0),
-                        total_tokens=prev_usage_metadata.get("total_tokens", 0)
-                        + curr_usage_metadata.get("total_tokens", 0),
-                    )
+                    else add_usage(prev_usage_metadata, message.usage_metadata)
                 )
 
                 if run_manager:

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -63,15 +63,9 @@ def _check_usage_metadata(message: AIMessage) -> None:
     assert message.usage_metadata["input_tokens"] > 0
     assert message.usage_metadata["output_tokens"] > 0
     assert message.usage_metadata["total_tokens"] > 0
-    if "output_token_details" in message.usage_metadata:
-        thought_tokens = message.usage_metadata["output_token_details"]["reasoning"]
-    else:
-        thought_tokens = 0
 
     assert (
-        message.usage_metadata["input_tokens"]
-        + message.usage_metadata["output_tokens"]
-        + thought_tokens
+        message.usage_metadata["input_tokens"] + message.usage_metadata["output_tokens"]
     ) == message.usage_metadata["total_tokens"]
 
 

--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -21,8 +21,9 @@ class TestGeminiAI2Standard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model": "models/gemini-2.0-flash-001",
+            "model": "models/gemini-2.5-flash",
             "rate_limiter": rate_limiter,
+            "thinking_budget": 0,
         }
 
     @property
@@ -63,6 +64,12 @@ class TestGeminiAIStandard(ChatModelIntegrationTests):
         self, model: BaseChatModel, my_adder_tool: BaseTool
     ) -> None:
         super().test_tool_message_histories_list_content(model, my_adder_tool)
+
+    @pytest.mark.xfail(
+        reason="Investigate: prompt_token_count inconsistent in final chunk."
+    )
+    def test_usage_metadata_streaming(self, model: BaseChatModel) -> None:
+        super().test_usage_metadata_streaming(model)
 
     @property
     def supported_usage_metadata_details(

--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -45,16 +45,6 @@ class TestGeminiAI2Standard(ChatModelIntegrationTests):
     def supports_audio_inputs(self) -> bool:
         return True
 
-    @pytest.mark.xfail(
-        reason="Likely a bug in genai: prompt_token_count inconsistent in final chunk."
-    )
-    def test_usage_metadata_streaming(self, model: BaseChatModel) -> None:
-        super().test_usage_metadata_streaming(model)
-
-    @pytest.mark.xfail(reason="investigate")
-    def test_bind_runnables_as_tools(self, model: BaseChatModel) -> None:
-        super().test_bind_runnables_as_tools(model)
-
 
 class TestGeminiAIStandard(ChatModelIntegrationTests):
     @property
@@ -73,12 +63,6 @@ class TestGeminiAIStandard(ChatModelIntegrationTests):
         self, model: BaseChatModel, my_adder_tool: BaseTool
     ) -> None:
         super().test_tool_message_histories_list_content(model, my_adder_tool)
-
-    @pytest.mark.xfail(
-        reason="Investigate: prompt_token_count inconsistent in final chunk."
-    )
-    def test_usage_metadata_streaming(self, model: BaseChatModel) -> None:
-        super().test_usage_metadata_streaming(model)
 
     @property
     def supported_usage_metadata_details(


### PR DESCRIPTION
Addresses two issues:

1. `output_tokens` in [usage_metadata](https://python.langchain.com/api_reference/core/messages/langchain_core.messages.ai.UsageMetadata.html) currently does not include thought token counts. Here we add those so that `input_tokens` + `output_tokens` = `total_tokens`.

2. refactor to use utility functions for adding and subtracting usage metadata in core.