### PR TITLE
Add test coverage for optional BigQuery dependency

### DIFF
--- a/libs/community/langchain_google_community/bigquery.py
+++ b/libs/community/langchain_google_community/bigquery.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Any
 
 from langchain_core.document_loaders import BaseLoader
 from langchain_core.documents import Document
+from langchain_core.utils import guard_import
 
 from langchain_google_community._utils import get_client_info
 
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials  # type: ignore[import]
+
+
+def import_bigquery() -> Any:
+    """Import the google-cloud-bigquery library and return the client."""
+    return guard_import(
+        "google.cloud.bigquery", pip_name="langchain-google-community[bigquery]"
+    )
 
 
 class BigQueryLoader(BaseLoader):
@@ -44,6 +52,7 @@ class BigQueryLoader(BaseLoader):
                 (`google.auth.compute_engine.Credentials`) or Service Account
                 (`google.oauth2.service_account.Credentials`) credentials directly.
         """
+        import_bigquery()
         self.query = query
         self.project = project
         self.page_content_columns = page_content_columns

--- a/libs/community/tests/unit_tests/test_bigquery.py
+++ b/libs/community/tests/unit_tests/test_bigquery.py
@@ -1,0 +1,24 @@
+"""Unit tests for the BigQueryLoader."""
+import pytest
+from unittest.mock import patch
+
+from langchain_google_community.bigquery import BigQueryLoader
+
+
+@patch("langchain_google_community.bigquery.import_bigquery")
+def test_bigquery_loader_import_error(mock_import_bigquery):
+    """Test that BigQueryLoader raises an ImportError if google-cloud-bigquery is not installed."""
+    # Simulate the ImportError that occurs when the dependency is missing
+    mock_import_bigquery.side_effect = ImportError(
+        "Could not import google.cloud.bigquery python package. "
+        "Please, install it with `pip install langchain-google-community[bigquery]`"
+    )
+
+    with pytest.raises(ImportError) as excinfo:
+        BigQueryLoader(query="SELECT 1")
+
+    assert "Could not import google.cloud.bigquery python package." in str(excinfo.value)
+    assert (
+        "Please, install it with `pip install langchain-google-community[bigquery]`"
+        in str(excinfo.value)
+    )


### PR DESCRIPTION
## PR Description
This update addresses the issue of limited test coverage for optional dependencies within the `langchain-google-community` package, using `BigQueryLoader` as the initial implementation.

Previously, modules with optional dependencies might not have been adequately tested for scenarios where those dependencies were missing, potentially leading to unexpected errors for users with minimal installations.

This change enhances the robustness of the package by:

1.  **Adding a Guarded Import:** The `BigQueryLoader` now checks for the `google-cloud-bigquery` package upon instantiation. If the dependency is not found, it raises a clear `ImportError` with instructions on how to install it.
2.  **Introducing a New Unit Test:** A dedicated unit test has been added to simulate an environment where `google-cloud-bigquery` is not installed. This test verifies that the `BigQueryLoader` raises the correct `ImportError`, ensuring this behavior is maintained and preventing future regressions.

This approach improves the reliability and user experience of the library, providing graceful failures and clear guidance when required dependencies are missing.

All existing and new tests pass successfully after these changes.
