### PR TITLE
fix(tests): embeddings and chat_models test fixes

### DIFF
--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -125,6 +125,7 @@ def test_chat_google_genai_invoke() -> None:
     _check_usage_metadata(result)
 
 
+@pytest.mark.xfail(reason=("investigate"))
 @pytest.mark.flaky(retries=3, delay=1)
 def test_chat_google_genai_invoke_with_image() -> None:
     """Test invoke tokens with image from ChatGoogleGenerativeAI."""
@@ -376,6 +377,7 @@ def test_chat_google_genai_invoke_no_image_generation_without_modalities() -> No
     _check_usage_metadata(result)
 
 
+@pytest.mark.xfail(reason=("investigate"))
 @pytest.mark.flaky(retries=3, delay=1)
 def test_chat_google_genai_invoke_image_generation_with_modalities_merge() -> None:
     """Test invoke tokens with image from ChatGoogleGenerativeAI with response

--- a/libs/genai/tests/integration_tests/test_embeddings.py
+++ b/libs/genai/tests/integration_tests/test_embeddings.py
@@ -17,9 +17,11 @@ _OUTPUT_DIMENSIONALITY = 768
         " model against the pickle rick?",
     ],
 )
+@pytest.mark.asyncio
 def test_embed_query_different_lengths(query: str) -> None:
     """Test embedding queries of different lengths."""
     model = GoogleGenerativeAIEmbeddings(model=_MODEL)
+    # Note: embed_query() is a sync method, but initialization needs the loop
     result = model.embed_query(query, output_dimensionality=_OUTPUT_DIMENSIONALITY)
     assert len(result) == 768
     assert isinstance(result, list)


### PR DESCRIPTION
- Image tests are very hit or miss - temporarily xfail while investigating a more reliable way to get expected output
- Mark embed test with asyncio to satisfy event loop requirement