### PR TITLE
chore: added latest meta models

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/model_garden_maas/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden_maas/_base.py
@@ -39,6 +39,9 @@ _MISTRAL_MODELS: List[str] = [
 _LLAMA_MODELS: List[str] = [
     "meta/llama-3.2-90b-vision-instruct-maas",
     "meta/llama-3.3-70b-instruct-maas",
+    "meta/llama-4-maverick-17b-128e-instruct-maas",
+    "meta/llama-4-maverick-17b-16e-instruct-maas"
+
 ]
 
 


### PR DESCRIPTION
## PR Description

Add support for two new Llama models to the `_LLAMA_MODELS` list in `model_garden_maas/_base.py`:
- "meta/llama-4-maverick-17b-128e-instruct-maas"
- "meta/llama-4-maverick-17b-16e-instruct-maas"

## Relevant issues

N/A

## Type

🆕 New Feature

## Changes

- Added the following model names to the `_LLAMA_MODELS` list:
  - "meta/llama-4-maverick-17b-128e-instruct-maas"
  - "meta/llama-4-maverick-17b-16e-instruct-maas"

## Testing

- Confirmed that the models are now recognized as valid Llama models in the codebase.

## Note

This PR only updates the list of supported Llama models. No other changes were