### PR TITLE
vertexai: Add support for image output in ChatVertexAI code execution

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -119,7 +119,10 @@ from google.cloud.aiplatform_v1beta1.types import (
     VideoMetadata,
 )
 from langchain_google_vertexai._base import _VertexAICommon
-from langchain_google_vertexai._image_utils import ImageBytesLoader
+from langchain_google_vertexai._image_utils import (
+    ImageBytesLoader,
+    image_bytes_to_b64_string,
+)
 from langchain_google_vertexai._utils import (
     create_retry_decorator,
     get_generation_info,
@@ -727,6 +730,25 @@ def _parse_response_candidate(
                     content.append(execution_result)
                 else:
                     raise Exception("Unexpected content type")
+
+        if part.inline_data.mime_type.startswith("image/"):
+            image_format = part.inline_data.mime_type[6:]
+            image_message = {
+                "type": "image_url",
+                "image_url": {
+                    "url": image_bytes_to_b64_string(
+                        part.inline_data.data, image_format=image_format
+                    )
+                },
+            }
+            if not content:
+                content = [image_message]
+            elif isinstance(content, str):
+                content = [content, image_message]
+            elif isinstance(content, list):
+                content.append(image_message)
+            else:
+                raise Exception("Unexpected content type")
 
     if content is None:
         content = ""

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -1,5 +1,6 @@
 """Test chat model integration."""
 
+import base64
 import json
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -7,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from google.cloud.aiplatform_v1beta1.types import (
+    Blob,
     Candidate,
     Content,
     FunctionCall,
@@ -672,6 +674,98 @@ def test_default_params_gemini() -> None:
             ),
             AIMessage(
                 content=["Mike age is 30", "Arthur age is 30"],
+                additional_kwargs={},
+            ),
+        ),
+        (
+            Candidate(
+                content=Content(
+                    role="model",
+                    parts=[
+                        Part(
+                            inline_data=Blob(
+                                data=base64.b64decode("Qk0eAAAAAABoAAMAQABAEAGAAP8A"),
+                                mime_type="image/png",
+                            )
+                        )
+                    ],
+                )
+            ),
+            AIMessage(
+                content=[
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,Qk0eAAAAAABoAAMAQABAEAGAAP8A"
+                        },
+                    }
+                ],
+                additional_kwargs={},
+            ),
+        ),
+        (
+            Candidate(
+                content=Content(
+                    role="model",
+                    parts=[
+                        Part(text="Here is an image:"),
+                        Part(
+                            inline_data=Blob(
+                                data=base64.b64decode("Qk0eAAAAAABoAAMAQABAEAGAAP8A"),
+                                mime_type="image/jpeg",
+                            )
+                        ),
+                    ],
+                )
+            ),
+            AIMessage(
+                content=[
+                    "Here is an image:",
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/jpeg;base64,Qk0eAAAAAABoAAMAQABAEAGAAP8A"
+                        },
+                    },
+                ],
+                additional_kwargs={},
+            ),
+        ),
+        (
+            Candidate(
+                content=Content(
+                    role="model",
+                    parts=[
+                        Part(
+                            inline_data=Blob(
+                                data=base64.b64decode("Qk0eAAAAAABoAAMAQABAEAGAAP8A"),
+                                mime_type="image/png",
+                            )
+                        ),
+                        Part(
+                            inline_data=Blob(
+                                data=base64.b64decode("Qk0eAAAAAABoAAMAQABAEAGAAP8A"),
+                                mime_type="image/gif",
+                            )
+                        ),
+                    ],
+                )
+            ),
+            AIMessage(
+                content=[
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,Qk0eAAAAAABoAAMAQABAEAGAAP8A"
+                        },
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/gif;base64,Qk0eAAAAAABoAAMAQABAEAGAAP8A"
+                        },
+                    },
+                ],
                 additional_kwargs={},
             ),
         ),


### PR DESCRIPTION
## PR Description

This PR adds support for handling image output in ChatVertexAI when code execution generates plots (e.g using matplotlib). The changes ensure that image data (in formats like PNG, JPEG, or GIF) is properly converted to base64-encoded URLs and included in the response similar to `langchain_google_genai`, addressing the issue where image data was not returned.

## Relevant issues

Fixes #1048 

## Type

🐛 Bug Fix
✅ Test

## Changes

- Modified `libs/vertexai/langchain_google_vertexai/chat_models.py`:
  - Updated `_parse_response_candidate` to handle `inline_data` with image MIME types, converting image data to base64-encoded URLs in the response content.
- Modified `libs/vertexai/tests/unit_tests/test_chat_models.py`:
  - Added test cases to cover scenarios where response candidates include image data (e.g., PNG, JPEG, GIF).
  - Ensured tests validate the correct handling of single and multiple image parts, as well as mixed content (text and images).

## Testing

- **Test Procedure**:
  - Added unit tests in `test_chat_models.py` to simulate response candidates with `inline_data` containing image data.
  - Tests verify that image data is correctly parsed into `AIMessage` content as base64-encoded URLs.
  - Ran `make format`, `make lint`, and `make test` to ensure code quality and test coverage.
- **Test Result**:
  - All new tests pass, confirming that image data is properly included in the response.
  - Existing tests remain unaffected, ensuring backward compatibility.

## Note

- The changes are backwards compatible and do not introduce new dependencies.
- The PR focuses solely on the `vertexai` package.