### PR TITLE
Chore/fix incorrect meta model name

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/model_garden_maas/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden_maas/_base.py
@@ -39,6 +39,9 @@ _MISTRAL_MODELS: List[str] = [
 _LLAMA_MODELS: List[str] = [
     "meta/llama-3.2-90b-vision-instruct-maas",
     "meta/llama-3.3-70b-instruct-maas",
+    "meta/llama-4-maverick-17b-128e-instruct-maas",
+    "meta/llama-4-maverick-17b-16e-instruct-maas"
+
 ]
 
 

--- a/libs/vertexai/langchain_google_vertexai/model_garden_maas/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden_maas/_base.py
@@ -40,7 +40,7 @@ _LLAMA_MODELS: List[str] = [
     "meta/llama-3.2-90b-vision-instruct-maas",
     "meta/llama-3.3-70b-instruct-maas",
     "meta/llama-4-maverick-17b-128e-instruct-maas",
-    "meta/llama-4-maverick-17b-16e-instruct-maas"
+    "meta/llama-4-scout-17b-16e-instruct-maas"
 
 ]
 


### PR DESCRIPTION
## PR Description

Corrects the model name in `_LLAMA_MODELS` from `meta/llama-4-maverick-17b-16e-instruct-maas` to `llama-4-scout-17b-16e-instruct-maas` in `model_garden_maas/_base.py`. The previous name was incorrect.

## Relevant issues

N/A

## Type

🐛 Bug Fix

## Changes

- Updated the model name in the `_LLAMA_MODELS` list to the correct value.

## Testing

- Verified that the model name is now correct and matches the intended Vertex AI model identifier.

## Note

- This fixes a typo in the model name to ensure