### PR TITLE
vertexai : add media_resolution parameter support to ChatVertexAI

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -166,6 +166,9 @@ _allowed_params = [
     "thinking_budget",
     "include_thoughts",
 ]
+_allowed_beta_params = [
+    "media_resolution",
+]
 _allowed_params_prediction_service = ["request", "timeout", "metadata", "labels"]
 
 
@@ -1477,6 +1480,10 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             params["thinking_config"]["include_thoughts"] = include_thoughts
         _ = params.pop("include_thoughts", None)
 
+        media_resolution = kwargs.get("media_resolution")
+        if media_resolution is not None:
+            params["media_resolution"] = media_resolution
+
         return params
 
     def _get_ls_params(
@@ -1566,6 +1573,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
                 stop=stop,
                 stream=stream,
                 **{k: v for k, v in kwargs.items() if k in _allowed_params},
+                **{k: v for k, v in kwargs.items() if k in _allowed_beta_params},
             )
         )
 


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

<!-- e.g. "Implement user authentication feature" -->

Add support for media resolution parameter in ``ChatVertexAI``


<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes(optional)

<!-- List of changes -->

- Add a list of beta parameters since `media_resolution` is a parameter available in beta version only. 
- Process `media-resolution` from `kwargs` in `_prepare_params()`.
- Add `media_resolution` to returned `GenerationConfig` in `_generation_config_gemini`

## Testing(optional)

I didn't find any tests that did verification with regards to thoses parameters. Feel free to tell me if there is a problem.

<!-- Test procedure -->
<!-- Test result -->

## Note(optional)

I added a beta parameters list as to make future PRs that introduce beta parameters simpler since the scaffold is already added. 

I also add the link to the `media_resolution` parameter i mentionned below :  
https://ai.google.dev/api/generate-content#MediaResolution

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
