### PR TITLE
genai: do not ignore Enum field definition

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -414,6 +414,8 @@ def _get_items_from_schema(schema: Union[Dict, List, str]) -> Dict[str, Any]:
             items["nullable"] = True
         if "required" in schema:
             items["required"] = schema["required"]
+        if "enum" in schema:
+            items["enum"] = schema["enum"]
     else:
         # str
         items["type_"] = _get_type_from_schema({"type": schema})


### PR DESCRIPTION
## PR Description

With this change `langchain_google_genai` will no longer ignore `enum` constraints on array items.

## Relevant issues

Fixes #858

## Type

🐛 Bug Fix

## Changes(optional)

Added `enum` to the copied fields.

## Testing(optional)

Added a regression unit test that fails on current master and passes in this PR.
