### PR TITLE
fix(genai): Update image input tests

### DIFF
--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -443,7 +443,7 @@ def test_chat_google_genai_invoke_multimodal_by_url() -> None:
                 },
                 {
                     "type": "image_url",
-                    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+                    "image_url": "https://httpbin.org/image/jpeg",
                 },
             ]
         ),

--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -52,7 +52,7 @@ class TestGeminiFlashStandard(ChatModelIntegrationTests):
         """Override parent method to use a reliable image URL."""
         if not self.supports_image_inputs:
             pytest.skip("Model does not support image message.")
-        
+
         # Use a reliable image URL that works with requests
         image_url = "https://httpbin.org/image/jpeg"
         image_data = base64.b64encode(httpx.get(image_url).content).decode("utf-8")

--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -1,9 +1,12 @@
 """Standard LangChain interface tests"""
 
+import base64
 from typing import Dict, List, Literal, Type
 
+import httpx
 import pytest
 from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage
 from langchain_core.rate_limiters import InMemoryRateLimiter
 from langchain_core.tools import BaseTool
 from langchain_tests.integration_tests import ChatModelIntegrationTests
@@ -44,6 +47,55 @@ class TestGeminiFlashStandard(ChatModelIntegrationTests):
     @property
     def supports_audio_inputs(self) -> bool:
         return True
+
+    def test_image_inputs(self, model: BaseChatModel) -> None:
+        """Override parent method to use a reliable image URL."""
+        if not self.supports_image_inputs:
+            pytest.skip("Model does not support image message.")
+        
+        # Use a reliable image URL that works with requests
+        image_url = "https://httpbin.org/image/jpeg"
+        image_data = base64.b64encode(httpx.get(image_url).content).decode("utf-8")
+
+        # OpenAI format, base64 data
+        message = HumanMessage(
+            content=[
+                {"type": "text", "text": "describe the weather in this image"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{image_data}"},
+                },
+            ],
+        )
+        _ = model.invoke([message])
+
+        # Standard format, base64 data
+        message = HumanMessage(
+            content=[
+                {"type": "text", "text": "describe the weather in this image"},
+                {
+                    "type": "image",
+                    "source_type": "base64",
+                    "mime_type": "image/jpeg",
+                    "data": image_data,
+                },
+            ],
+        )
+        _ = model.invoke([message])
+
+        # Standard format, URL
+        if self.supports_image_urls:
+            message = HumanMessage(
+                content=[
+                    {"type": "text", "text": "describe the weather in this image"},
+                    {
+                        "type": "image",
+                        "source_type": "url",
+                        "url": image_url,
+                    },
+                ],
+            )
+            _ = model.invoke([message])
 
 
 class TestGeminiProStandard(ChatModelIntegrationTests):


### PR DESCRIPTION
Fixed failing integration tests caused by external image URL access issues. The Wikipedia image URL used in tests returns 403 Forbidden when accessed via Python's requests library, causing test failures that were unrelated to code changes.

Changes

- `test_chat_models.py`: Updated image URL from Wikipedia to https://httpbin.org/image/jpeg
- `test_standard.py`: Added custom `test_image_inputs()` to override the hardcoded Wikipedia URL in `langchain-tests`  with the same reliable image URL