### PR TITLE
fix(vertexai): resolve Pydantic deprecation warning in VertexAI LLM

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/llms.py
+++ b/libs/vertexai/langchain_google_vertexai/llms.py
@@ -52,7 +52,7 @@ class VertexAI(_VertexAICommon, BaseLLM):
 
         # Get all valid field names, including aliases
         valid_fields = set()
-        for field_name, field_info in self.model_fields.items():
+        for field_name, field_info in self.__class__.model_fields.items():
             valid_fields.add(field_name)
             if hasattr(field_info, "alias") and field_info.alias is not None:
                 valid_fields.add(field_info.alias)


### PR DESCRIPTION
The warning was occurring in the VertexAI class constructor when iterating over model fields for argument validation. 

Changed `self.model_fields` to `self.__class__.model_fields`