### PR TITLE
test(vertexai): add pytest warnings filter for unsupported parameters in `ChatVertexAI`

### DIFF
--- a/libs/vertexai/tests/unit_tests/test_standard.py
+++ b/libs/vertexai/tests/unit_tests/test_standard.py
@@ -1,6 +1,7 @@
 from typing import Type
 from unittest.mock import patch
 
+import pytest
 from google.cloud.aiplatform_v1beta1.types import (
     GenerateContentResponse,
 )
@@ -8,6 +9,15 @@ from langchain_core.language_models import BaseChatModel
 from langchain_tests.unit_tests import ChatModelUnitTests
 
 from langchain_google_vertexai import ChatVertexAI
+
+# Suppress warnings about parameters not supported by ChatVertexAI
+# The standard test suite passes generic parameters like 'timeout' and 'api_key'
+# that are common across providers, but ChatVertexAI uses Google Cloud auth
+# (service accounts, ADC, workload identity) and handles timeouts via client config
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:.*timeout.*not default parameter.*:UserWarning",
+    "ignore:.*api_key.*not default parameter.*:UserWarning",
+)
 
 
 class TestGemini_AIStandard(ChatModelUnitTests):


### PR DESCRIPTION
Suppress warnings related to unsupported parameters in the `ChatVertexAI` tests for a cleaner test output.