### PR TITLE
test(vertexai): suppress `UserWarning` in parameter tests

### DIFF
--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+import warnings
 from dataclasses import dataclass
 from typing import Any, Optional
 from unittest.mock import MagicMock, patch
@@ -93,13 +94,17 @@ def test_init() -> None:
 
     # test initialization with an invalid argument to check warning
     with patch("langchain_google_vertexai.chat_models.logger.warning") as mock_warning:
-        llm = ChatVertexAI(
-            model_name="gemini-pro",
-            project="test-project",
-            safety_setting={
-                "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
-            },  # Invalid arg
-        )
+        # Suppress UserWarning during test execution - we're testing the warning
+        # mechanism via logger mock assertions, not via pytest's warning system
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            llm = ChatVertexAI(
+                model_name="gemini-pro",
+                project="test-project",
+                safety_setting={
+                    "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
+                },  # Invalid arg
+            )
         assert llm.model_name == "gemini-pro"
         assert llm.project == "test-project"
         mock_warning.assert_called_once()

--- a/libs/vertexai/tests/unit_tests/test_llm.py
+++ b/libs/vertexai/tests/unit_tests/test_llm.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -36,13 +37,17 @@ def test_model_name() -> None:
 
     # Test initialization with an invalid argument to check warning
     with patch("langchain_google_vertexai.llms.logger.warning") as mock_warning:
-        llm = VertexAI(
-            model_name="gemini-pro",
-            project="test-project",
-            safety_setting={
-                "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
-            },  # Invalid arg
-        )
+        # Suppress UserWarning during test execution - we're testing the warning
+        # mechanism via logger mock assertions, not via pytest's warning system
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            llm = VertexAI(
+                model_name="gemini-pro",
+                project="test-project",
+                safety_setting={
+                    "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
+                },  # Invalid arg
+            )
         assert llm.model_name == "gemini-pro"
         assert llm.project == "test-project"
         mock_warning.assert_called_once()


### PR DESCRIPTION
The unit tests for both `ChatVertexAI` and `VertexAI` classes intentionally pass an invalid parameter name (`safety_setting` instead of `safety_settings`) to test the warning mechanism. However, this was causing pytest to display the UserWarning during test execution, creating noise in test output.