### PR TITLE
fix(vertexai): Set `requires_reference=True` for `VertexPairWiseStringEvaluator`

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/evaluators/evaluation.py
+++ b/libs/vertexai/langchain_google_vertexai/evaluators/evaluation.py
@@ -240,6 +240,11 @@ class VertexStringEvaluator(_EvaluatorBase, StringEvaluator):
 class VertexPairWiseStringEvaluator(_EvaluatorBase, PairwiseStringEvaluator):
     """Evaluate the perplexity of a predicted string."""
 
+    @property
+    def requires_reference(self) -> bool:
+        """Whether this evaluator requires a reference label."""
+        return True
+
     def __init__(self, metric: str, **kwargs):
         super().__init__(metric, **kwargs)
         if _format_metric(metric) not in _PAIRWISE_METRICS:


### PR DESCRIPTION
Eliminates misleading "Ignoring reference..." warning during evaluation calls.

The evaluator inherited `requires_reference=False` from the base class,  but it actually uses and expects reference parameters for pairwise comparisons:

```python
request = self._prepare_request(prediction_b, reference, input, baseline_prediction=prediction, **kwargs)

# reference param is passed as the second arg
```

As a result of the mismatch, warnings were triggered.