### PR TITLE
fix(vertexai): add Union type support to V1 schema formatter

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/functions_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/functions_utils.py
@@ -102,6 +102,10 @@ def _format_json_schema_to_gapic_v1(schema: Dict[str, Any]) -> Dict[str, Any]:
                     f"Got {len(value)}, ignoring other than first value!"
                 )
             return _format_json_schema_to_gapic_v1(value[0])
+        elif key == "anyOf":
+            converted_schema["anyOf"] = [
+                _format_json_schema_to_gapic_v1(anyOf_type) for anyOf_type in value
+            ]
         elif key not in _ALLOWED_SCHEMA_FIELDS_SET:
             logger.warning(f"Key '{key}' is not supported in schema, ignoring")
         else:

--- a/libs/vertexai/tests/unit_tests/test_function_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_function_utils.py
@@ -263,14 +263,13 @@ def test_format_json_schema_to_gapic_union_types() -> None:
 
     schema_v1 = RecordPerson_v1.schema()
     schema_v2 = RecordPerson.model_json_schema()
-    del schema_v2
 
     result_v1 = _format_json_schema_to_gapic_v1(schema_v1)
-    # result_v2 = _format_json_schema_to_gapic(schema_v2)
     result_v1["title"] = "RecordPerson"
 
-    # TODO: add a proper support for Union since it has finally arrived!
-    # assert result_v1 == result_v2
+    result_v2 = _format_json_schema_to_gapic(schema_v2)
+
+    assert result_v1 == result_v2
 
 
 # reusable test inputs


### PR DESCRIPTION
Add proper `anyOf` handling to `_format_json_schema_to_gapic_v1` to ensure consistent formatting between Pydantic V1 and V2 Union types.

Base case is reached when a schema contains only `'type'`, `'title'`, and keys in `_ALLOWED_SCHEMA_FIELDS_SET`.