### PR TITLE
fix(genai): defer async client init for embeddings; avoid eager loop creation

### DIFF
--- a/libs/genai/langchain_google_genai/embeddings.py
+++ b/libs/genai/langchain_google_genai/embeddings.py
@@ -117,7 +117,8 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
             transport=self.transport,
         )
         # Always defer async client initialization to first async call.
-        # This avoids creating event loops implicitly and aligns with lazy init in chat models.
+        # Avoids implicit event loop creation and aligns with lazy init
+        # in chat models.
         self.async_client = None
         return self
 

--- a/libs/genai/langchain_google_genai/embeddings.py
+++ b/libs/genai/langchain_google_genai/embeddings.py
@@ -116,22 +116,9 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
             client_options=self.client_options,
             transport=self.transport,
         )
-        # Only initialize async client if there's an event loop running
-        # to avoid RuntimeError during synchronous initialization
-        if _is_event_loop_running():
-            # async clients don't support "rest" transport
-            transport = self.transport
-            if transport == "rest":
-                transport = "grpc_asyncio"
-            self.async_client = build_generative_async_service(
-                credentials=self.credentials,
-                api_key=google_api_key,
-                client_info=client_info,
-                client_options=self.client_options,
-                transport=transport,
-            )
-        else:
-            self.async_client = None
+        # Always defer async client initialization to first async call.
+        # This avoids creating event loops implicitly and aligns with lazy init in chat models.
+        self.async_client = None
         return self
 
     @property


### PR DESCRIPTION
Defer async client initialization in GoogleGenerativeAIEmbeddings to first async use.\n\n- Set async_client=None in validator; lazy-create via _async_client property\n- Avoid implicit event loop creation during sync init\n- Align behavior with Chat model lazy pattern\n- Verified with unit tests (embeddings) and lint_package target locally\n\Fixes #1064