### PR TITLE
fix(vertexai): honor max_retries=0 and disable GAPIC retries

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_retry.py
+++ b/libs/vertexai/langchain_google_vertexai/_retry.py
@@ -113,9 +113,12 @@ def create_base_retry_decorator(
         else:
             retry_instance = (retry_instance) | (retry_if_exception_type(error))
 
+    # Interpret max_retries=0 as "no retries" which still allows 1 attempt.
+    attempts = 1 if max_retries is None or max_retries <= 0 else max_retries
+
     return retry(
         reraise=True,
-        stop=stop_after_attempt(max_retries),
+        stop=stop_after_attempt(attempts),
         wait=wait_exponential(**wait_params),
         retry=retry_instance,
         before_sleep=_before_sleep,

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -170,7 +170,14 @@ _allowed_params = [
 _allowed_beta_params = [
     "media_resolution",
 ]
-_allowed_params_prediction_service = ["request", "timeout", "metadata", "labels"]
+_allowed_params_prediction_service = [
+    "request",
+    "timeout",
+    "metadata",
+    "labels",
+    # Allow controlling GAPIC client retries from callers.
+    "retry",
+]
 
 
 _FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY = (
@@ -775,6 +782,10 @@ def _completion_with_retry(
     def _completion_with_retry_inner(generation_method: Callable, **kwargs: Any) -> Any:
         return generation_method(**kwargs)
 
+    # If user requested 0 retries, disable GAPIC retries too unless explicitly set.
+    if max_retries <= 0 and "retry" not in kwargs:
+        kwargs["retry"] = None
+
     params = {
         k: v for k, v in kwargs.items() if k in _allowed_params_prediction_service
     }
@@ -804,6 +815,10 @@ async def _acompletion_with_retry(
         generation_method: Callable, **kwargs: Any
     ) -> Any:
         return await generation_method(**kwargs)
+
+    # If user requested 0 retries, disable GAPIC retries too unless explicitly set.
+    if max_retries <= 0 and "retry" not in kwargs:
+        kwargs["retry"] = None
 
     params = {
         k: v for k, v in kwargs.items() if k in _allowed_params_prediction_service

--- a/libs/vertexai/tests/unit_tests/test_retry.py
+++ b/libs/vertexai/tests/unit_tests/test_retry.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from langchain_google_vertexai._retry import create_base_retry_decorator
+from langchain_google_vertexai.chat_models import _completion_with_retry
+
+
+class _DummyTimeoutError(Exception):
+    pass
+
+
+def test_create_base_retry_decorator_zero_retries_means_single_attempt() -> None:
+    """Ensure max_retries=0 performs exactly one attempt and no retries."""
+    calls = {"count": 0}
+
+    def will_timeout():
+        calls["count"] += 1
+        raise _DummyTimeoutError("timeout")
+
+    decorator = create_base_retry_decorator(
+        error_types=[_DummyTimeoutError], max_retries=0
+    )
+    wrapped = decorator(will_timeout)
+
+    with pytest.raises(_DummyTimeoutError):
+        wrapped()
+
+    assert calls["count"] == 1
+
+
+def test_completion_with_retry_injects_retry_none_when_zero() -> None:
+    """_completion_with_retry should pass retry=None to GAPIC when max_retries=0."""
+    gen_method = MagicMock(return_value="ok")
+
+    result = _completion_with_retry(
+        gen_method,
+        max_retries=0,
+        request={"dummy": True},
+        timeout=120,
+        metadata=(),
+    )
+
+    assert result == "ok"
+    # Ensure called exactly once and with retry=None passed through
+    assert gen_method.call_count == 1
+    kwargs = gen_method.call_args.kwargs
+    assert "retry" in kwargs and kwargs["retry"] is None
+
+
+def test_completion_with_retry_does_not_inject_retry_when_positive() -> None:
+    """When max_retries>0, do not auto-inject retry=None."""
+    gen_method = MagicMock(return_value="ok")
+
+    result = _completion_with_retry(
+        gen_method,
+        max_retries=2,
+        request={"dummy": True},
+        timeout=30,
+        metadata=(),
+    )
+
+    assert result == "ok"
+    assert gen_method.call_count == 1
+    kwargs = gen_method.call_args.kwargs
+    assert "retry" not in kwargs


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "[package]: [brief description]"

  - Where "package" is genai, vertexai, or community
  - Use "docs: ..." for purely docs changes, "templates: ..." for template changes, "infra: ..." for CI changes
  - Example: "community: add foobar LLM"

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## PR Description

Fixes issue where max_retries did not work for VertexAI and ChatVertexAI.
Now max_retries=0 correctly disables retries, and GAPIC retries are also disabled.

## Relevant issues

Fixes #1093 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes(optional)


## Testing(optional)

<!-- Test procedure -->
<!-- Test result -->

## Note(optional)

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
