### PR TITLE
fix(community): Fix AttributeError: module 'google.oauth2.service_account' has no attribute 'ServiceCredentials' in utils

### DIFF
--- a/libs/community/langchain_google_community/_utils.py
+++ b/libs/community/langchain_google_community/_utils.py
@@ -79,7 +79,7 @@ def import_google() -> Tuple[Request, Credentials, ServiceCredentials]:
         ).Credentials,
         guard_import(
             module_name="google.oauth2.service_account", pip_name="google-auth"
-        ).ServiceCredentials,
+        ).Credentials,
     )
 
 


### PR DESCRIPTION
## Description

When trying to instantiate CalendarToolkit, there is an AttributeError raised to a mismatch in aliases. The safe import should still call the original class name instead of the alias. 

## Relevant issues

N/A

## Type

🐛 Bug Fix

## Note(optional)

Discovered using this notebook: https://github.com/langchain-ai/langchain/blob/master/docs/docs/integrations/tools/google_calendar.ipynb
