### PR TITLE
test: use `gemini-flash-lite-latest`

### DIFF
--- a/libs/genai/README.md
+++ b/libs/genai/README.md
@@ -61,7 +61,7 @@ Then use the `ChatGoogleGenerativeAI` interface:
 ```python
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-llm = ChatGoogleGenerativeAI(model="gemini-2.5-flash")
+llm = ChatGoogleGenerativeAI(model="gemini-flash-latest")
 response = llm.invoke("Sing a ballad of LangChain.")
 print(response.content)
 ```
@@ -82,7 +82,7 @@ Most Gemini models support image inputs.
 from langchain_core.messages import HumanMessage
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-llm = ChatGoogleGenerativeAI(model="gemini-2.5-flash")
+llm = ChatGoogleGenerativeAI(model="gemini-flash-latest")
 
 message = HumanMessage(
     content=[

--- a/libs/genai/tests/integration_tests/test_callbacks.py
+++ b/libs/genai/tests/integration_tests/test_callbacks.py
@@ -7,7 +7,7 @@ from langchain_core.prompts import PromptTemplate
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-model_names = ["gemini-2.5-flash"]
+MODEL_NAMES = ["gemini-flash-lite-latest"]
 
 
 class StreamingLLMCallbackHandler(BaseCallbackHandler):
@@ -25,7 +25,7 @@ class StreamingLLMCallbackHandler(BaseCallbackHandler):
 
 @pytest.mark.parametrize(
     "model_name",
-    model_names,
+    MODEL_NAMES,
 )
 def test_streaming_callback(model_name: str) -> None:
     prompt_template = "Tell me details about the Company {name} with 2 bullet point?"

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -26,7 +26,7 @@ from langchain_google_genai import (
     Modality,
 )
 
-_MODEL = "models/gemini-2.5-flash"
+_MODEL = "gemini-flash-lite-latest"
 _VISION_MODEL = "models/gemini-2.0-flash-001"
 _IMAGE_OUTPUT_MODEL = "models/gemini-2.0-flash-exp-image-generation"
 _AUDIO_OUTPUT_MODEL = "models/gemini-2.5-flash-preview-tts"

--- a/libs/genai/tests/integration_tests/test_function_call.py
+++ b/libs/genai/tests/integration_tests/test_function_call.py
@@ -11,12 +11,12 @@ from langchain_google_genai.chat_models import (
     ChatGoogleGenerativeAI,
 )
 
-model_names = ["gemini-2.5-flash"]
+MODEL_NAMES = ["gemini-flash-lite-latest"]
 
 
 @pytest.mark.parametrize(
     "model_name",
-    model_names,
+    MODEL_NAMES,
 )
 def test_function_call(model_name: str) -> None:
     functions = [
@@ -50,7 +50,7 @@ def test_function_call(model_name: str) -> None:
 
 @pytest.mark.parametrize(
     "model_name",
-    model_names,
+    MODEL_NAMES,
 )
 def test_tool_call(model_name: str) -> None:
     @tool
@@ -79,7 +79,7 @@ class MyModel(BaseModel):
 
 @pytest.mark.parametrize(
     "model_name",
-    model_names,
+    MODEL_NAMES,
 )
 def test_pydantic_call(model_name: str) -> None:
     llm = ChatGoogleGenerativeAI(model=model_name).bind(functions=[MyModel])

--- a/libs/genai/tests/integration_tests/test_llms.py
+++ b/libs/genai/tests/integration_tests/test_llms.py
@@ -10,12 +10,12 @@ from langchain_core.outputs import LLMResult
 
 from langchain_google_genai import GoogleGenerativeAI, HarmBlockThreshold, HarmCategory
 
-model_names = ["gemini-2.5-flash"]
+MODEL_NAMES = ["gemini-flash-lite-latest"]
 
 
 @pytest.mark.parametrize(
     "model_name",
-    model_names,
+    MODEL_NAMES,
 )
 def test_google_generativeai_call(model_name: str) -> None:
     """Test valid call to Google GenerativeAI text API."""
@@ -31,7 +31,7 @@ def test_google_generativeai_call(model_name: str) -> None:
 
 @pytest.mark.parametrize(
     "model_name",
-    model_names,
+    MODEL_NAMES,
 )
 def test_google_generativeai_generate(model_name: str) -> None:
     llm = GoogleGenerativeAI(temperature=0.3, model=model_name)
@@ -47,7 +47,7 @@ def test_google_generativeai_generate(model_name: str) -> None:
 
 @pytest.mark.parametrize(
     "model_name",
-    model_names,
+    MODEL_NAMES,
 )
 async def test_google_generativeai_agenerate(model_name: str) -> None:
     llm = GoogleGenerativeAI(temperature=0, model=model_name)
@@ -57,7 +57,7 @@ async def test_google_generativeai_agenerate(model_name: str) -> None:
 
 @pytest.mark.parametrize(
     "model_name",
-    model_names,
+    MODEL_NAMES,
 )
 def test_generativeai_stream(model_name: str) -> None:
     llm = GoogleGenerativeAI(temperature=0, model=model_name)
@@ -67,7 +67,7 @@ def test_generativeai_stream(model_name: str) -> None:
 
 @pytest.mark.parametrize(
     "model_name",
-    model_names,
+    MODEL_NAMES,
 )
 def test_generativeai_get_num_tokens_gemini(model_name: str) -> None:
     llm = GoogleGenerativeAI(temperature=0, model=model_name)
@@ -77,7 +77,7 @@ def test_generativeai_get_num_tokens_gemini(model_name: str) -> None:
 
 @pytest.mark.parametrize(
     "model_name",
-    model_names,
+    MODEL_NAMES,
 )
 def test_safety_settings_gemini(model_name: str) -> None:
     # test with blocked prompt

--- a/libs/genai/tests/integration_tests/test_tools.py
+++ b/libs/genai/tests/integration_tests/test_tools.py
@@ -2,6 +2,8 @@ from langchain_core.tools import tool
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
+MODEL = "gemini-flash-lite-latest"
+
 
 @tool
 def check_weather(location: str) -> str:
@@ -25,7 +27,7 @@ def test_multiple_tools() -> None:
     tools = [check_weather, check_live_traffic, check_tennis_score]
 
     model = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL,
     )
 
     model_with_tools = model.bind_tools(tools)

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -42,11 +42,13 @@ from langchain_google_genai.chat_models import (
     _response_to_result,
 )
 
+MODEL_NAME = "gemini-flash-lite-latest"
+
 
 def test_integration_initialization() -> None:
     """Test chat model initialization."""
     llm = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr("..."),
         top_k=2,
         top_p=1,
@@ -56,27 +58,27 @@ def test_integration_initialization() -> None:
     ls_params = llm._get_ls_params()
     assert ls_params == {
         "ls_provider": "google_genai",
-        "ls_model_name": "gemini-2.5-flash",
+        "ls_model_name": MODEL_NAME,
         "ls_model_type": "chat",
         "ls_temperature": 0.7,
     }
 
     llm = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr("..."),
         max_output_tokens=10,
     )
     ls_params = llm._get_ls_params()
     assert ls_params == {
         "ls_provider": "google_genai",
-        "ls_model_name": "gemini-2.5-flash",
+        "ls_model_name": MODEL_NAME,
         "ls_model_type": "chat",
         "ls_temperature": 0.7,
         "ls_max_tokens": 10,
     }
 
     ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         api_key=SecretStr("..."),
         top_k=2,
         top_p=1,
@@ -88,13 +90,13 @@ def test_integration_initialization() -> None:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             llm = ChatGoogleGenerativeAI(
-                model="gemini-2.5-flash",
+                model=MODEL_NAME,
                 google_api_key=SecretStr("..."),
                 safety_setting={
                     "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
                 },  # Invalid arg
             )
-        assert llm.model == "models/gemini-2.5-flash"
+        assert llm.model == f"models/{MODEL_NAME}"
         mock_warning.assert_called_once()
         call_args = mock_warning.call_args[0][0]
         assert "Unexpected argument 'safety_setting'" in call_args
@@ -109,7 +111,7 @@ def test_safety_settings_initialization() -> None:
 
     # Test initialization with safety_settings
     llm = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr("test-key"),
         temperature=0.7,
         safety_settings=safety_settings,
@@ -118,7 +120,7 @@ def test_safety_settings_initialization() -> None:
     # Verify the safety_settings are stored correctly
     assert llm.safety_settings == safety_settings
     assert llm.temperature == 0.7
-    assert llm.model == "models/gemini-2.5-flash"
+    assert llm.model == f"models/{MODEL_NAME}"
 
 
 def test_initialization_inside_threadpool() -> None:
@@ -127,30 +129,28 @@ def test_initialization_inside_threadpool() -> None:
     with ThreadPoolExecutor() as executor:
         executor.submit(
             ChatGoogleGenerativeAI,
-            model="gemini-2.5-flash",
+            model=MODEL_NAME,
             google_api_key=SecretStr("secret-api-key"),
         ).result()
 
 
 def test_client_transport() -> None:
     """Test client transport configuration."""
-    model = ChatGoogleGenerativeAI(model="gemini-2.5-flash", google_api_key="fake-key")
+    model = ChatGoogleGenerativeAI(model=MODEL_NAME, google_api_key="fake-key")
     assert model.client.transport.kind == "grpc"
 
     model = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash", google_api_key="fake-key", transport="rest"
+        model=MODEL_NAME, google_api_key="fake-key", transport="rest"
     )
     assert model.client.transport.kind == "rest"
 
     async def check_async_client() -> None:
-        model = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash", google_api_key="fake-key"
-        )
+        model = ChatGoogleGenerativeAI(model=MODEL_NAME, google_api_key="fake-key")
         assert model.async_client.transport.kind == "grpc_asyncio"
 
         # Test auto conversion of transport to "grpc_asyncio" from "rest"
         model = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash", google_api_key="fake-key", transport="rest"
+            model=MODEL_NAME, google_api_key="fake-key", transport="rest"
         )
         assert model.async_client.transport.kind == "grpc_asyncio"
 
@@ -159,7 +159,7 @@ def test_client_transport() -> None:
 
 def test_initalization_without_async() -> None:
     chat = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr("secret-api-key"),
     )
     assert chat.async_client is None
@@ -168,7 +168,7 @@ def test_initalization_without_async() -> None:
 def test_initialization_with_async() -> None:
     async def initialize_chat_with_async_client() -> ChatGoogleGenerativeAI:
         model = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
+            model=MODEL_NAME,
             google_api_key=SecretStr("secret-api-key"),
         )
         _ = model.async_client
@@ -180,7 +180,7 @@ def test_initialization_with_async() -> None:
 
 def test_api_key_is_string() -> None:
     chat = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr("secret-api-key"),
     )
     assert isinstance(chat.google_api_key, SecretStr)
@@ -190,7 +190,7 @@ def test_api_key_masked_when_passed_via_constructor(
     capsys: pytest.CaptureFixture,
 ) -> None:
     chat = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr("secret-api-key"),
     )
     print(chat.google_api_key, end="")  # noqa: T201
@@ -396,7 +396,7 @@ def test_additional_headers_support(headers: Optional[dict[str, str]]) -> None:
         mock_client,
     ):
         chat = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
+            model=MODEL_NAME,
             google_api_key=param_secret_api_key,
             client_options=param_client_options,
             transport=param_transport,
@@ -434,7 +434,7 @@ def test_default_metadata_field_alias() -> None:
     # error
     # This is the main issue: LangSmith Playground passes None to default_metadata_input
     chat1 = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr("test-key"),
         default_metadata_input=None,
     )
@@ -445,7 +445,7 @@ def test_default_metadata_field_alias() -> None:
     # Test with empty list for default_metadata_input (should not cause validation
     # error)
     chat2 = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr("test-key"),
         default_metadata_input=[],
     )
@@ -454,7 +454,7 @@ def test_default_metadata_field_alias() -> None:
 
     # Test with tuple for default_metadata_input (should not cause validation error)
     chat3 = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr("test-key"),
         default_metadata_input=[("X-Test", "test")],
     )
@@ -763,7 +763,7 @@ def test_parse_response_candidate(raw_candidate: dict, expected: AIMessage) -> N
 
 
 def test_serialize() -> None:
-    llm = ChatGoogleGenerativeAI(model="gemini-2.5-flash", google_api_key="test-key")
+    llm = ChatGoogleGenerativeAI(model=MODEL_NAME, google_api_key="test-key")
     serialized = dumps(llm)
     llm_loaded = loads(
         serialized,
@@ -802,20 +802,20 @@ def test__convert_tool_message_to_parts__sets_tool_name(
 def test_temperature_range_pydantic_validation() -> None:
     """Test that temperature is in the range [0.0, 2.0]."""
     with pytest.raises(ValidationError):
-        ChatGoogleGenerativeAI(model="gemini-2.5-flash", temperature=2.1)
+        ChatGoogleGenerativeAI(model=MODEL_NAME, temperature=2.1)
 
     with pytest.raises(ValidationError):
-        ChatGoogleGenerativeAI(model="gemini-2.5-flash", temperature=-0.1)
+        ChatGoogleGenerativeAI(model=MODEL_NAME, temperature=-0.1)
 
     llm = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr("..."),
         temperature=1.5,
     )
     ls_params = llm._get_ls_params()
     assert ls_params == {
         "ls_provider": "google_genai",
-        "ls_model_name": "gemini-2.5-flash",
+        "ls_model_name": MODEL_NAME,
         "ls_model_type": "chat",
         "ls_temperature": 1.5,
     }
@@ -824,30 +824,30 @@ def test_temperature_range_pydantic_validation() -> None:
 def test_temperature_range_model_validation() -> None:
     """Test that temperature is in the range [0.0, 2.0]."""
     with pytest.raises(ValueError):
-        ChatGoogleGenerativeAI(model="gemini-2.5-flash", temperature=2.5)
+        ChatGoogleGenerativeAI(model=MODEL_NAME, temperature=2.5)
 
     with pytest.raises(ValueError):
-        ChatGoogleGenerativeAI(model="gemini-2.5-flash", temperature=-0.5)
+        ChatGoogleGenerativeAI(model=MODEL_NAME, temperature=-0.5)
 
 
 def test_model_kwargs() -> None:
     """Test we can transfer unknown params to model_kwargs."""
     llm = ChatGoogleGenerativeAI(
-        model="my-model",
+        model=MODEL_NAME,
         convert_system_message_to_human=True,
         model_kwargs={"foo": "bar"},
     )
-    assert llm.model == "models/my-model"
+    assert llm.model == f"models/{MODEL_NAME}"
     assert llm.convert_system_message_to_human is True
     assert llm.model_kwargs == {"foo": "bar"}
 
     with pytest.warns(match="transferred to model_kwargs"):
         llm = ChatGoogleGenerativeAI(
-            model="my-model",
+            model=MODEL_NAME,
             convert_system_message_to_human=True,
             foo="bar",
         )
-    assert llm.model == "models/my-model"
+    assert llm.model == f"models/{MODEL_NAME}"
     assert llm.convert_system_message_to_human is True
     assert llm.model_kwargs == {"foo": "bar"}
 
@@ -1191,7 +1191,7 @@ def test_thinking_config_merging_with_generation_config() -> None:
         mock_retry.return_value = mock_response
 
         llm = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
+            model=MODEL_NAME,
             google_api_key=SecretStr("test-key"),
         )
 

--- a/libs/genai/tests/unit_tests/test_embeddings.py
+++ b/libs/genai/tests/unit_tests/test_embeddings.py
@@ -14,6 +14,8 @@ from pydantic import SecretStr
 
 from langchain_google_genai.embeddings import GoogleGenerativeAIEmbeddings
 
+MODEL_NAME = "gemini-embedding-001"
+
 
 def test_integration_initialization() -> None:
     """Test chat model initialization."""
@@ -21,7 +23,7 @@ def test_integration_initialization() -> None:
         "langchain_google_genai._genai_extension.v1betaGenerativeServiceClient"
     ) as mock_prediction_service:
         _ = GoogleGenerativeAIEmbeddings(
-            model="models/gemini-embedding-001",
+            model=f"models/{MODEL_NAME}",
             google_api_key=SecretStr("..."),
         )
         mock_prediction_service.assert_called_once()
@@ -34,7 +36,7 @@ def test_integration_initialization() -> None:
         "langchain_google_genai._genai_extension.v1betaGenerativeServiceClient"
     ) as mock_prediction_service:
         _ = GoogleGenerativeAIEmbeddings(
-            model="models/gemini-embedding-001",
+            model=f"models/{MODEL_NAME}",
             google_api_key=SecretStr("..."),
             task_type="retrieval_document",
         )
@@ -43,7 +45,7 @@ def test_integration_initialization() -> None:
 
 def test_api_key_is_string() -> None:
     embeddings = GoogleGenerativeAIEmbeddings(
-        model="models/gemini-embedding-001",
+        model=f"models/{MODEL_NAME}",
         google_api_key=SecretStr("secret-api-key"),
     )
     assert isinstance(embeddings.google_api_key, SecretStr)
@@ -53,7 +55,7 @@ def test_api_key_masked_when_passed_via_constructor(
     capsys: pytest.CaptureFixture,
 ) -> None:
     embeddings = GoogleGenerativeAIEmbeddings(
-        model="models/gemini-embedding-001",
+        model=f"models/{MODEL_NAME}",
         google_api_key=SecretStr("secret-api-key"),
     )
     print(embeddings.google_api_key, end="")  # noqa: T201
@@ -72,13 +74,13 @@ def test_embed_query() -> None:
         )
         mock_prediction_service.return_value.embed_content = mock_embed
         llm = GoogleGenerativeAIEmbeddings(
-            model="models/embedding-test",
+            model=f"models/{MODEL_NAME}",
             google_api_key=SecretStr("test-key"),
             task_type="classification",
         )
         llm.embed_query("test text", output_dimensionality=524)
         request = EmbedContentRequest(
-            model="models/embedding-test",
+            model=f"models/{MODEL_NAME}",
             content={"parts": [{"text": "test text"}]},
             task_type="CLASSIFICATION",
             output_dimensionality=524,
@@ -97,22 +99,22 @@ def test_embed_documents() -> None:
         mock_prediction_service.return_value.batch_embed_contents = mock_embed
 
         llm = GoogleGenerativeAIEmbeddings(
-            model="models/embedding-test",
+            model=f"models/{MODEL_NAME}",
             google_api_key=SecretStr("test-key"),
         )
 
         llm.embed_documents(["test text", "test text2"], titles=["title1", "title2"])
         request = BatchEmbedContentsRequest(
-            model="models/embedding-test",
+            model=f"models/{MODEL_NAME}",
             requests=[
                 EmbedContentRequest(
-                    model="models/embedding-test",
+                    model=f"models/{MODEL_NAME}",
                     content={"parts": [{"text": "test text"}]},
                     task_type="RETRIEVAL_DOCUMENT",
                     title="title1",
                 ),
                 EmbedContentRequest(
-                    model="models/embedding-test",
+                    model=f"models/{MODEL_NAME}",
                     content={"parts": [{"text": "test text2"}]},
                     task_type="RETRIEVAL_DOCUMENT",
                     title="title2",
@@ -135,7 +137,7 @@ def test_embed_documents_with_numerous_texts() -> None:
         mock_prediction_service.return_value.batch_embed_contents = mock_embed
 
         llm = GoogleGenerativeAIEmbeddings(
-            model="models/embedding-test",
+            model=f"models/{MODEL_NAME}",
             google_api_key=SecretStr("test-key"),
         )
 
@@ -145,10 +147,10 @@ def test_embed_documents_with_numerous_texts() -> None:
             titles=["title1" for _ in range(test_corpus_size)],
         )
         request = BatchEmbedContentsRequest(
-            model="models/embedding-test",
+            model=f"models/{MODEL_NAME}",
             requests=[
                 EmbedContentRequest(
-                    model="models/embedding-test",
+                    model=f"models/{MODEL_NAME}",
                     content={"parts": [{"text": "test text"}]},
                     task_type="RETRIEVAL_DOCUMENT",
                     title="title1",

--- a/libs/genai/tests/unit_tests/test_llms.py
+++ b/libs/genai/tests/unit_tests/test_llms.py
@@ -2,20 +2,22 @@ from unittest.mock import patch
 
 from langchain_google_genai.llms import GoogleGenerativeAI
 
+MODEL_NAME = "gemini-flash-lite-latest"
+
 
 def test_tracing_params() -> None:
     # Test standard tracing params
-    llm = GoogleGenerativeAI(model="gemini-2.5-flash", google_api_key="foo")
+    llm = GoogleGenerativeAI(model=MODEL_NAME, google_api_key="foo")
     ls_params = llm._get_ls_params()
     assert ls_params == {
         "ls_provider": "google_genai",
         "ls_model_type": "llm",
-        "ls_model_name": "gemini-2.5-flash",
+        "ls_model_name": MODEL_NAME,
         "ls_temperature": 0.7,
     }
 
     llm = GoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         temperature=0.1,
         max_output_tokens=10,
         google_api_key="foo",
@@ -24,7 +26,7 @@ def test_tracing_params() -> None:
     assert ls_params == {
         "ls_provider": "google_genai",
         "ls_model_type": "llm",
-        "ls_model_name": "gemini-2.5-flash",
+        "ls_model_name": MODEL_NAME,
         "ls_temperature": 0.1,
         "ls_max_tokens": 10,
     }
@@ -32,15 +34,15 @@ def test_tracing_params() -> None:
     # Test initialization with an invalid argument to check warning
     with patch("langchain_google_genai.llms.logger.warning") as mock_warning:
         llm = GoogleGenerativeAI(
-            model="gemini-2.5-flash",
+            model=MODEL_NAME,
             google_api_key="foo",
             safety_setting={
                 "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
             },  # Invalid arg
         )
-        assert llm.model == "models/gemini-2.5-flash"
+        assert llm.model == f"models/{MODEL_NAME}"
         ls_params = llm._get_ls_params()
-        assert ls_params.get("ls_model_name") == "gemini-2.5-flash"
+        assert ls_params.get("ls_model_name") == MODEL_NAME
         mock_warning.assert_called_once()
         call_args = mock_warning.call_args[0][0]
         assert "Unexpected argument 'safety_setting'" in call_args

--- a/libs/vertexai/tests/integration_tests/conftest.py
+++ b/libs/vertexai/tests/integration_tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-_DEFAULT_MODEL_NAME = "gemini-2.0-flash-001"
+_DEFAULT_MODEL_NAME = "gemini-flash-lite-latest"
 _DEFAULT_THINKING_MODEL_NAME = "gemini-2.5-flash"
 _DEFAULT_IMAGE_GENERATION_MODEL_NAME = "gemini-2.0-flash-preview-image-generation"
 

--- a/libs/vertexai/tests/integration_tests/conftest.py
+++ b/libs/vertexai/tests/integration_tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-_DEFAULT_MODEL_NAME = "gemini-flash-lite-latest"
+_DEFAULT_MODEL_NAME = "gemini-2.0-flash-001"
 _DEFAULT_THINKING_MODEL_NAME = "gemini-2.5-flash"
 _DEFAULT_IMAGE_GENERATION_MODEL_NAME = "gemini-2.0-flash-preview-image-generation"
 

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -1264,7 +1264,7 @@ def test_context_catching_tools() -> None:
 @pytest.mark.release
 def test_json_serializable() -> None:
     llm = ChatVertexAI(
-        model_name="gemini-2.0-flash-001",
+        model_name=_DEFAULT_MODEL_NAME,
     )
     # Needed to init self.client and self.async_client
     llm.prediction_client
@@ -1395,7 +1395,7 @@ def test_init_from_credentials_obj() -> None:
     credentials = service_account.Credentials.from_service_account_info(
         credentials_dict
     )
-    llm = ChatVertexAI(model="gemini-2.0-flash-001", credentials=credentials)
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, credentials=credentials)
     llm.invoke("how are you")
 
 
@@ -1403,7 +1403,7 @@ def test_init_from_credentials_obj() -> None:
 @pytest.mark.release
 def test_label_metadata() -> None:
     llm = ChatVertexAI(
-        model="gemini-2.0-flash-001",
+        model=_DEFAULT_MODEL_NAME,
         labels={
             "task": "labels_using_declaration",
             "environment": "testing",
@@ -1415,7 +1415,7 @@ def test_label_metadata() -> None:
 @pytest.mark.xfail(reason="can't add labels to the gemini content using invoke method")
 @pytest.mark.release
 def test_label_metadata_invoke_method() -> None:
-    llm = ChatVertexAI(model="gemini-2.0-flash-001")
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME)
     llm.invoke(
         "hello! invoke method",
         labels={
@@ -1427,7 +1427,7 @@ def test_label_metadata_invoke_method() -> None:
 
 @pytest.mark.release
 def test_response_metadata_avg_logprobs() -> None:
-    llm = ChatVertexAI(model="gemini-2.0-flash-001")
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME)
     response = llm.invoke("Hello!")
     probs = response.response_metadata.get("avg_logprobs")
     if probs is not None:
@@ -1489,7 +1489,7 @@ def test_multimodal_pdf_input_b64(multimodal_pdf_chain: RunnableSerializable) ->
 @pytest.mark.xfail(reason="logprobs are subject to daily quotas")
 @pytest.mark.release
 def test_logprobs() -> None:
-    llm = ChatVertexAI(model="gemini-2.0-flash-001", logprobs=2)
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, logprobs=2)
     msg = llm.invoke("hey")
     tokenprobs = msg.response_metadata.get("logprobs_result")
     assert tokenprobs is None or isinstance(tokenprobs, list)
@@ -1506,34 +1506,32 @@ def test_logprobs() -> None:
                 assert isinstance(token.get("top_logprobs"), list)
                 stack.extend(token.get("top_logprobs", []))
 
-    llm2 = ChatVertexAI(model="gemini-2.0-flash-001", logprobs=True)
+    llm2 = ChatVertexAI(model=_DEFAULT_MODEL_NAME, logprobs=True)
     msg2 = llm2.invoke("how are you")
     assert msg2.response_metadata["logprobs_result"]
 
-    llm3 = ChatVertexAI(model="gemini-2.0-flash-001", logprobs=False)
+    llm3 = ChatVertexAI(model=_DEFAULT_MODEL_NAME, logprobs=False)
     msg3 = llm3.invoke("howdy")
     assert msg3.response_metadata.get("logprobs_result") is None
 
 
 def test_location_init() -> None:
     # If I don't initialize vertexai before, defaults to us-central-1
-    llm = ChatVertexAI(model="gemini-2.0-flash-001", logprobs=2)
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, logprobs=2)
     assert llm.location == "us-central1"
 
     # If I init vertexai with other region the model is in that particular region
     vertexai.init(location="europe-west1")
-    llm = ChatVertexAI(model="gemini-2.0-flash-001", logprobs=2)
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, logprobs=2)
     assert llm.location == "europe-west1"
 
     # If I specify the location, it follows that location
-    llm = ChatVertexAI(
-        model="gemini-2.0-flash-001", logprobs=2, location="europe-west2"
-    )
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, logprobs=2, location="europe-west2")
     assert llm.location == "europe-west2"
 
     # It reverts to the default
     vertexai.init(location="us-central1")
-    llm = ChatVertexAI(model="gemini-2.0-flash-001", logprobs=2)
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, logprobs=2)
     assert llm.location == "us-central1"
 
 
@@ -1568,7 +1566,7 @@ def test_nested_bind_tools() -> None:
     class People(BaseModel):
         data: list[Person] = Field(description="The people.")
 
-    llm = ChatVertexAI(model="gemini-2.0-flash-001")
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME)
     llm_with_tools = llm.bind_tools([People], tool_choice="People")
 
     response = llm_with_tools.invoke("Chester, no hair color provided.")

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -1467,7 +1467,7 @@ def test_multimodal_pdf_input_gcs(multimodal_pdf_chain: RunnableSerializable) ->
 
 @pytest.mark.release
 def test_multimodal_pdf_input_url(multimodal_pdf_chain: RunnableSerializable) -> None:
-    url = "https://abc.xyz/assets/95/eb/9cef90184e09bac553796896c633/2023q4-alphabet-earnings-release.pdf"
+    url = "https://s206.q4cdn.com/479360582/files/doc_financials/2025/q1/2025q1-alphabet-earnings-release.pdf"
     # URL
     response = multimodal_pdf_chain.invoke({"image": url})
     assert isinstance(response, AIMessage)
@@ -1475,7 +1475,7 @@ def test_multimodal_pdf_input_url(multimodal_pdf_chain: RunnableSerializable) ->
 
 @pytest.mark.release
 def test_multimodal_pdf_input_b64(multimodal_pdf_chain: RunnableSerializable) -> None:
-    url = "https://abc.xyz/assets/95/eb/9cef90184e09bac553796896c633/2023q4-alphabet-earnings-release.pdf"
+    url = "https://s206.q4cdn.com/479360582/files/doc_financials/2025/q1/2025q1-alphabet-earnings-release.pdf"
     request_response = requests.get(url, allow_redirects=True)
     # B64
     with io.BytesIO() as stream:

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -52,6 +52,9 @@ from langchain_google_vertexai.chat_models import (
     _parse_response_candidate,
 )
 from langchain_google_vertexai.model_garden import ChatAnthropicVertex
+from tests.integration_tests.conftest import (
+    _DEFAULT_MODEL_NAME,
+)
 
 
 @pytest.fixture
@@ -64,28 +67,28 @@ def clear_prediction_client_cache() -> None:
 def test_init() -> None:
     for llm in [
         ChatVertexAI(
-            model_name="gemini-pro",
+            model_name=_DEFAULT_MODEL_NAME,
             project="test-project",
             max_output_tokens=10,
             stop=["bar"],
             location="moon-dark1",
         ),
         ChatVertexAI(
-            model="gemini-pro",
+            model=_DEFAULT_MODEL_NAME,
             max_tokens=10,
             stop_sequences=["bar"],
             location="moon-dark1",
             project="test-proj",
         ),
     ]:
-        assert llm.model_name == "gemini-pro"
+        assert llm.model_name == _DEFAULT_MODEL_NAME
         assert llm.max_output_tokens == 10
         assert llm.stop == ["bar"]
 
         ls_params = llm._get_ls_params()
         assert ls_params == {
             "ls_provider": "google_vertexai",
-            "ls_model_name": "gemini-pro",
+            "ls_model_name": _DEFAULT_MODEL_NAME,
             "ls_model_type": "chat",
             "ls_temperature": None,
             "ls_max_tokens": 10,
@@ -99,13 +102,13 @@ def test_init() -> None:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             llm = ChatVertexAI(
-                model_name="gemini-pro",
+                model_name=_DEFAULT_MODEL_NAME,
                 project="test-project",
                 safety_setting={
                     "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
                 },  # Invalid arg
             )
-        assert llm.model_name == "gemini-pro"
+        assert llm.model_name == _DEFAULT_MODEL_NAME
         assert llm.project == "test-project"
         mock_warning.assert_called_once()
         call_args = mock_warning.call_args[0][0]
@@ -182,12 +185,12 @@ def test_model_name_presence_in_chat_results(
 
 def test_tuned_model_name() -> None:
     llm = ChatVertexAI(
-        model_name="gemini-pro",
+        model_name=_DEFAULT_MODEL_NAME,
         project="test-project",
         tuned_model_name="projects/123/locations/europe-west4/endpoints/456",
         max_tokens=500,
     )
-    assert llm.model_name == "gemini-pro"
+    assert llm.model_name == _DEFAULT_MODEL_NAME
     assert llm.tuned_model_name == "projects/123/locations/europe-west4/endpoints/456"
     assert llm.full_model_name == "projects/123/locations/europe-west4/endpoints/456"
     assert llm.max_output_tokens == 500
@@ -625,7 +628,7 @@ def test_default_params_gemini() -> None:
         mock_generate_content = MagicMock(return_value=response)
         mc.return_value.generate_content = mock_generate_content
 
-        model = ChatVertexAI(model_name="gemini-pro", project="test-project")
+        model = ChatVertexAI(model_name=_DEFAULT_MODEL_NAME, project="test-project")
         message = HumanMessage(content=user_prompt)
         _ = model.invoke([message])
         mock_generate_content.assert_called_once()
@@ -1093,7 +1096,7 @@ def test_parser_multiple_tools() -> None:
 
 def test_generation_config_gemini() -> None:
     model = ChatVertexAI(
-        model_name="gemini-pro",
+        model_name=_DEFAULT_MODEL_NAME,
         project="test-project",
         temperature=0.2,
         top_k=3,
@@ -1120,7 +1123,7 @@ def test_generation_config_gemini() -> None:
 
 def test_safety_settings_gemini() -> None:
     model = ChatVertexAI(
-        model_name="gemini-pro", temperature=0.2, top_k=3, project="test-project"
+        model_name=_DEFAULT_MODEL_NAME, temperature=0.2, top_k=3, project="test-project"
     )
     expected_safety_setting = SafetySetting(
         category=HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
@@ -1153,7 +1156,7 @@ def test_safety_settings_gemini_init() -> None:
         )
     ]
     model = ChatVertexAI(
-        model_name="gemini-pro",
+        model_name=_DEFAULT_MODEL_NAME,
         temperature=0.2,
         top_k=3,
         project="test-project",
@@ -1481,7 +1484,7 @@ def test_thinking_configuration() -> None:
 
     # Test init params
     llm = ChatVertexAI(
-        model="gemini-2.5-flash",
+        model=_DEFAULT_MODEL_NAME,
         project="test-project",
         thinking_budget=100,
         include_thoughts=True,
@@ -1491,7 +1494,7 @@ def test_thinking_configuration() -> None:
     assert request.generation_config.thinking_config.include_thoughts is True
 
     # Test invocation params
-    llm = ChatVertexAI(model="gemini-2.5-flash", project="test-project")
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, project="test-project")
     request = llm._prepare_request_gemini(
         [input_message],
         thinking_budget=100,
@@ -1503,7 +1506,7 @@ def test_thinking_configuration() -> None:
 
 def test_thought_signature() -> None:
     llm = ChatVertexAI(
-        model="gemini-2.5-flash",
+        model=_DEFAULT_MODEL_NAME,
         project="test-project",
         include_thoughts=True,
     )
@@ -1560,7 +1563,7 @@ def test_thought_signature() -> None:
 
 
 def test_python_literal_inputs() -> None:
-    llm = ChatVertexAI(model="gemini-2.5-flash", project="test-project")
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, project="test-project")
 
     for input_string in ["None", "(1, 2)", "[1, 2, 3]", "{1, 2, 3}"]:
         _ = llm._prepare_request_gemini([HumanMessage(input_string)])
@@ -1568,7 +1571,7 @@ def test_python_literal_inputs() -> None:
 
 def test_v1_function_parts() -> None:
     llm = ChatVertexAI(
-        model="gemini-2.5-flash", project="test-project", endpoint_version="v1"
+        model=_DEFAULT_MODEL_NAME, project="test-project", endpoint_version="v1"
     )
 
     messages = [

--- a/libs/vertexai/tests/unit_tests/test_llm.py
+++ b/libs/vertexai/tests/unit_tests/test_llm.py
@@ -18,6 +18,9 @@ from langchain_google_vertexai._base import (
     _get_prediction_client,
 )
 from langchain_google_vertexai.llms import VertexAI
+from tests.integration_tests.conftest import (
+    _DEFAULT_MODEL_NAME,
+)
 
 
 @pytest.fixture
@@ -29,10 +32,12 @@ def clear_prediction_client_cache() -> None:
 
 def test_model_name() -> None:
     for llm in [
-        VertexAI(model_name="gemini-pro", project="test-project", max_output_tokens=10),
-        VertexAI(model="gemini-pro", project="test-project", max_tokens=10),
+        VertexAI(
+            model_name=_DEFAULT_MODEL_NAME, project="test-project", max_output_tokens=10
+        ),
+        VertexAI(model=_DEFAULT_MODEL_NAME, project="test-project", max_tokens=10),
     ]:
-        assert llm.model_name == "gemini-pro"
+        assert llm.model_name == _DEFAULT_MODEL_NAME
         assert llm.max_output_tokens == 10
 
     # Test initialization with an invalid argument to check warning
@@ -42,13 +47,13 @@ def test_model_name() -> None:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             llm = VertexAI(
-                model_name="gemini-pro",
+                model_name=_DEFAULT_MODEL_NAME,
                 project="test-project",
                 safety_setting={
                     "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_LOW_AND_ABOVE"
                 },  # Invalid arg
             )
-        assert llm.model_name == "gemini-pro"
+        assert llm.model_name == _DEFAULT_MODEL_NAME
         assert llm.project == "test-project"
         mock_warning.assert_called_once()
         call_args = mock_warning.call_args[0][0]
@@ -58,11 +63,11 @@ def test_model_name() -> None:
 
 def test_tuned_model_name() -> None:
     llm = VertexAI(
-        model_name="gemini-pro",
+        model_name=_DEFAULT_MODEL_NAME,
         project="test-project",
         tuned_model_name="projects/123/locations/europe-west4/endpoints/456",
     )
-    assert llm.model_name == "gemini-pro"
+    assert llm.model_name == _DEFAULT_MODEL_NAME
     assert llm.tuned_model_name == "projects/123/locations/europe-west4/endpoints/456"
     assert (
         llm.client.full_model_name
@@ -95,7 +100,9 @@ def test_vertexai_args_passed(clear_prediction_client_cache: Any) -> None:
         )
         mock_prediction_service.return_value.generate_content = mock_generate_content
 
-        llm = VertexAI(model_name="gemini-pro", project="test-proj", **prompt_params)
+        llm = VertexAI(
+            model_name=_DEFAULT_MODEL_NAME, project="test-proj", **prompt_params
+        )
         response = llm.invoke(
             user_prompt, temperature=0.5, frequency_penalty=0.5, presence_penalty=0.5
         )
@@ -176,7 +183,7 @@ def test_tracing_params() -> None:
         }
 
         llm = VertexAI(
-            model_name="gemini-pro",
+            model_name=_DEFAULT_MODEL_NAME,
             temperature=0.1,
             max_output_tokens=10,
             project="test-proj",
@@ -185,7 +192,7 @@ def test_tracing_params() -> None:
         assert ls_params == {
             "ls_provider": "google_vertexai",
             "ls_model_type": "llm",
-            "ls_model_name": "gemini-pro",
+            "ls_model_name": _DEFAULT_MODEL_NAME,
             "ls_temperature": 0.1,
             "ls_max_tokens": 10,
         }


### PR DESCRIPTION
Use the latest `gemini-flash-lite-latest` model across various tests for cost savings/efficiency.