### PR TITLE
fix(genai): catch thought signatures in v1 translation

### DIFF
--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -143,6 +143,10 @@ def _convert_from_v1_to_generativelanguage_v1beta(
         # TextContentBlock
         if block_dict["type"] == "text":
             new_block = {"text": block_dict.get("text", "")}
+            if (
+                thought_signature := (block_dict.get("extras") or {}).get("signature")  # type: ignore[attr-defined]
+            ) and model_provider == "google_genai":
+                new_block["thought_signature"] = thought_signature
             new_content.append(new_block)
             # Citations are only handled on output. Can't pass them back :/
 


### PR DESCRIPTION
`_convert_to_parts` handles thought signatures on text blocks: https://github.com/langchain-ai/langchain-google/blob/ee60a4ef177df730159b03da4139b6f3ba134b20/libs/genai/langchain_google_genai/chat_models.py#L318-L330

But for v1 content, we skip this function: https://github.com/langchain-ai/langchain-google/blob/ee60a4ef177df730159b03da4139b6f3ba134b20/libs/genai/langchain_google_genai/chat_models.py#L706-L711

So we need to add the same handling in `_convert_from_v1_to_generativelanguage_v1beta`.

Note that in the v1 case the conversion to bytes happens when constructing the Part directly: https://github.com/langchain-ai/langchain-google/blob/ee60a4ef177df730159b03da4139b6f3ba134b20/libs/genai/langchain_google_genai/chat_models.py#L728