### PR TITLE
release(vertexai): 3.0.3

### DIFF
--- a/libs/vertexai/pyproject.toml
+++ b/libs/vertexai/pyproject.toml
@@ -9,7 +9,7 @@ license = {text = "MIT"}
 readme = "README.md"
 authors = []
 
-version = "3.0.2"
+version = "3.0.3"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.0.0,<2.0.0",

--- a/libs/vertexai/uv.lock
+++ b/libs/vertexai/uv.lock
@@ -934,7 +934,7 @@ wheels = [
 
 [[package]]
 name = "langchain-google-vertexai"
-version = "3.0.2"
+version = "3.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "bottleneck" },


### PR DESCRIPTION
- Fix import blocking I/O in async contexts #1267
- Bump `google-cloud-storage` constraint to <4.0.0 #1303
- Add `transport` as an alias of `api_transport` and fix some `base_url` behavior #1293