### PR TITLE
chore(vertexai): bump `pyarrow` constraint to <23.0.0

### DIFF
--- a/libs/vertexai/pyproject.toml
+++ b/libs/vertexai/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "validators>=0.22.0,<1.0.0",
     "bottleneck>=1.4.0,<2.0.0",
     "numexpr>=2.8.6,<3.0.0",
-    "pyarrow>=19.0.1,<22.0.0",
+    "pyarrow>=19.0.1,<23.0.0",
 ]
 
 [project.urls]

--- a/libs/vertexai/uv.lock
+++ b/libs/vertexai/uv.lock
@@ -1010,7 +1010,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-mistralai", marker = "extra == 'mistral'", specifier = ">=0.2.0,<2.0.0" },
     { name = "numexpr", specifier = ">=2.8.6,<3.0.0" },
-    { name = "pyarrow", specifier = ">=19.0.1,<22.0.0" },
+    { name = "pyarrow", specifier = ">=19.0.1,<23.0.0" },
     { name = "pydantic", specifier = ">=2.9.0,<3.0.0" },
     { name = "validators", specifier = ">=0.22.0,<1.0.0" },
 ]


### PR DESCRIPTION

## Description

Bumps the upper bound constraint for pyarrow from <22.0.0 to <23.0.0 in the langchain-google-vertexai package.
pyarrow 22.0.0 was released on Oct 24, 2025: https://pypi.org/project/pyarrow/#history
This change is required for Python 3.14 compatibility, because pyarrow 22+ provides wheels for Python 3.14: https://pypi.org/project/pyarrow/22.0.0/#files

## Changes

- Updated pyarrow dependency constraint in libs/vertexai/pyproject.toml from >=19.0.1,<22.0.0 to >=19.0.1,<23.0.0
- Regenerated uv.lock to reflect the updated constraint
