### PR TITLE
chore(genai): mark `google_vector_store` module deprecated

### DIFF
--- a/libs/genai/langchain_google_genai/google_vector_store.py
+++ b/libs/genai/langchain_google_genai/google_vector_store.py
@@ -1,4 +1,4 @@
-"""Google Generative AI Vector Store.
+"""DEPRECATED. To be removed or re-written for file search service.
 
 The GenAI Semantic Retriever API is a managed end-to-end service that allows developers
 to create a corpus of documents to perform semantic search on related passages given a


### PR DESCRIPTION
#1032

https://discuss.ai.google.dev/t/ragstore-replacing-semantic-search/106546

[Also not stable](https://ai.google.dev/gemini-api/docs/api-versions)