### PR TITLE
fix(vertexai): preserve cache_control during ToolMessage → tool_result conversion

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
@@ -406,6 +406,12 @@ def _merge_messages(
                 if curr.status == "error":
                     tool_result_block["is_error"] = True
 
+                cache_control = None
+                if isinstance(curr.additional_kwargs, dict):
+                    cache_control = curr.additional_kwargs.get("cache_control")
+                if cache_control:
+                    tool_result_block["cache_control"] = cache_control
+
                 curr = HumanMessage([tool_result_block])
         elif isinstance(curr, AIMessage):
             # Clean streaming metadata from AIMessage content blocks

--- a/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
@@ -1279,3 +1279,33 @@ def test_format_messages_complex_multiturn_with_tools() -> None:
     # Fourth message (AI response) should have 'index' removed
     assert "index" not in formatted[3]["content"][0]
     assert formatted[3]["content"][0]["text"] == "It's sunny and 22°C in Paris!"
+
+
+def test_tool_message_preserves_cache_control() -> None:
+    messages = [
+        AIMessage(
+            content="",
+            tool_calls=[
+                create_tool_call(
+                    name="get_weather",
+                    args={"city": "Paris"},
+                    id="call_1",
+                )
+            ],
+        ),
+        ToolMessage(
+            content="Sunny, 22°C",
+            tool_call_id="call_1",
+            additional_kwargs={"cache_control": {"type": "ephemeral"}},
+        ),
+    ]
+
+    _, formatted = _format_messages_anthropic(messages, project="test-project")
+    tool_result = formatted[1]["content"][0]
+
+    assert tool_result == {
+        "type": "tool_result",
+        "content": "Sunny, 22°C",
+        "tool_use_id": "call_1",
+        "cache_control": {"type": "ephemeral"},
+    }


### PR DESCRIPTION
This PR resolves an issue in the VertexAI Anthropic message formatting pipeline where `ToolMessage.additional_kwargs["cache_control"]` was lost when converting `ToolMessage` instances into Anthropic `tool_result` blocks via `_merge_messages`.

## Background

Anthropic requires tool responses to be represented as `tool_result` content blocks.
During the conversion, LangChain correctly forwarded `content` and `tool_use_id`, but unintentionally **dropped the `cache_control` metadata** attached to the original `ToolMessage`.

`cache_control` is part of LangChain’s standardized message schema and is used by Anthropic to enable **semantic** and **ephemeral** caching. Losing it leads to inconsistent message semantics and prevents proper cache-aware behavior.

## What This PR Changes

### 🛠️ 1. Preserve `cache_control` metadata

During the `_merge_messages` transformation, the formatter now retains:

```python
curr.additional_kwargs.get("cache_control")
```

The generated `tool_result` block now properly includes the metadata:

```json
{
  "type": "tool_result",
  "content": "...",
  "tool_use_id": "...",
  "cache_control": { "type": "ephemeral" }
}
```

This aligns `ToolMessage` behavior with `HumanMessage` and `AIMessage`, which already preserve `cache_control` in their text content blocks.

---

### 🧪 2. Add regression test

Introduces `test_tool_message_preserves_cache_control`, ensuring:

* `cache_control` propagates from `ToolMessage` → `tool_result`
* future refactors cannot reintroduce the regression

The test **fails on `main`** and **passes with this fix**.

---

### 🔒 3. No behavioral changes outside this path

Only the tool-message conversion inside `_merge_messages` is affected.

All other functionality remains unchanged, including:

* tool_call handling
* text/image content formatting
* streaming metadata cleanup

---

## Why This Matters

Anthropic models rely on cache metadata for correct, cache-aware inference. Dropping `cache_control` on tool results:

* breaks parity with `HumanMessage` / `AIMessage` handling
* prevents expected caching behaviors
* deviates from `langchain-anthropic`, which already preserves this metadata

This PR restores consistency and ensures the VertexAI formatter behaves correctly and predictably.

---

## Type

🐛 **Bug Fix**
✅ **Adds regression test**

