### PR TITLE
fix(vertexai): mime type parsing from image URLs with params

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
@@ -1,5 +1,6 @@
 import base64
 import re
+import urllib
 import warnings
 from collections.abc import Callable, Sequence
 from typing import (
@@ -90,7 +91,8 @@ def _format_image(image_url: str, project: str | None) -> dict:
     if validators.url(image_url):
         loader = ImageBytesLoader(project=project)
         image_bytes = loader.load_bytes(image_url)
-        raw_mime_type = image_url.split(".")[-1].lower()
+        path = urllib.parse.urlparse(image_url).path
+        raw_mime_type = path.split(".")[-1].lower()
         doc_type = "application" if raw_mime_type == "pdf" else "image"
         mime_type = (
             f"{doc_type}/jpeg"


### PR DESCRIPTION
## Description

The mime type is parsed incorrectly when there are parameters in the image URLs that are sent to the Anthropic VertexAI provider resulting in rejected requests. This PR fixes the mime type parsing.

## Type

🐛 Bug Fix
