### PR TITLE
feat(community): Add Google Tasks integration toolkit

### DIFF
--- a/libs/community/langchain_google_community/__init__.py
+++ b/libs/community/langchain_google_community/__init__.py
@@ -52,6 +52,14 @@ from langchain_google_community.sheets import (
     SheetsToolkit,
     SheetsUpdateValuesTool,
 )
+from langchain_google_community.tasks.toolkit import (
+    TasksCreateTask,
+    TasksDeleteTask,
+    TasksGetTask,
+    TasksListTasks,
+    TasksToolkit,
+    TasksUpdateTask,
+)
 from langchain_google_community.texttospeech import TextToSpeechTool
 from langchain_google_community.translate import GoogleTranslateTransformer
 from langchain_google_community.vertex_ai_search import (
@@ -96,6 +104,12 @@ __all__ = [
     "SheetsReadDataTool",
     "SheetsToolkit",
     "SheetsUpdateValuesTool",
+    "TasksCreateTask",
+    "TasksDeleteTask",
+    "TasksGetTask",
+    "TasksListTasks",
+    "TasksToolkit",
+    "TasksUpdateTask",
     "GoogleGeocodingAPIWrapper",
     "GoogleGeocodingTool",
     "GooglePlacesAPIWrapper",

--- a/libs/community/langchain_google_community/tasks/__init__.py
+++ b/libs/community/langchain_google_community/tasks/__init__.py
@@ -1,0 +1,34 @@
+"""Google Tasks toolkit."""
+
+from langchain_google_community.tasks.create_task import (
+    CreateTaskSchema,
+    TasksCreateTask,
+)
+from langchain_google_community.tasks.delete_task import (
+    DeleteTaskSchema,
+    TasksDeleteTask,
+)
+from langchain_google_community.tasks.get_task import GetTaskSchema, TasksGetTask
+from langchain_google_community.tasks.list_tasks import (
+    ListTasksSchema,
+    TasksListTasks,
+)
+from langchain_google_community.tasks.toolkit import TasksToolkit
+from langchain_google_community.tasks.update_task import (
+    TasksUpdateTask,
+    UpdateTaskSchema,
+)
+
+__all__ = [
+    "CreateTaskSchema",
+    "TasksCreateTask",
+    "DeleteTaskSchema",
+    "TasksDeleteTask",
+    "GetTaskSchema",
+    "TasksGetTask",
+    "ListTasksSchema",
+    "TasksListTasks",
+    "TasksToolkit",
+    "UpdateTaskSchema",
+    "TasksUpdateTask",
+]

--- a/libs/community/langchain_google_community/tasks/base.py
+++ b/libs/community/langchain_google_community/tasks/base.py
@@ -1,0 +1,38 @@
+"""Base class for Google Tasks tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from langchain_core.tools import BaseTool
+from pydantic import Field
+
+from langchain_google_community.tasks.utils import build_tasks_service
+
+if TYPE_CHECKING:
+    # This is for linting and IDE typehints
+    from googleapiclient.discovery import Resource  # type: ignore[import]
+else:
+    try:
+        # We do this so pydantic can resolve the types when instantiating
+        from googleapiclient.discovery import Resource
+    except ImportError:
+        pass
+
+
+class TasksBaseTool(BaseTool):  # type: ignore[override]
+    """Base class for Google Tasks tools."""
+
+    api_resource: Resource = Field(default_factory=build_tasks_service)
+
+    @classmethod
+    def from_api_resource(cls, api_resource: Resource) -> "TasksBaseTool":
+        """Create a tool from an api resource.
+
+        Args:
+            api_resource: The api resource to use.
+
+        Returns:
+            A tool.
+        """
+        return cls(api_resource=api_resource)  # type: ignore[call-arg]

--- a/libs/community/langchain_google_community/tasks/create_task.py
+++ b/libs/community/langchain_google_community/tasks/create_task.py
@@ -1,0 +1,99 @@
+"""Create a task in Google Tasks."""
+
+from typing import Optional, Type
+
+from langchain_core.callbacks import CallbackManagerForToolRun
+from pydantic import BaseModel, Field
+
+from langchain_google_community.tasks.base import TasksBaseTool
+
+
+class CreateTaskSchema(BaseModel):
+    """Input schema for `TasksCreateTask`."""
+
+    title: str = Field(..., description="The title of the task.")
+
+    notes: Optional[str] = Field(
+        default=None, description="Notes or description for the task."
+    )
+
+    due: Optional[str] = Field(
+        default=None,
+        description=(
+            "Due date of the task in RFC 3339 format (e.g., '2024-12-31T23:59:59Z'). "
+            "Optional."
+        ),
+    )
+
+    tasklist: str = Field(
+        default="@default",
+        description=(
+            "The task list ID to create the task in. "
+            "Use '@default' for the default task list."
+        ),
+    )
+
+
+class TasksCreateTask(TasksBaseTool):  # type: ignore[override]
+    """Tool that creates a task in Google Tasks."""
+
+    name: str = "create_google_task"
+
+    description: str = (
+        "Use this tool to create a new task in Google Tasks. "
+        "The input must include the title of the task. "
+        "You can optionally include notes and a due date."
+    )
+
+    args_schema: Type[CreateTaskSchema] = CreateTaskSchema
+
+    def _run(
+        self,
+        title: str,
+        notes: Optional[str] = None,
+        due: Optional[str] = None,
+        tasklist: str = "@default",
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Create a task in Google Tasks.
+
+        Args:
+            title: The title of the task.
+            notes: Optional notes or description for the task.
+            due: Optional due date in RFC 3339 format.
+            tasklist: The task list ID. Defaults to '@default'.
+            run_manager: Optional callback manager.
+
+        Returns:
+            A string confirming the task creation with task details.
+        """
+        try:
+            task_body = {"title": title}
+
+            if notes:
+                task_body["notes"] = notes
+
+            if due:
+                task_body["due"] = due
+
+            result = (
+                self.api_resource.tasks()
+                .insert(tasklist=tasklist, body=task_body)
+                .execute()
+            )
+
+            task_id = result.get("id", "Unknown")
+            task_title = result.get("title", "Unknown")
+
+            response = f"Task created successfully!\nID: {task_id}\nTitle: {task_title}"
+
+            if result.get("notes"):
+                response += f"\nNotes: {result['notes']}"
+
+            if result.get("due"):
+                response += f"\nDue: {result['due']}"
+
+            return response
+
+        except Exception as e:
+            return f"An error occurred while creating the task: {str(e)}"

--- a/libs/community/langchain_google_community/tasks/delete_task.py
+++ b/libs/community/langchain_google_community/tasks/delete_task.py
@@ -1,0 +1,59 @@
+"""Delete a task from Google Tasks."""
+
+from typing import Optional, Type
+
+from langchain_core.callbacks import CallbackManagerForToolRun
+from pydantic import BaseModel, Field
+
+from langchain_google_community.tasks.base import TasksBaseTool
+
+
+class DeleteTaskSchema(BaseModel):
+    """Input schema for `TasksDeleteTask`."""
+
+    task_id: str = Field(..., description="The ID of the task to delete.")
+
+    tasklist: str = Field(
+        default="@default",
+        description=(
+            "The task list ID containing the task. "
+            "Use '@default' for the default task list."
+        ),
+    )
+
+
+class TasksDeleteTask(TasksBaseTool):  # type: ignore[override]
+    """Tool that deletes a task from Google Tasks."""
+
+    name: str = "delete_google_task"
+
+    description: str = (
+        "Use this tool to delete a task from Google Tasks. "
+        "You must provide the task ID."
+    )
+
+    args_schema: Type[DeleteTaskSchema] = DeleteTaskSchema
+
+    def _run(
+        self,
+        task_id: str,
+        tasklist: str = "@default",
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Delete a task from Google Tasks.
+
+        Args:
+            task_id: The ID of the task to delete.
+            tasklist: The task list ID. Defaults to '@default'.
+            run_manager: Optional callback manager.
+
+        Returns:
+            A string confirming the task deletion.
+        """
+        try:
+            self.api_resource.tasks().delete(tasklist=tasklist, task=task_id).execute()
+
+            return f"Task with ID '{task_id}' has been deleted successfully."
+
+        except Exception as e:
+            return f"An error occurred while deleting the task: {str(e)}"

--- a/libs/community/langchain_google_community/tasks/get_task.py
+++ b/libs/community/langchain_google_community/tasks/get_task.py
@@ -1,0 +1,78 @@
+"""Get a specific task from Google Tasks."""
+
+from typing import Optional, Type
+
+from langchain_core.callbacks import CallbackManagerForToolRun
+from pydantic import BaseModel, Field
+
+from langchain_google_community.tasks.base import TasksBaseTool
+
+
+class GetTaskSchema(BaseModel):
+    """Input schema for `TasksGetTask`."""
+
+    task_id: str = Field(..., description="The ID of the task to retrieve.")
+
+    tasklist: str = Field(
+        default="@default",
+        description=(
+            "The task list ID containing the task. "
+            "Use '@default' for the default task list."
+        ),
+    )
+
+
+class TasksGetTask(TasksBaseTool):  # type: ignore[override]
+    """Tool that retrieves a specific task from Google Tasks."""
+
+    name: str = "get_google_task"
+
+    description: str = (
+        "Use this tool to get detailed information about a specific task "
+        "from Google Tasks. You must provide the task ID."
+    )
+
+    args_schema: Type[GetTaskSchema] = GetTaskSchema
+
+    def _run(
+        self,
+        task_id: str,
+        tasklist: str = "@default",
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Get a specific task from Google Tasks.
+
+        Args:
+            task_id: The ID of the task to retrieve.
+            tasklist: The task list ID. Defaults to '@default'.
+            run_manager: Optional callback manager.
+
+        Returns:
+            A formatted string with the task details.
+        """
+        try:
+            task = (
+                self.api_resource.tasks().get(tasklist=tasklist, task=task_id).execute()
+            )
+
+            response = "Task Details:\n"
+            response += f"ID: {task.get('id', 'Unknown')}\n"
+            response += f"Title: {task.get('title', 'No title')}\n"
+            response += f"Status: {task.get('status', 'Unknown')}\n"
+
+            if task.get("notes"):
+                response += f"Notes: {task['notes']}\n"
+
+            if task.get("due"):
+                response += f"Due: {task['due']}\n"
+
+            if task.get("updated"):
+                response += f"Last Updated: {task['updated']}\n"
+
+            if task.get("completed"):
+                response += f"Completed: {task['completed']}\n"
+
+            return response
+
+        except Exception as e:
+            return f"An error occurred while retrieving the task: {str(e)}"

--- a/libs/community/langchain_google_community/tasks/list_tasks.py
+++ b/libs/community/langchain_google_community/tasks/list_tasks.py
@@ -1,0 +1,117 @@
+"""List tasks from Google Tasks."""
+
+from typing import Optional, Type
+
+from langchain_core.callbacks import CallbackManagerForToolRun
+from pydantic import BaseModel, Field
+
+from langchain_google_community.tasks.base import TasksBaseTool
+
+
+class ListTasksSchema(BaseModel):
+    """Input schema for `TasksListTasks`."""
+
+    tasklist: str = Field(
+        default="@default",
+        description=(
+            "The task list ID to retrieve tasks from. "
+            "Use '@default' for the default task list."
+        ),
+    )
+
+    max_results: int = Field(
+        default=10,
+        description="Maximum number of tasks to return. Default is 10.",
+    )
+
+    show_completed: bool = Field(
+        default=False,
+        description=(
+            "Whether to include completed tasks in the results. Default is False."
+        ),
+    )
+
+    show_hidden: bool = Field(
+        default=False,
+        description="Whether to include hidden tasks in the results. Default is False.",
+    )
+
+
+class TasksListTasks(TasksBaseTool):  # type: ignore[override]
+    """Tool that lists tasks from Google Tasks."""
+
+    name: str = "list_google_tasks"
+
+    description: str = (
+        "Use this tool to list tasks from a Google Tasks list. "
+        "You can specify the task list ID, maximum number of results, "
+        "and whether to include completed or hidden tasks."
+    )
+
+    args_schema: Type[ListTasksSchema] = ListTasksSchema
+
+    def _run(
+        self,
+        tasklist: str = "@default",
+        max_results: int = 10,
+        show_completed: bool = False,
+        show_hidden: bool = False,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """List tasks from Google Tasks.
+
+        Args:
+            tasklist: The task list ID. Defaults to '@default'.
+            max_results: Maximum number of tasks to return.
+            show_completed: Whether to include completed tasks.
+            show_hidden: Whether to include hidden tasks.
+            run_manager: Optional callback manager.
+
+        Returns:
+            A formatted string with the list of tasks.
+        """
+        try:
+            results = (
+                self.api_resource.tasks()
+                .list(
+                    tasklist=tasklist,
+                    maxResults=max_results,
+                    showCompleted=show_completed,
+                    showHidden=show_hidden,
+                )
+                .execute()
+            )
+
+            tasks = results.get("items", [])
+
+            if not tasks:
+                return "No tasks found."
+
+            response = f"Found {len(tasks)} task(s):\n\n"
+
+            for i, task in enumerate(tasks, 1):
+                task_id = task.get("id", "Unknown")
+                title = task.get("title", "No title")
+                status = task.get("status", "Unknown")
+
+                response += f"{i}. {title}\n"
+                response += f"   ID: {task_id}\n"
+                response += f"   Status: {status}\n"
+
+                if task.get("notes"):
+                    notes = task["notes"][:100]  # Truncate long notes
+                    response += (
+                        f"   Notes: {notes}...\n"
+                        if len(task["notes"]) > 100
+                        else f"   Notes: {notes}\n"
+                    )
+
+                if task.get("due"):
+                    response += f"   Due: {task['due']}\n"
+
+                response += "\n"
+
+            return response.strip()
+
+        except Exception as e:
+            return f"An error occurred while listing tasks: {str(e)}"

--- a/libs/community/langchain_google_community/tasks/toolkit.py
+++ b/libs/community/langchain_google_community/tasks/toolkit.py
@@ -1,0 +1,101 @@
+"""Google Tasks Toolkit."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+from langchain_core.tools import BaseTool, BaseToolkit
+from pydantic import ConfigDict, Field
+
+from langchain_google_community.tasks.create_task import TasksCreateTask
+from langchain_google_community.tasks.delete_task import TasksDeleteTask
+from langchain_google_community.tasks.get_task import TasksGetTask
+from langchain_google_community.tasks.list_tasks import TasksListTasks
+from langchain_google_community.tasks.update_task import TasksUpdateTask
+from langchain_google_community.tasks.utils import build_tasks_service
+
+if TYPE_CHECKING:
+    # This is for linting and IDE typehints
+    from googleapiclient.discovery import Resource  # type: ignore[import]
+else:
+    try:
+        # We do this so pydantic can resolve the types when instantiating
+        from googleapiclient.discovery import Resource
+    except ImportError:
+        pass
+
+
+class TasksToolkit(BaseToolkit):
+    """Toolkit for interacting with Google Tasks.
+
+    This toolkit provides tools for creating, listing, updating,
+    deleting, and retrieving tasks from Google Tasks.
+
+    Setup:
+        Install ``langchain-google-community`` and set up Google authentication.
+
+        .. code-block:: bash
+
+            pip install -U langchain-google-community
+
+        You'll need to enable the Google Tasks API and set up credentials.
+
+    Instantiation:
+        .. code-block:: python
+
+            from langchain_google_community import TasksToolkit
+
+            toolkit = TasksToolkit()
+
+    Tools:
+        .. code-block:: python
+
+            tools = toolkit.get_tools()
+            # Returns: [TasksCreateTask, TasksListTasks, TasksUpdateTask,
+            #           TasksDeleteTask, TasksGetTask]
+
+    Use within an agent:
+        .. code-block:: python
+
+            from langchain_openai import ChatOpenAI
+            from langgraph.prebuilt import create_react_agent
+
+            llm = ChatOpenAI(model="gpt-4o-mini")
+            agent_executor = create_react_agent(llm, tools)
+
+            example_query = "Create a task to review the quarterly report"
+            events = agent_executor.stream(
+                {"messages": [("user", example_query)]},
+                stream_mode="values",
+            )
+            for event in events:
+                event["messages"][-1].pretty_print()
+
+    !!! warning "Security"
+        This toolkit contains tools that can read and modify the state of a
+        service. For example, it can create, update, and delete tasks
+        on behalf of the associated account.
+
+        See [Security Policy](https://docs.langchain.com/oss/python/security-policy)
+        for more information.
+    """
+
+    api_resource: Resource = Field(default_factory=build_tasks_service)
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
+
+    def get_tools(self) -> List[BaseTool]:
+        """Get the tools in the toolkit.
+
+        Returns:
+            A list of tools for interacting with Google Tasks.
+        """
+        return [
+            TasksCreateTask(api_resource=self.api_resource),
+            TasksListTasks(api_resource=self.api_resource),
+            TasksUpdateTask(api_resource=self.api_resource),
+            TasksDeleteTask(api_resource=self.api_resource),
+            TasksGetTask(api_resource=self.api_resource),
+        ]

--- a/libs/community/langchain_google_community/tasks/update_task.py
+++ b/libs/community/langchain_google_community/tasks/update_task.py
@@ -1,0 +1,125 @@
+"""Update a task in Google Tasks."""
+
+from typing import Optional, Type
+
+from langchain_core.callbacks import CallbackManagerForToolRun
+from pydantic import BaseModel, Field
+
+from langchain_google_community.tasks.base import TasksBaseTool
+
+
+class UpdateTaskSchema(BaseModel):
+    """Input schema for `TasksUpdateTask`."""
+
+    task_id: str = Field(..., description="The ID of the task to update.")
+
+    title: Optional[str] = Field(default=None, description="The new title of the task.")
+
+    notes: Optional[str] = Field(
+        default=None, description="The new notes or description for the task."
+    )
+
+    status: Optional[str] = Field(
+        default=None,
+        description=(
+            "The new status of the task. Use 'completed' to mark as complete, "
+            "or 'needsAction' to mark as incomplete."
+        ),
+    )
+
+    due: Optional[str] = Field(
+        default=None,
+        description=(
+            "The new due date in RFC 3339 format (e.g., '2024-12-31T23:59:59Z')."
+        ),
+    )
+
+    tasklist: str = Field(
+        default="@default",
+        description=(
+            "The task list ID containing the task. "
+            "Use '@default' for the default task list."
+        ),
+    )
+
+
+class TasksUpdateTask(TasksBaseTool):  # type: ignore[override]
+    """Tool that updates a task in Google Tasks."""
+
+    name: str = "update_google_task"
+
+    description: str = (
+        "Use this tool to update an existing task in Google Tasks. "
+        "You can update the title, notes, status (completed/needsAction), or due date. "
+        "You must provide the task ID."
+    )
+
+    args_schema: Type[UpdateTaskSchema] = UpdateTaskSchema
+
+    def _run(
+        self,
+        task_id: str,
+        title: Optional[str] = None,
+        notes: Optional[str] = None,
+        status: Optional[str] = None,
+        due: Optional[str] = None,
+        tasklist: str = "@default",
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Update a task in Google Tasks.
+
+        Args:
+            task_id: The ID of the task to update.
+            title: Optional new title.
+            notes: Optional new notes.
+            status: Optional new status ('completed' or 'needsAction').
+            due: Optional new due date in RFC 3339 format.
+            tasklist: The task list ID. Defaults to '@default'.
+            run_manager: Optional callback manager.
+
+        Returns:
+            A string confirming the task update with updated details.
+        """
+        try:
+            # First, get the current task
+            task = (
+                self.api_resource.tasks().get(tasklist=tasklist, task=task_id).execute()
+            )
+
+            # Update only the fields that were provided
+            if title is not None:
+                task["title"] = title
+
+            if notes is not None:
+                task["notes"] = notes
+
+            if status is not None:
+                task["status"] = status
+
+            if due is not None:
+                task["due"] = due
+
+            # Update the task
+            result = (
+                self.api_resource.tasks()
+                .update(tasklist=tasklist, task=task_id, body=task)
+                .execute()
+            )
+
+            task_id = result.get("id", "Unknown")
+            task_title = result.get("title", "Unknown")
+            response = f"Task updated successfully!\nID: {task_id}\nTitle: {task_title}"
+
+            if result.get("status"):
+                response += f"\nStatus: {result['status']}"
+
+            if result.get("notes"):
+                response += f"\nNotes: {result['notes']}"
+
+            if result.get("due"):
+                response += f"\nDue: {result['due']}"
+
+            return response
+
+        except Exception as e:
+            return f"An error occurred while updating the task: {str(e)}"

--- a/libs/community/langchain_google_community/tasks/utils.py
+++ b/libs/community/langchain_google_community/tasks/utils.py
@@ -1,0 +1,41 @@
+"""Google Tasks tool utils."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from langchain_google_community._utils import (
+    get_google_credentials,
+    import_googleapiclient_resource_builder,
+)
+
+if TYPE_CHECKING:
+    from google.oauth2.credentials import Credentials
+    from googleapiclient.discovery import Resource
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_SCOPES = ["https://www.googleapis.com/auth/tasks"]
+
+
+def build_tasks_service(
+    credentials: Optional[Credentials] = None,
+    service_name: str = "tasks",
+    service_version: str = "v1",
+) -> Resource:
+    """Build a Google Tasks service.
+
+    Args:
+        credentials: Optional credentials to use. If not provided,
+            will use default credentials.
+        service_name: The name of the service. Default is 'tasks'.
+        service_version: The version of the service. Default is 'v1'.
+
+    Returns:
+        A Resource object for interacting with the Google Tasks API.
+    """
+    credentials = credentials or get_google_credentials(scopes=DEFAULT_SCOPES)
+    builder = import_googleapiclient_resource_builder()
+    return builder(service_name, service_version, credentials=credentials)

--- a/libs/community/tests/unit_tests/test_google_tasks.py
+++ b/libs/community/tests/unit_tests/test_google_tasks.py
@@ -1,0 +1,200 @@
+"""Unit tests for Google Tasks tools."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from langchain_google_community.tasks.create_task import TasksCreateTask
+from langchain_google_community.tasks.delete_task import TasksDeleteTask
+from langchain_google_community.tasks.get_task import TasksGetTask
+from langchain_google_community.tasks.list_tasks import TasksListTasks
+from langchain_google_community.tasks.update_task import TasksUpdateTask
+
+
+def test_create_task() -> None:
+    """Test creating a task."""
+    mock_api_resource = MagicMock()
+    mock_api_resource.tasks().insert().execute.return_value = {
+        "id": "task123",
+        "title": "Test Task",
+        "notes": "Test notes",
+    }
+
+    # Bypass pydantic validation as google-api-python-client is not a dependency
+    tool = TasksCreateTask.model_construct(api_resource=mock_api_resource)
+    tool_input = {
+        "title": "Test Task",
+        "notes": "Test notes",
+    }
+    result = tool.run(tool_input)
+    assert tool.args_schema is not None
+    assert "Task created successfully!" in result
+    assert "task123" in result
+    assert "Test Task" in result
+
+
+def test_create_task_with_due_date() -> None:
+    """Test creating a task with a due date."""
+    mock_api_resource = MagicMock()
+    mock_api_resource.tasks().insert().execute.return_value = {
+        "id": "task456",
+        "title": "Task with due date",
+        "due": "2025-12-31T23:59:59Z",
+    }
+
+    tool = TasksCreateTask.model_construct(api_resource=mock_api_resource)
+    tool_input = {
+        "title": "Task with due date",
+        "due": "2025-12-31T23:59:59Z",
+    }
+    result = tool.run(tool_input)
+    assert "Task created successfully!" in result
+    assert "2025-12-31T23:59:59Z" in result
+
+
+def test_list_tasks() -> None:
+    """Test listing tasks."""
+    mock_api_resource = MagicMock()
+    mock_api_resource.tasks().list().execute.return_value = {
+        "items": [
+            {
+                "id": "task1",
+                "title": "First Task",
+                "status": "needsAction",
+            },
+            {
+                "id": "task2",
+                "title": "Second Task",
+                "status": "completed",
+                "notes": "Some notes here",
+            },
+        ]
+    }
+
+    tool = TasksListTasks.model_construct(api_resource=mock_api_resource)
+    tool_input = {"max_results": 10}
+    result = tool.run(tool_input)
+    assert tool.args_schema is not None
+    assert "Found 2 task(s)" in result
+    assert "First Task" in result
+    assert "Second Task" in result
+
+
+def test_list_tasks_empty() -> None:
+    """Test listing tasks when no tasks exist."""
+    mock_api_resource = MagicMock()
+    mock_api_resource.tasks().list().execute.return_value = {"items": []}
+
+    tool = TasksListTasks.model_construct(api_resource=mock_api_resource)
+    tool_input: dict = {}
+    result = tool.run(tool_input)
+    assert "No tasks found" in result
+
+
+def test_update_task() -> None:
+    """Test updating a task."""
+    mock_api_resource = MagicMock()
+    mock_api_resource.tasks().get().execute.return_value = {
+        "id": "task123",
+        "title": "Old Title",
+        "status": "needsAction",
+    }
+    mock_api_resource.tasks().update().execute.return_value = {
+        "id": "task123",
+        "title": "New Title",
+        "status": "completed",
+    }
+
+    tool = TasksUpdateTask.model_construct(api_resource=mock_api_resource)
+    tool_input = {
+        "task_id": "task123",
+        "title": "New Title",
+        "status": "completed",
+    }
+    result = tool.run(tool_input)
+    assert tool.args_schema is not None
+    assert "Task updated successfully!" in result
+    assert "New Title" in result
+    assert "completed" in result
+
+
+def test_delete_task() -> None:
+    """Test deleting a task."""
+    mock_api_resource = MagicMock()
+    mock_api_resource.tasks().delete().execute.return_value = None
+
+    tool = TasksDeleteTask.model_construct(api_resource=mock_api_resource)
+    tool_input = {"task_id": "task123"}
+    result = tool.run(tool_input)
+    assert tool.args_schema is not None
+    assert "deleted successfully" in result
+    assert "task123" in result
+
+
+def test_get_task() -> None:
+    """Test getting a specific task."""
+    mock_api_resource = MagicMock()
+    mock_api_resource.tasks().get().execute.return_value = {
+        "id": "task123",
+        "title": "Sample Task",
+        "status": "needsAction",
+        "notes": "Task notes",
+        "due": "2025-12-31T23:59:59Z",
+    }
+
+    tool = TasksGetTask.model_construct(api_resource=mock_api_resource)
+    tool_input = {"task_id": "task123"}
+    result = tool.run(tool_input)
+    assert tool.args_schema is not None
+    assert "Task Details:" in result
+    assert "Sample Task" in result
+    assert "needsAction" in result
+    assert "Task notes" in result
+
+
+def test_toolkit() -> None:
+    """Test the TasksToolkit."""
+    mock_api_resource = MagicMock()
+    # Create individual tools with model_construct
+    create_tool = TasksCreateTask.model_construct(api_resource=mock_api_resource)
+    list_tool = TasksListTasks.model_construct(api_resource=mock_api_resource)
+    update_tool = TasksUpdateTask.model_construct(api_resource=mock_api_resource)
+    delete_tool = TasksDeleteTask.model_construct(api_resource=mock_api_resource)
+    get_tool = TasksGetTask.model_construct(api_resource=mock_api_resource)
+
+    # Verify tools can be created
+    assert create_tool.name == "create_google_task"
+    assert list_tool.name == "list_google_tasks"
+    assert update_tool.name == "update_google_task"
+    assert delete_tool.name == "delete_google_task"
+    assert get_tool.name == "get_google_task"
+
+
+@pytest.mark.requires("google-api-python-client")
+def test_imports() -> None:
+    """Test that all imports work correctly."""
+    from langchain_google_community.tasks import (
+        CreateTaskSchema,
+        DeleteTaskSchema,
+        GetTaskSchema,
+        ListTasksSchema,
+        TasksCreateTask,
+        TasksDeleteTask,
+        TasksGetTask,
+        TasksListTasks,
+        TasksToolkit,
+        TasksUpdateTask,
+        UpdateTaskSchema,
+    )
+
+    assert CreateTaskSchema is not None
+    assert DeleteTaskSchema is not None
+    assert GetTaskSchema is not None
+    assert ListTasksSchema is not None
+    assert TasksCreateTask is not None
+    assert TasksDeleteTask is not None
+    assert TasksGetTask is not None
+    assert TasksListTasks is not None
+    assert TasksToolkit is not None
+    assert TasksUpdateTask is not None
+    assert UpdateTaskSchema is not None


### PR DESCRIPTION
This PR adds a comprehensive Google Tasks integration toolkit to langchain-google-community.

## Overview
- Implements TasksToolkit with 5 tools for full CRUD operations on Google Tasks
- Follows existing patterns from Calendar and Gmail integrations
- Fully tested with unit tests (9/9 passing)

## Tools Included
1. **TasksCreateTask** - Create new tasks with title, notes, and due dates
2. **TasksListTasks** - List tasks with filtering options (completed, hidden)
3. **TasksUpdateTask** - Update task properties (title, notes, status, due date)
4. **TasksDeleteTask** - Delete tasks by ID
5. **TasksGetTask** - Retrieve detailed task information

## Testing
- ✅ 9 comprehensive unit tests (all passing)
- ✅ Tested with real Google Tasks API via OAuth
- ✅ All external API calls properly mocked in unit tests
- ✅ No network dependencies in tests