### PR TITLE
feat(genai): add Computer Use tool support for Gemini

### DIFF
--- a/libs/genai/tests/integration_tests/test_builtin_tools.py
+++ b/libs/genai/tests/integration_tests/test_builtin_tools.py
@@ -1,8 +1,9 @@
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
 _MODEL = "gemini-2.5-flash"
+_COMPUTER_USE_MODEL = "gemini-2.5-computer-use-preview-10-2025"
 
 
 def test_url_context_tool() -> None:
@@ -19,3 +20,24 @@ def test_url_context_tool() -> None:
         ]
         is not None
     )
+
+
+def test_computer_use_tool() -> None:
+    """Test computer_use built-in tool (Issue #1243)."""
+    llm = ChatGoogleGenerativeAI(model=_COMPUTER_USE_MODEL)
+    llm_with_cu = llm.bind_tools([{"computer_use": {"environment": "browser"}}])
+
+    response = llm_with_cu.invoke(
+        [HumanMessage(content="Open a web browser and navigate to google.com")]
+    )
+
+    assert isinstance(response, AIMessage)
+    assert len(response.tool_calls) > 0
+    # Common actions: open_web_browser, navigate, click_at, type_text_at
+    assert response.tool_calls[0]["name"] in [
+        "open_web_browser",
+        "navigate",
+        "click_at",
+        "type_text_at",
+        "scroll_document",
+    ]

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -389,6 +389,26 @@ def test_format_tool_to_genai_function() -> None:
     result = convert_to_genai_function_declarations([src_4])
     assert result == src_4
 
+    # Test computer_use built-in tool (Issue #1243)
+    src_5: dict[str, Any] = {"computer_use": {"environment": "browser"}}
+    result = convert_to_genai_function_declarations([src_5])
+    assert result.computer_use is not None
+    assert (
+        result.computer_use.environment
+        == glm.Tool.ComputerUse.Environment.ENVIRONMENT_BROWSER
+    )
+    # Should NOT be treated as a function declaration (was the bug)
+    assert len(result.function_declarations) == 0
+
+    # Test computer_use with default environment
+    src_6: dict[str, Any] = {"computer_use": {}}
+    result = convert_to_genai_function_declarations([src_6])
+    assert result.computer_use is not None
+    assert (
+        result.computer_use.environment
+        == glm.Tool.ComputerUse.Environment.ENVIRONMENT_BROWSER
+    )
+
     with pytest.raises(ValueError) as exc_info1:
         _ = convert_to_genai_function_declarations(["fake_tool"])  # type: ignore
     assert str(exc_info1.value).startswith("Unsupported tool")


### PR DESCRIPTION

## Description

This PR adds support for Gemini's Computer Use model (`gemini-2.5-computer-use-preview-10-2025`) in `langchain-google-genai`. The Computer Use tool enables browser/desktop automation by returning UI actions like clicks, typing, scrolling, and navigation.

Fixes #1243 and #1414

### Problem

When users tried to use the Computer Use model:

```python
llm = ChatGoogleGenerativeAI(model="gemini-2.5-computer-use-preview-10-2025")
response = llm.invoke([HumanMessage(content="Open a browser")])
```

They received:
```
InvalidArgument: 400 This model requires the use of the Computer Use tool
```

Even when trying to pass `{"computer_use": {...}}` via `bind_tools()`, it failed with "Invalid function name" because the dict was incorrectly treated as a function declaration.

### Solution

Added `computer_use` as a recognized built-in tool in `_function_utils.py`, following the same pattern as `google_search`, `code_execution`, and `url_context`.

### Usage

```python
from langchain_google_genai import ChatGoogleGenerativeAI
from langchain_core.messages import HumanMessage

llm = ChatGoogleGenerativeAI(model="gemini-2.5-computer-use-preview-10-2025")
llm_with_cu = llm.bind_tools([{"computer_use": {"environment": "browser"}}])

response = llm_with_cu.invoke([
    HumanMessage(content="Navigate to google.com")
])

# Returns tool_calls with UI actions
for tool_call in response.tool_calls:
    print(f"Action: {tool_call['name']}, Args: {tool_call['args']}")
    # Example: Action: open_web_browser, Args: {}
```

## Relevant issues

Fixes #1243

## Type

🆕 New Feature


## Changes

| File | Description |
|------|-------------|
| `langchain_google_genai/_function_utils.py` | Added `_ComputerUseLike` type, updated `_ToolDict`, added detection + handler |
| `tests/unit_tests/test_function_utils.py` | Added unit tests for `computer_use` dict conversion |
| `tests/integration_tests/test_builtin_tools.py` | Added `test_computer_use_tool()` integration test |

## Testing

- [x] All existing unit tests pass (163 total via `make test`)
- [x] New unit tests for `computer_use` conversion added
- [x] New integration test `test_computer_use_tool` passes
- [x] Lint/format checks pass (`make lint`, `make format`)
- [x] Manual verification with real API confirms fix


## Note(optional)
- Follows the existing built-in tool pattern (`google_search`, `code_execution`, `url_context`)
- No changes needed to `chat_models.py` - existing `bind_tools()` fallback handles routing
- Default environment is `"browser"` if not specified




<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "<type>[optional scope]: <description>"

  - Where type is one of: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, release
  - Scope is used to specifiy the package targeted. Options are: genai, vertex, community, infra (repo-level)

- [x] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [x] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [x] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [x] PR title and description are appropriate
- [x] Necessary tests and documentation have been added
- [x] Lint and tests pass successfully
- [x] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->
