### PR TITLE
fix(genai): don't silently drop thinking config

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2583,8 +2583,6 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         )
         if not has_thinking_params:
             return None
-        if not self._supports_thinking():
-            return None
 
         config: dict[str, Any] = {}
 
@@ -2927,9 +2925,9 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         # Auto-set audio output for TTS models if not explicitly configured
         if response_modalities is None and self.model.endswith("-tts"):
             response_modalities = ["AUDIO"]
-        # Create thinking config if supported
+        # Create thinking config if provided
         thinking_config = None
-        if params.thinking_config is not None and self._supports_thinking():
+        if params.thinking_config is not None:
             thinking_config = ThinkingConfig(
                 include_thoughts=params.thinking_config.include_thoughts,
                 thinking_budget=params.thinking_config.thinking_budget,


### PR DESCRIPTION
Thinking parameters were only sent to the API if the model's profile indicated reasoning_output: True. For models without a profile entry, this caused `include_thoughts`, `thinking_budget`, and `thinking_level` to be silently ignored—even when the model actually supported thinking.

This change removes the profile check, ensuring user-provided thinking config is always forwarded to the API. Unsupported models will now receive proper API errors instead of silent failures.