### PR TITLE
feat(genai): support optional `seed` parameter

### DIFF
--- a/libs/genai/langchain_google_genai/_common.py
+++ b/libs/genai/langchain_google_genai/_common.py
@@ -452,6 +452,18 @@ class _BaseGoogleGenerativeAI(BaseModel):
             ```
     """  # noqa: E501
 
+    seed: int | None = Field(default=None)
+    """Seed used in decoding for reproducible generations.
+
+    By default, a random number is used.
+
+    !!! note
+
+        Using the same seed does not guarantee identical outputs, but makes them more
+        deterministic. Reproducibility is "best effort" based on the model and
+        infrastructure.
+    """
+
     @model_validator(mode="after")
     def _resolve_project_from_credentials(self) -> Self:
         """Extract project from credentials if not explicitly set.

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2564,6 +2564,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             "response_modalities": kwargs.get(
                 "response_modalities", self.response_modalities
             ),
+            "seed": kwargs.get("seed", self.seed),
         }
         thinking_config = self._build_thinking_config(**kwargs)
         if thinking_config is not None:

--- a/libs/genai/langchain_google_genai/llms.py
+++ b/libs/genai/langchain_google_genai/llms.py
@@ -84,6 +84,7 @@ class GoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseLLM):
             base_url=self.base_url,
             additional_headers=self.additional_headers,
             safety_settings=self.safety_settings,
+            seed=self.seed,
         )
 
         return self

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -129,6 +129,25 @@ def test_integration_initialization() -> None:
         assert "Did you mean: 'safety_settings'?" in call_args
 
 
+def test_seed_initialization() -> None:
+    """Test chat model initialization with `seed` parameter."""
+    # Test with explicit seed
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        seed=42,
+    )
+    assert llm.seed == 42
+    assert llm.model == MODEL_NAME
+
+    # Test without seed (should default to None)
+    llm_no_seed = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+    assert llm_no_seed.seed is None
+
+
 def test_safety_settings_initialization() -> None:
     """Test chat model initialization with `safety_settings` parameter."""
     safety_settings: dict[HarmCategory, HarmBlockThreshold] = {


### PR DESCRIPTION
Credit to @Odessit007 for the original implementation.

Adds support for an optional `seed` parameter to `ChatGoogleGenerativeAI` and `GoogleGenerativeAI`, enabling more reproducible generations when desired.

The Google GenAI SDK exposes a `seed` parameter for reproducible generations, but `langchain-google-genai` previously lacked this functionality. This feature allows users to get more deterministic outputs when needed for testing, debugging, or reproducibility requirements.

## Usage

```python
from langchain_google_genai import ChatGoogleGenerativeAI

# With seed for reproducible outputs
llm = ChatGoogleGenerativeAI(
    model="gemini-2.5-flash",
    seed=42,
)

# Without seed (default behavior - random seed each time)
llm = ChatGoogleGenerativeAI(
    model="gemini-2.5-flash",
)
```

> [!NOTE]
> Using the same seed does not guarantee identical outputs, but makes them more deterministic.
> 
> Reproducibility is "best effort" based on the model and infrastructure.

- This revives the changes from PR #1356 which was accidentally closed
