### PR TITLE
fix(genai): respect `max_retries` in classic `GoogleGenerativeAI` LLM

### DIFF
--- a/libs/genai/langchain_google_genai/llms.py
+++ b/libs/genai/langchain_google_genai/llms.py
@@ -79,6 +79,7 @@ class GoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseLLM):
             top_p=self.top_p,
             top_k=self.top_k,
             max_tokens=self.max_output_tokens,
+            max_retries=self.max_retries,
             timeout=self.timeout,
             model=self.model,
             base_url=self.base_url,


### PR DESCRIPTION
Fixes #1445