### PR TITLE
feat(vertexai): Built-in support for `Anthropic's` web search tool in `ChatAnthropicVertex`, eliminating the need for manual header injection.

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/model_garden.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden.py
@@ -495,7 +495,8 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
         """Bind tool-like objects to this chat model."""
         # Check if web_search is in tools
         has_web_search = False
-        processed_tools: list[dict[str, Any] | type[BaseModel] | Callable | BaseTool] = []
+        processed_tools: list[dict[str, Any] | type[BaseModel] | Callable |
+         BaseTool] = []
 
         for tool in tools:
             # Check for string "web_search"

--- a/libs/vertexai/langchain_google_vertexai/model_garden.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden.py
@@ -487,7 +487,7 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
 
     def bind_tools(
         self,
-        tools: Sequence[dict[str, Any] | type[BaseModel] | Callable | BaseTool],
+        tools: Sequence[dict[str, Any] | type[BaseModel] | Callable | BaseTool| str],
         *,
         tool_choice: dict[str, str] | Literal["any", "auto"] | str | None = None,
         **kwargs: Any,
@@ -495,7 +495,7 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
         """Bind tool-like objects to this chat model."""
         # Check if web_search is in tools
         has_web_search = False
-        processed_tools = []
+        processed_tools: list[dict[str, Any] | type[BaseModel] | Callable | BaseTool] = []
 
         for tool in tools:
             # Check for string "web_search"
@@ -509,7 +509,7 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
                 has_web_search = True
                 processed_tools.append(tool)
             else:
-                processed_tools.append(tool)
+                processed_tools.append(tool)  # type: ignore[arg-type]
 
         # Auto-inject the beta header if web_search detected
         if has_web_search:
@@ -519,9 +519,9 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
                 kwargs["additional_headers"]["anthropic-beta"] = "web-search-2025-03-05"
 
             # Use processed_tools instead of tools for formatting
-        tools_to_format = processed_tools if has_web_search else tools
+        tools_to_format = processed_tools if has_web_search else list(tools)
 
-        formatted_tools = []
+        formatted_tools = list[Any] = []
         for tool in tools_to_format:
             if isinstance(tool, dict) and tool.get("type") == "web_search_20250305":
                 formatted_tools.append(tool)

--- a/libs/vertexai/langchain_google_vertexai/model_garden.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden.py
@@ -275,6 +275,12 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
             params["model"] = kwargs["model"]
         if kwargs.get("betas"):
             params["betas"] = kwargs["betas"]
+        if kwargs.get("additional_headers"):
+            merged_headers = {
+                **(self.additional_headers or {}),
+                **kwargs["additional_headers"],
+            }
+            params["extra_headers"] = merged_headers
         params.pop("model_name", None)
         params.update(
             {
@@ -330,10 +336,13 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
 
         @retry_decorator
         def _completion_with_retry_inner(**params: Any) -> Any:
+            extra_headers = params.pop("extra_headers", None)
             has_betas = True if params.get("betas") else False
             if has_betas:
-                return self.client.beta.messages.create(**params)
-            return self.client.messages.create(**params)
+                return self.client.beta.messages.create(
+                    **params, extra_headers=extra_headers
+                )
+            return self.client.messages.create(**params, extra_headers=extra_headers)
 
         data = _completion_with_retry_inner(**params)
         return self._format_output(data, **kwargs)
@@ -360,10 +369,15 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
 
         @retry_decorator
         async def _acompletion_with_retry_inner(**params: Any) -> Any:
+            extra_headers = params.pop("extra_headers", None)
             has_betas = True if params.get("betas") else False
             if has_betas:
-                return await self.async_client.beta.messages.create(**params)
-            return await self.async_client.messages.create(**params)
+                return await self.async_client.beta.messages.create(
+                    **params, extra_headers=extra_headers
+                )
+            return await self.async_client.messages.create(
+                **params, extra_headers=extra_headers
+            )
 
         data = await _acompletion_with_retry_inner(**params)
         return self._format_output(data, **kwargs)
@@ -394,10 +408,15 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
         @retry_decorator
         def _stream_with_retry(**params: Any) -> Any:
             params.pop("stream", None)
+            extra_headers = params.pop("extra_headers", None)
             has_betas = True if params.get("betas") else False
             if has_betas:
-                return self.client.beta.messages.create(**params, stream=True)
-            return self.client.messages.create(**params, stream=True)
+                return self.client.beta.messages.create(
+                    **params, stream=True, extra_headers=extra_headers
+                )
+            return self.client.messages.create(
+                **params, stream=True, extra_headers=extra_headers
+            )
 
         stream = _stream_with_retry(**params)
         coerce_content_to_string = (
@@ -438,12 +457,15 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
         @retry_decorator
         async def _astream_with_retry(**params: Any) -> Any:
             params.pop("stream", None)
+            extra_headers = params.pop("extra_headers", None)
             has_betas = True if params.get("betas") else False
             if has_betas:
                 return await self.async_client.beta.messages.create(
-                    stream=True, **params
+                    stream=True, **params, extra_headers=extra_headers
                 )
-            return await self.async_client.messages.create(**params, stream=True)
+            return await self.async_client.messages.create(
+                **params, stream=True, extra_headers=extra_headers
+            )
 
         stream = await _astream_with_retry(**params)
         coerce_content_to_string = (
@@ -471,7 +493,41 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, AIMessage]:
         """Bind tool-like objects to this chat model."""
-        formatted_tools = [convert_to_anthropic_tool(tool) for tool in tools]
+        # Check if web_search is in tools
+        has_web_search = False
+        processed_tools = []
+
+        for tool in tools:
+            # Check for string "web_search"
+            if isinstance(tool, str) and tool == "web_search":
+                has_web_search = True
+                processed_tools.append(
+                    {"type": "web_search_20250305", "name": "web_search"}
+                )
+            # Check for dict with web_search type
+            elif isinstance(tool, dict) and tool.get("type") == "web_search_20250305":
+                has_web_search = True
+                processed_tools.append(tool)
+            else:
+                processed_tools.append(tool)
+
+        # Auto-inject the beta header if web_search detected
+        if has_web_search:
+            if "additional_headers" not in kwargs:
+                kwargs["additional_headers"] = {}
+            if "anthropic-beta" not in kwargs.get("additional_headers", {}):
+                kwargs["additional_headers"]["anthropic-beta"] = "web-search-2025-03-05"
+
+            # Use processed_tools instead of tools for formatting
+        tools_to_format = processed_tools if has_web_search else tools
+
+        formatted_tools = []
+        for tool in tools_to_format:
+            if isinstance(tool, dict) and tool.get("type") == "web_search_20250305":
+                formatted_tools.append(tool)
+            else:
+                formatted_tools.append(convert_to_anthropic_tool(tool))
+
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "<type>[optional scope]: <description>"

  - Where type is one of: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, release
  - Scope is used to specifiy the package targeted. Options are: genai, vertex, community, infra (repo-level)

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## Description

<!-- e.g. "Implement user authentication feature" -->
Adds built-in support for **Anthropic's** web search tool in `ChatAnthropicVertex`, eliminating the need for manual header injection.

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #1411 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🧹 Refactoring
📖 Documentation
✅ Test

## Changes(optional)

<!-- List of changes -->
- Updated `bind_tools()` to detect `"web_search"` string or web_search dict
- Auto-injects `anthropic-beta: web-search-2025-03-05` header when web_search is used
- Updated `_format_params()` to merge additional_headers from kwargs
- Updated all 4 API methods (`_generate`, `_agenerate`, `_stream`, `_astream`) to pass `extra_headers`

## Usage
```python
llm = ChatAnthropicVertex(model="claude-sonnet-4-5@20250929")
llm_with_search = llm.bind_tools(["web_search"])
```

## Testing(optional)

<!-- Test procedure -->
<!-- Test result -->
Test code used to check implementation:
```
from unittest.mock import patch, MagicMock
from langchain_google_vertexai.model_garden import ChatAnthropicVertex

@patch('anthropic.AnthropicVertex')
@patch('anthropic.AsyncAnthropicVertex')
def test_real_bind_tools(mock_sync, mock_async):
    mock_sync.return_value = MagicMock()
    mock_async.return_value = MagicMock()

    llm = ChatAnthropicVertex(model="claude-sonnet-4-5@20250929", project="test")
    llm_with_search = llm.bind_tools(["web_search"])

    assert llm_with_search.kwargs["tools"][0]["type"] == "web_search_20250305"
    assert llm_with_search.kwargs["additional_headers"]["anthropic-beta"] == "web-search-2025-03-05"
    print("implementation works!")

if __name__ == "__main__":
    test_real_bind_tools()

```
## Note(optional)

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
An additional PR will be opened mentioning a small documentation regarding this update, as the user mentioned , https://github.com/langchain-ai/langchain-google/issues/1411#:~:text=and%20I%20can%E2%80%99t%20find%20clear%20guidance%20in%20the%20docs.%20(the%20only%20docs%20about%20web%20search%20I%20found%20are%20ChatAnthropic()%2C%20ChatVertexAI()) .