### PR TITLE
feat(genai): Add support for FileContentBlock with 'id' field in `ChatGoogleGenerativeAI`

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -228,6 +228,16 @@ def _convert_to_parts(
                             )
                         )
                     )
+                elif part.get("type") == "file" and "id" in part:
+                    # Translation layer: Convert FileContentBlock to media format
+                    # This handles the case where FileContentBlock uses "id" instead of
+                    # "file_id"
+                    mime_type = part.get("mime_type", "application/octet-stream")
+                    parts.append(
+                        Part(
+                            file_data=FileData(file_uri=part["id"], mime_type=mime_type)
+                        )
+                    )
                 elif is_data_content_block(part):
                     # Handle both legacy LC blocks (with `source_type`) and blocks >= v1
 


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "<type>[optional scope]: <description>"

  - Where type is one of: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, release
  - Scope is used to specifiy the package targeted. Options are: genai, vertex, community, infra (repo-level)

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## Description

<!-- e.g. "Implement user authentication feature" -->
This PR adds support for `FileContentBlock` when using the `id` field to specify file location. Previously, only `file_id` was supported, causing a `ValueError` when users passed FileContentBlock with the `id` field.

## Approach Used
Add a translation that changes the  label  file to media in Google connector.
## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #1378
## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes(optional)

<!-- List of changes -->
- Added support for `type="file"` with `id` field in `_convert_to_parts()`
- Maintains backward compatibility with existing `file_id` and `media` formats
- No breaking changes

## Testing(optional)

Tested with the example from the issue:
```python
pdf = FileContentBlock(
    type="file",
    mime_type="application/pdf",
    id="gs://cloud-samples-data/generative-ai/pdf/1706.03762v7.pdf",
)
human_msg = HumanMessage(content_blocks=[pdf, text_block])
response = llm.invoke([human_msg])  
Now works! 
```

**Before:** `ValueError: Unrecognized message part type: file`  
**After:** Successfully processes PDF files with FileContentBlock
<!-- Test procedure -->
<!-- Test result -->

## Note(optional)

<!-- Information about the errors fixed by PR -->
<!-- Remaining issue or something -->
<!-- Other information about PR -->
