### PR TITLE
test(genai): update models used

### DIFF
--- a/libs/genai/tests/integration_tests/test_callbacks.py
+++ b/libs/genai/tests/integration_tests/test_callbacks.py
@@ -7,7 +7,7 @@ from langchain_core.prompts import PromptTemplate
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-MODEL_NAMES = ["gemini-2.5-flash"]
+MODEL_NAMES = ["gemini-3-flash-preview"]
 
 
 class StreamingLLMCallbackHandler(BaseCallbackHandler):

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -46,8 +46,8 @@ from langchain_google_genai import (
     create_context_cache,
 )
 
-_MODEL = "gemini-2.5-flash"
-_PRO_MODEL = "gemini-2.5-flash"
+_MODEL = "gemini-3-flash-preview"
+_PRO_MODEL = "gemini-3-pro-preview"
 _VISION_MODEL = "gemini-2.5-flash"
 _IMAGE_OUTPUT_MODEL = "gemini-2.5-flash-image"
 _IMAGE_EDITING_MODEL = "gemini-3-pro-image-preview"
@@ -1537,6 +1537,7 @@ def _check_web_search_output(message: AIMessage, output_version: str) -> None:
         assert v1_text_block.get("annotations")
 
 
+@pytest.mark.flaky(retries=3, delay=1)
 @pytest.mark.parametrize("output_version", ["v0", "v1"])
 def test_search_builtin(output_version: str, backend_config: dict) -> None:
     llm = ChatGoogleGenerativeAI(

--- a/libs/genai/tests/integration_tests/test_function_call.py
+++ b/libs/genai/tests/integration_tests/test_function_call.py
@@ -11,7 +11,7 @@ from langchain_google_genai.chat_models import (
     ChatGoogleGenerativeAI,
 )
 
-MODEL_NAMES = ["gemini-2.5-flash-lite"]
+MODEL_NAMES = ["gemini-3-flash-preview"]
 
 
 @pytest.mark.parametrize(

--- a/libs/genai/tests/integration_tests/test_llms.py
+++ b/libs/genai/tests/integration_tests/test_llms.py
@@ -10,7 +10,7 @@ from langchain_core.outputs import LLMResult
 
 from langchain_google_genai import GoogleGenerativeAI, HarmBlockThreshold, HarmCategory
 
-MODEL_NAMES = ["gemini-2.5-flash-lite"]
+MODEL_NAMES = ["gemini-3-flash-preview"]
 
 
 @pytest.mark.parametrize(

--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -12,7 +12,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 
 rate_limiter = InMemoryRateLimiter(requests_per_second=0.25)
 
-_FLASH_MODEL = "gemini-2.5-flash"
+_FLASH_MODEL = "gemini-3-flash-preview"
 _PRO_MODEL = "gemini-3-pro-preview"
 
 

--- a/libs/genai/tests/integration_tests/test_structured_output_integration.py
+++ b/libs/genai/tests/integration_tests/test_structured_output_integration.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.skipif(
     not os.getenv("GOOGLE_API_KEY"), reason="GOOGLE_API_KEY not set"
 )
 
-MODEL_NAME = "gemini-2.5-flash"
+MODEL_NAME = "gemini-3-flash-preview"
 
 
 class SimpleResponse(BaseModel):

--- a/libs/genai/tests/integration_tests/test_tools.py
+++ b/libs/genai/tests/integration_tests/test_tools.py
@@ -3,7 +3,7 @@ from langchain_core.tools import tool
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-MODEL = "gemini-2.5-flash-lite"
+MODEL = "gemini-3-flash-preview"
 
 
 @tool


### PR DESCRIPTION
& mark `test_search_builtin` flaky due to upstream nondeterminism