### PR TITLE
fix(genai): Normalize streaming token format for Gemini models

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -3138,7 +3138,26 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 gen = cast("ChatGenerationChunk", _chat_result.generations[0])
                 message = cast("AIMessageChunk", gen.message)
 
-            # Populate index if missing
+                # normalize if instance of list
+                if isinstance(message.content, list):
+                    text_content = "".join(
+                        item.get("text", "")
+                        for item in message.content
+                        if isinstance(item, dict) and item.get("type") == "text"
+                    )
+                    normalized_message = AIMessageChunk(
+                        content=text_content,
+                        additional_kwargs=message.additional_kwargs,
+                        response_metadata=message.response_metadata,
+                        tool_call_chunks=message.tool_call_chunks,
+                        id=message.id,
+                    )
+                    gen = ChatGenerationChunk(
+                        message=normalized_message,
+                        generation_info=gen.generation_info,
+                    )
+
+            # populate index if missing
             if isinstance(message.content, list):
                 for block in message.content:
                     if isinstance(block, dict) and "type" in block:
@@ -3205,6 +3224,25 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             )
             gen = cast("ChatGenerationChunk", _chat_result.generations[0])
             message = cast("AIMessageChunk", gen.message)
+
+            # normalize if instance of list
+            if isinstance(message.content, list):
+                text_content = "".join(
+                    item.get("text", "")
+                    for item in message.content
+                    if isinstance(item, dict) and item.get("type") == "text"
+                )
+                normalized_message = AIMessageChunk(
+                    content=text_content,
+                    additional_kwargs=message.additional_kwargs,
+                    response_metadata=message.response_metadata,
+                    tool_call_chunks=message.tool_call_chunks,
+                    id=message.id,
+                )
+                gen = ChatGenerationChunk(
+                    message=normalized_message,
+                    generation_info=gen.generation_info,
+                )
 
             # populate index if missing
             if isinstance(message.content, list):


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "<type>[optional scope]: <description>"

  - Where type is one of: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, release
  - Scope is used to specifiy the package targeted. Options are: genai, vertex, community, infra (repo-level)

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## Description

This PR fixes an inconsistency in streaming token handling for Gemini models in `langchain-google-genai`.

When using `gemini-3-flash-preview`, the `on_llm_new_token` callback receives a **list of content blocks** instead of a plain string, which breaks the expected callback contract (`token: str`). This differs from the behavior of `gemini-2.5-flash`, where tokens are emitted as strings.

This change normalizes streamed tokens by extracting and concatenating text from content blocks before invoking `on_llm_new_token`, ensuring consistent behavior across Gemini model versions.

## Relevant issues

Fixes #1460 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix


## Changes(optional)

<!-- List of changes -->
- Normalize streamed token payloads to plain strings before invoking `on_llm_new_token`
- Ensure consistent callback behavior across Gemini 2.5 Flash and Gemini 3 Flash Preview

## Example Usuage

<!-- Test procedure -->
<!-- Test result -->
Manually verified streaming behavior for both Gemini 2.5 Flash and Gemini 3 Flash Preview.

```python
from langchain_google_genai import ChatGoogleGenerativeAI
from langchain_core.callbacks import BaseCallbackHandler

class StreamingCallback(BaseCallbackHandler):
    def on_llm_new_token(self, token: str, **kwargs) -> None:
        print(f"Token type: {type(token)}, value: {token}")

llm = ChatGoogleGenerativeAI(
    model="gemini-3-flash-preview",
    streaming=True,
    callbacks=[StreamingCallback()]
)

response = llm.invoke("Hi?")
```

### Output 

```bash
Token type: <class 'str'>, value: Hello! How can I help you today?
Token type: <class 'str'>, value:
Token type: <class 'str'>, value:
```


