### PR TITLE
feat(google): support external URLs and GCS URIs in file_uri (#1504)

### DIFF
--- a/libs/genai/langchain_google_genai/_common.py
+++ b/libs/genai/langchain_google_genai/_common.py
@@ -16,6 +16,11 @@ from langchain_google_genai._enums import (
 _TELEMETRY_TAG = "remote_reasoning_engine"
 _TELEMETRY_ENV_VARIABLE_NAME = "GOOGLE_CLOUD_AGENT_ENGINE_ID"
 
+# Maximum file size (100MB) supported for file_uri (external URLs and registered GCS files)
+# Files up to this size can be passed directly as file_uri without needing base64 encoding
+# or ephemeral uploads
+_MAX_FILE_URI_SIZE_BYTES = 100 * 1024 * 1024  # 100MB
+
 # Cache package version at module import time to avoid blocking I/O in async contexts
 try:
     LC_GOOGLE_GENAI_VERSION = metadata.version("langchain-google-genai")

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3002,6 +3002,74 @@ def test_convert_to_parts_media_missing_data_and_file_uri() -> None:
         _convert_to_parts(content)
 
 
+def test_convert_to_parts_data_content_block_url_as_file_uri() -> None:
+    """Test `_convert_to_parts` with data content block URL passed as file_uri."""
+    content = [
+        {
+            "type": "file",
+            "url": "https://example.com/document.pdf",
+            "mime_type": "application/pdf",
+        }
+    ]
+    result = _convert_to_parts(content)
+    assert len(result) == 1
+    assert result[0].file_data is not None
+    assert result[0].file_data.file_uri == "https://example.com/document.pdf"
+    assert result[0].file_data.mime_type == "application/pdf"
+    assert result[0].inline_data is None
+
+
+def test_convert_to_parts_data_content_block_url_with_signed_url() -> None:
+    """Test `_convert_to_parts` with signed URL passed as file_uri."""
+    signed_url = (
+        "https://storage.googleapis.com/bucket/file.pdf?"
+        "X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test"
+    )
+    content = [
+        {
+            "type": "file",
+            "url": signed_url,
+            "mime_type": "application/pdf",
+        }
+    ]
+    result = _convert_to_parts(content)
+    assert len(result) == 1
+    assert result[0].file_data is not None
+    assert result[0].file_data.file_uri == signed_url
+    assert result[0].file_data.mime_type == "application/pdf"
+    assert result[0].inline_data is None
+
+
+def test_convert_to_parts_data_content_block_url_legacy_source_type() -> None:
+    """Test `_convert_to_parts` with legacy source_type='url' passed as file_uri."""
+    content = [
+        {
+            "type": "file",
+            "source_type": "url",
+            "url": "https://example.com/image.jpg",
+            "mime_type": "image/jpeg",
+        }
+    ]
+    result = _convert_to_parts(content)
+    assert len(result) == 1
+    assert result[0].file_data is not None
+    assert result[0].file_data.file_uri == "https://example.com/image.jpg"
+    assert result[0].file_data.mime_type == "image/jpeg"
+    assert result[0].inline_data is None
+
+
+def test_convert_to_parts_image_url_as_file_uri() -> None:
+    """Test `_convert_to_parts` with image_url URL passed as file_uri."""
+    url = "https://example.com/image.png"
+    content = [{"type": "image_url", "image_url": url}]
+    result = _convert_to_parts(content)
+    assert len(result) == 1
+    assert result[0].file_data is not None
+    assert result[0].file_data.file_uri == url
+    assert result[0].file_data.mime_type == "image/png"
+    assert result[0].inline_data is None
+
+
 def test_convert_to_parts_missing_executable_code_keys() -> None:
     """Test `_convert_to_parts` with missing keys in `executable_code`."""
     content = [


### PR DESCRIPTION
Description
1. Summary This PR adds support for expanded input handling in the Gemini API by enabling external HTTPS URLs and registered Google Cloud Storage (GCS) URIs to be passed directly via the file_uri parameter. By leveraging this native API capability, the integration eliminates the need for local downloads or base64 encoding, which improves request performance and enables support for multimodal inputs up to 100MB.

2. Key Changes I updated the core loading logic to detect external HTTPS URLs and pass them directly as file_uri. This removes the overhead of downloading files locally and provides full support for both public and signed URLs (S3, Azure, or GCS), allowing the Gemini API to fetch the media directly.

To handle large-scale data, I added a register_gcs_files helper in the utils module. This allows users to register GCS files with the Gemini Files API, making it easy to reference persistent cloud storage by URI instead of sending raw data in every request.

The internal handling in ImageBytesLoader and _convert_to_parts now routes these URIs automatically. I included a use_file_uri_for_urls parameter (defaulting to True) so that anyone needing the legacy local-download behavior can still use it, ensuring zero breaking changes for existing workflows across both the genai and vertexai packages.

3. Files Modified libs/genai/langchain_google_genai/_image_utils.py, chat_models.py, utils.py, _common.py, libs/vertexai/langchain_google_vertexai/_image_utils.py, and unit tests in libs/genai/tests/unit_tests/test_image_utils.py and test_chat_models.py.

4. Testing I added unit tests to verify the parsing of public and signed URLs and the new GCS registration flow. I also confirmed that the use_file_uri_for_urls toggle correctly reverts to the legacy encoding path, and all code passed the project's standard linting checks.

Fixes #1504