### PR TITLE
fix(vertexai): default to json_mode for structured output

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -2538,7 +2538,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         schema: dict | type[BaseModel] | type,
         *,
         include_raw: bool = False,
-        method: Literal["json_mode"] | None = None,
+        method: Literal["json_mode"] | None = "json_mode",
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, dict | BaseModel]:
         """Model wrapper that returns outputs formatted to match the given schema.


### PR DESCRIPTION
## Summary
- Changes the default `method` parameter in `ChatVertexAI.with_structured_output()` from `None` to `"json_mode"`
- This only affects calls to `with_structured_output()` when a user provides a schema - normal chat completions are unaffected

## Problem
When using `ChatVertexAI.with_structured_output(schema)` without explicitly setting `method`, the output is always `null`. This happens because:
1. `method=None` defaults to `function_calling` mode
2. `function_calling` uses `JsonOutputKeyToolsParser` which expects responses in tool-call format
3. Gemini returns direct JSON, not tool calls
4. Parser can't find expected structure, returns `null`

## Solution
Change the default from `None` to `"json_mode"`, which uses `JsonOutputParser` that correctly parses Gemini's direct JSON responses.

## When this change applies
- ✅ User calls `model.with_structured_output(schema)` → now defaults to `json_mode`
- ❌ Normal chat completions (`model.invoke()`, `model.stream()`) → no change

## Test plan
- [x] Verified fix works in LangSmith prompt playground with Google Vertex AI provider
- [ ] Unit tests should pass (existing tests may need updating if they rely on the old default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)