### PR TITLE
fix(vertexai): Fix flaky tests for Vertex AI Vector store 2.0 delete tests

### DIFF
--- a/libs/vertexai/tests/integration_tests/test_vectorstores_v2.py
+++ b/libs/vertexai/tests/integration_tests/test_vectorstores_v2.py
@@ -283,7 +283,9 @@ def test_vector_store_v2_delete_by_ids(vector_store_v2: VectorSearchVectorStore)
     # Use large k value to thoroughly check the collection
     results = vector_store_v2.similarity_search("doc", k=100)
     result_ids = [doc.metadata.get("id") for doc in results]
-    assert delete_id not in result_ids, f"Deleted ID {delete_id} should not be in results"
+    assert delete_id not in result_ids, (
+        f"Deleted ID {delete_id} should not be in results"
+    )
 
 
 @pytest.mark.extended


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [x] PR Title: "fix(vertexai): Fix flaky tests for vector store 2.0 delete ids"

- [x] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [x] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [x] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [x] PR title and description are appropriate
- [x] Necessary tests and documentation have been added
- [x] Lint and tests pass successfully
- [x] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## Description

Fixed flaky test `test_vector_store_v2_delete_by_ids` that was failing in CI due to eventual consistency issues with Vertex AI Vector Search 2.0.

The test was failing because the module-scoped `vector_store_v2` fixture is shared across all tests, accumulating many documents. The test was checking if `keep_id` appeared in top 10 results, which was unreliable with a large collection

## Relevant issues

Fixes [test failures](https://github.com/langchain-ai/langchain-google/pull/1519/checks?check_run_id=60590020186) reported by maintainers after merge of previous PR.

## Type

🐛 Bug Fix

## Changes

- Added delay after `add_texts()` to allow indexing to complete
- Added delay after `delete()` to allow deletion to propagate
- Removed unreliable `keep_id` assertion that was causing false failures
- Only verify that `delete_id` is NOT in search results

## Testing

Tested with GCP project with 3 runs passed successfully confirming the fix properly handles eventual consistency.

## Note

The fix addresses eventual consistency in distributed systems by adding appropriate delays. The test now focuses solely on verifying deletion functionality rather than testing unreliable ordering assumptions about newly added documents in a large shared collection.