### PR TITLE
fix(genai): handle missing 'reasoning' key in message parts

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -387,7 +387,7 @@ def _convert_to_parts(
                         thought_sig = base64.b64decode(sig)
                     parts.append(
                         Part(
-                            text=part["reasoning"],
+                            text=part.get("reasoning", ""),
                             thought=True,
                             thought_signature=thought_sig,
                         )


### PR DESCRIPTION
## Description

This PR fixes a `KeyError: 'reasoning'` that occurs when [ChatGoogleGenerativeAI](cci:2://file:///Users/mohankumarsagadevan/Documents/projects/github/langchain-google/libs/genai/langchain_google_genai/chat_models.py:1263:0-3536:78) processes message parts with `type="reasoning"` but no explicit `"reasoning"` key. This situation arises when switching between models (e.g., OpenAI reasoning models) where the reasoning content might be hidden or summarized in the message method, leaving the key absent.

The fix involves safely accessing the `"reasoning"` key using `.get("reasoning", "")` instead of direct dictionary access, ensuring stability even when the content is missing.

## Relevant issues

Fixes [#6691](https://github.com/langchain-ai/langchain/issues/34933)

## Type

Bug Fix

## Changes(optional)

- Modified [_convert_to_parts](cci:1://file:///Users/mohankumarsagadevan/Documents/projects/github/langchain-google/libs/genai/langchain_google_genai/chat_models.py:184:0-484:16) in [libs/genai/langchain_google_genai/chat_models.py](cci:7://file:///Users/mohankumarsagadevan/Documents/projects/github/langchain-google/libs/genai/langchain_google_genai/chat_models.py:0:0-0:0) to use `.get("reasoning", "")` for safer key access.

## Testing(optional)

- **reproduction**: Created an isolated test script simulating a message block `{"type": "reasoning", ...}` without the `"reasoning"` key. Confirmed it crashed before the fix and passed after the fix.
- **unit tests**: Ran `make test` in `libs/genai`. Passed 251 tests with 0 failures, confirming no regressions.
- **linting**: Ran `make lint` in `libs/genai`. All checks passed.