### PR TITLE
feat(genai): add support for type: "video" as alias for "media"

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -315,8 +315,10 @@ def _convert_to_parts(
                     if thought_sig:
                         image_part.thought_signature = thought_sig
                     parts.append(image_part)
-                elif part["type"] == "media":
-                    # Handle `media` following pattern established in LangChain.js
+                elif part["type"] in ("media", "video"):
+                    # Handle `media` and `video` types
+                    # `video` is supported as an alias for `media` for convenience
+                    # Following pattern established in LangChain.js
                     # https://github.com/langchain-ai/langchainjs/blob/e536593e2585f1dd7b0afc187de4d07cb40689ba/libs/langchain-google-common/src/utils/gemini.ts#L93-L106
                     if "mime_type" not in part:
                         msg = f"Missing mime_type in media part: {part}"
@@ -329,10 +331,12 @@ def _convert_to_parts(
                         media_part_kwargs["inline_data"] = Blob(
                             data=part["data"], mime_type=mime_type
                         )
-                    elif "file_uri" in part:
+                    elif "file_uri" in part or "url" in part:
                         # Referenced files (e.g. stored in GCS)
+                        # `url` is supported as an alias for `file_uri`
+                        file_uri = part.get("file_uri") or part.get("url")
                         media_part_kwargs["file_data"] = FileData(
-                            file_uri=part["file_uri"], mime_type=mime_type
+                            file_uri=file_uri, mime_type=mime_type
                         )
                     else:
                         msg = f"Media part must have either data or file_uri: {part}"

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -2848,6 +2848,38 @@ def test_convert_to_parts_media_with_file_uri() -> None:
     assert result[0].file_data.file_uri == "gs://bucket/file.pdf"
 
 
+def test_convert_to_parts_video_type_alias() -> None:
+    """Test `_convert_to_parts` with video type as alias for media."""
+    content = [
+        {
+            "type": "video",
+            "mime_type": "video/mp4",
+            "file_uri": "gs://bucket/video.mp4",
+        }
+    ]
+    result = _convert_to_parts(content)
+    assert len(result) == 1
+    assert result[0].file_data is not None
+    assert result[0].file_data.mime_type == "video/mp4"
+    assert result[0].file_data.file_uri == "gs://bucket/video.mp4"
+
+
+def test_convert_to_parts_media_with_url_alias() -> None:
+    """Test `_convert_to_parts` with url as alias for file_uri."""
+    content = [
+        {
+            "type": "media",
+            "mime_type": "video/mp4",
+            "url": "gs://bucket/video.mp4",
+        }
+    ]
+    result = _convert_to_parts(content)
+    assert len(result) == 1
+    assert result[0].file_data is not None
+    assert result[0].file_data.mime_type == "video/mp4"
+    assert result[0].file_data.file_uri == "gs://bucket/video.mp4"
+
+
 def test_convert_to_parts_media_with_video_metadata() -> None:
     """Test `_convert_to_parts` with media type containing video metadata."""
     content = [

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -990,6 +990,46 @@ def test_parse_chat_history_gemini_without_literal_eval() -> None:
     assert expected == response
 
 
+def test_parse_chat_history_gemini_video_type_alias() -> None:
+    """Test that video type is accepted as alias for media."""
+    content = [
+        {
+            "type": "video",
+            "mime_type": "video/mp4",
+            "file_uri": "gs://bucket/video.mp4",
+        }
+    ]
+    history: list[BaseMessage] = [HumanMessage(content=content)]  # type: ignore[arg-type]
+    image_bytes_loader = ImageBytesLoader()
+    _, response = _parse_chat_history_gemini(
+        history=history,
+        imageBytesLoader=image_bytes_loader,
+    )
+    assert len(response) == 1
+    assert response[0].parts[0].file_data.file_uri == "gs://bucket/video.mp4"
+    assert response[0].parts[0].file_data.mime_type == "video/mp4"
+
+
+def test_parse_chat_history_gemini_url_alias() -> None:
+    """Test that url is accepted as alias for file_uri."""
+    content = [
+        {
+            "type": "media",
+            "mime_type": "video/mp4",
+            "url": "gs://bucket/video.mp4",
+        }
+    ]
+    history: list[BaseMessage] = [HumanMessage(content=content)]  # type: ignore[arg-type]
+    image_bytes_loader = ImageBytesLoader()
+    _, response = _parse_chat_history_gemini(
+        history=history,
+        imageBytesLoader=image_bytes_loader,
+    )
+    assert len(response) == 1
+    assert response[0].parts[0].file_data.file_uri == "gs://bucket/video.mp4"
+    assert response[0].parts[0].file_data.mime_type == "video/mp4"
+
+
 def test_python_literal_inputs() -> None:
     """In relation to literal eval, ensure that inputs are not misinterpreted."""
     llm = ChatVertexAI(model="gemini-2.5-flash", project="test-project")


### PR DESCRIPTION
## Summary

- Add "video" as an accepted content type alias for "media" in multimodal message handling
- Add "url" as an accepted field alias for "file_uri" in media parts
- Provides a more intuitive API and aligns with documentation examples

Issues: #1536

## Changes

| Before | After |
|--------|-------|
| `type: "media"` only | `type: "media"` or `type: "video"` |
| `file_uri` only | `file_uri` or `url` |

## Test plan

- [ ] Verify `type: "video"` works the same as `type: "media"`
- [ ] Verify `url` works the same as `file_uri`
- [ ] Verify existing usage still works
- [ ] Run unit tests