### PR TITLE
fix(genai): Number of attempts should be one more than retries

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2983,7 +2983,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
         retry_options = None
         if max_retries is not None:
-            retry_options = HttpRetryOptions(attempts=max_retries)
+            retry_options = HttpRetryOptions(attempts=1 + max_retries)
 
         http_options = None
         if timeout is not None or retry_options is not None:


### PR DESCRIPTION
## Description

Google genai library doesn't take a "retry count", instead takes an "attempt count", which, by definition is one extra.

I was running this example code:

```python
async def main():
    model = ChatGoogleGenerativeAI(
        model=LLMModel.GEMINI_3_PRO_PREVIEW,
        max_retries=0,
        timeout=10,
    )

    response = await model.ainvoke(
        [
            SystemMessage(system_prompt),
            HumanMessage(user_prompt),
        ]
    )


if __name__ == "__main__":
    asyncio.run(main())
```

With `HTTPS_PROXY` set to point to a local mitmproxy. That mitmproxy has a plugin script with the following code in it:

```python
import json

from mitmproxy.http import HTTPFlow, Response


def requestheaders(flow: HTTPFlow):
    flow.response = Response.make(
        status_code=504,
        content=json.dumps(
            {
                "error": {
                    "code": 504,
                    "message": "Deadline expired before operation could complete.",
                    "status": "DEADLINE_EXCEEDED",
                }
            }
        ),
        headers={
            "content-type": "application/json",
        },
    )
```

This is so requests fail, and we see multiple attempts. Now if we run mitmproxy and the above example script, we see 5 calls made to genai API. Whereas the `max_retries=0` indicates that exactly one call should be made.

But if we set `max_retries=1`, we see exactly one call made.

The reason setting it to `0` does that is because of this line:

https://github.com/googleapis/python-genai/blob/e15ad6457c615f1294875115854f929bc804aba5/google/genai/_api_client.py#L484

Here, instead of checking if `attempts is None` before using the default value, we just do an `or`, so setting it to `0` gets the default to be used, which is 5.

This way `max_retries` has the same meaning as it does in other libraries like `langchain-anthropic` etc.

This PR fixes this problem by setting `attempts` to _one_ more than the `max_retries` value.

⚠️ This correction does mean it won't be backwards compatible though.

Thank you for your time.

## Type

🐛 Bug Fix
