### PR TITLE
fix: correctly retry 429 errors that arrive as SSE chunk bodies in _astream

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -3202,39 +3202,63 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         prev_usage_metadata: UsageMetadata | None = None  # Cumulative usage
         index = -1
         index_type = ""
-        try:
-            stream = await self.client.aio.models.generate_content_stream(
-                **request,
-            )
-        except ClientError as e:
-            _handle_client_error(e, request)
 
-        async for chunk in stream:
-            _chat_result = _response_to_result(
-                chunk, stream=True, prev_usage=prev_usage_metadata
-            )
-            gen = cast("ChatGenerationChunk", _chat_result.generations[0])
-            message = cast("AIMessageChunk", gen.message)
+        _retriable_codes = {429, 500, 502, 503, 504}
+        _max_retries = self.max_retries if self.max_retries is not None else 0
+        _attempt = 0
 
-            # populate index if missing
-            if isinstance(message.content, list):
-                for block in message.content:
-                    if isinstance(block, dict) and "type" in block:
-                        if block["type"] != index_type:
-                            index_type = block["type"]
-                            index = index + 1
-                        if "index" not in block:
-                            block["index"] = index
+        while _attempt <= _max_retries:
+            _chunks_yielded = False
+            try:
+                stream = await self.client.aio.models.generate_content_stream(
+                    **request,
+                )
+            except ClientError as e:
+                _handle_client_error(e, request)
 
-            prev_usage_metadata = (
-                message.usage_metadata
-                if prev_usage_metadata is None
-                else add_usage(prev_usage_metadata, message.usage_metadata)
-            )
+            try:
+                async for chunk in stream:
+                    _chat_result = _response_to_result(
+                        chunk, stream=True, prev_usage=prev_usage_metadata
+                    )
+                    gen = cast("ChatGenerationChunk", _chat_result.generations[0])
+                    message = cast("AIMessageChunk", gen.message)
 
-            if run_manager:
-                await run_manager.on_llm_new_token(gen.text, chunk=gen)
-            yield gen
+                    # populate index if missing
+                    if isinstance(message.content, list):
+                        for block in message.content:
+                            if isinstance(block, dict) and "type" in block:
+                                if block["type"] != index_type:
+                                    index_type = block["type"]
+                                    index = index + 1
+                                if "index" not in block:
+                                    block["index"] = index
+
+                    prev_usage_metadata = (
+                        message.usage_metadata
+                        if prev_usage_metadata is None
+                        else add_usage(prev_usage_metadata, message.usage_metadata)
+                    )
+
+                    if run_manager:
+                        await run_manager.on_llm_new_token(gen.text, chunk=gen)
+                    _chunks_yielded = True
+                    yield gen
+                break  # Completed successfully
+            except ClientError as e:
+                if (
+                    _chunks_yielded
+                    or _attempt >= _max_retries
+                    or getattr(e, "code", None) not in _retriable_codes
+                ):
+                    raise
+                _attempt += 1
+                _wait = min(2**_attempt, 32)
+                logger.warning(
+                    f"Retrying stream after ClientError (code={getattr(e, 'code', '?')}), "
+                    f"attempt {_attempt}/{_max_retries}, wait={_wait}s"
+                )
+                await asyncio.sleep(_wait)
 
     def get_num_tokens(self, text: str) -> int:
         """Get the number of tokens present in the text. Uses the model's tokenizer.

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -3255,7 +3255,8 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 _attempt += 1
                 _wait = min(2**_attempt, 32)
                 logger.warning(
-                    f"Retrying stream after ClientError (code={getattr(e, 'code', '?')}), "
+                    "Retrying stream after ClientError "
+                    f"(code={getattr(e, 'code', '?')}), "
                     f"attempt {_attempt}/{_max_retries}, wait={_wait}s"
                 )
                 await asyncio.sleep(_wait)


### PR DESCRIPTION
PR Title
fix[genai]: correctly retry 429 errors that arrive as SSE chunk bodies in _astream

PR Description
ChatGoogleGenerativeAI._astream has max_retries support, but it only works for 429s that arrive as an HTTP-level rejection (status 429 before the stream opens). When the 429 arrives inside a streaming chunk body, it is never retried.

This happens because the SDK's tenacity retry scope wraps the function that makes the raw HTTP call (_async_request_once). Once the stream object is returned (HTTP 200 handshake), tenacity considers the call successful and exits the retry scope. However, Vertex AI can return a 429 rate limit mid-stream as a chunk body. This 429 is currently raised inside the async for chunk in stream: loop, completely outside any retry context, and propagates straight to the caller.

This PR fixes this by wrapping the stream creation and the async for loop in a manual while _attempt <= _max_retries: retry loop. The inner try/except ClientError catches 429s that arrive as chunk bodies and retries them with an exponential backoff.

Relevant issues:

N/A

Type
🐛 Bug Fix

Changes
Wrapped the stream generation and iteration logic inside ChatGoogleGenerativeAI._astream into a while loop.
Added state-tracking (_chunks_yielded) to ensure chunk generation immediately aborts and re-raises to prevent duplicating tokens if we've already yielded previous chunks.
Added exponential backoff 

min(2**_attempt, 32)
 for transient error codes (429, 500, 502, 503, 504) utilizing asyncio.sleep().
Formatted the warning log using f-strings for continuity.

Testing
Hammer the endpoint with concurrent requests using an asyncio.gather() benchmarking script to forcibly trigger rate limits (429 RESOURCE_EXHAUSTED errors). Then sometimes you will see the langchain warning of retrying but most of the time you wont see it. With the new logic you always retry correctly and not miss a single time.

Test result: I went from 78% successfull streams to 100% with 2 retries enables