### PR TITLE
fix(genai): preserve dict field type in nested tool schemas

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -578,9 +578,7 @@ def _get_properties_from_schema(schema: dict) -> dict[str, Any]:
                 # Preserve additionalProperties flag so that subsequent schema
                 # processing passes don't lose it and incorrectly downgrade
                 # dict-typed fields to STRING.
-                properties_item["additionalProperties"] = v[
-                    "additionalProperties"
-                ]
+                properties_item["additionalProperties"] = v["additionalProperties"]
             else:
                 # Only provide dummy type for object without properties AND
                 # without additionalProperties

--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -574,9 +574,16 @@ def _get_properties_from_schema(schema: dict) -> dict[str, Any]:
                     properties_item["required"] = [
                         k for k, v in v_properties.items() if "default" not in v
                     ]
-            elif not v.get("additionalProperties"):
-                # Only provide dummy type for object without properties AND without
-                # additionalProperties
+            elif v.get("additionalProperties"):
+                # Preserve additionalProperties flag so that subsequent schema
+                # processing passes don't lose it and incorrectly downgrade
+                # dict-typed fields to STRING.
+                properties_item["additionalProperties"] = v[
+                    "additionalProperties"
+                ]
+            else:
+                # Only provide dummy type for object without properties AND
+                # without additionalProperties
                 properties_item["type"] = types.Type.STRING
 
         if k == "title" and "description" not in properties_item:

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -1327,7 +1327,7 @@ def test_nested_dict_field_preserves_object_type() -> None:
     class Plan(BaseModel):
         steps: list[Step] = Field(description="List of steps")
 
-    @tool  # type: ignore[misc]
+    @tool
     def create_plan(plan: Plan) -> str:
         """Create a plan."""
         return "ok"
@@ -1335,9 +1335,11 @@ def test_nested_dict_field_preserves_object_type() -> None:
     fd = _format_base_tool_to_function_declaration(create_plan)
 
     assert fd.parameters is not None
+    assert fd.parameters.properties is not None
     plan_prop = fd.parameters.properties["plan"]
     assert plan_prop.type == Type.OBJECT
 
+    assert plan_prop.properties is not None
     steps_prop = plan_prop.properties["steps"]
     assert steps_prop.type == Type.ARRAY
     assert steps_prop.items is not None

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -1316,6 +1316,44 @@ def test_optional_dict_schema_validation() -> None:
     )
 
 
+def test_nested_dict_field_preserves_object_type() -> None:
+    """Test that nested dict fields retain OBJECT type instead of being
+    downgraded to STRING. Regression test for issue #1622."""
+
+    class Step(BaseModel):
+        name: str = Field(description="Step name")
+        config: dict = Field(default={}, description="Arbitrary config dict")
+
+    class Plan(BaseModel):
+        steps: list[Step] = Field(description="List of steps")
+
+    @tool  # type: ignore[misc]
+    def create_plan(plan: Plan) -> str:
+        """Create a plan."""
+        return "ok"
+
+    fd = _format_base_tool_to_function_declaration(create_plan)
+
+    assert fd.parameters is not None
+    plan_prop = fd.parameters.properties["plan"]
+    assert plan_prop.type == Type.OBJECT
+
+    steps_prop = plan_prop.properties["steps"]
+    assert steps_prop.type == Type.ARRAY
+    assert steps_prop.items is not None
+
+    step_items = steps_prop.items
+    assert step_items.type == Type.OBJECT
+    assert step_items.properties is not None
+
+    config_prop = step_items.properties["config"]
+    assert config_prop.type == Type.OBJECT, (
+        f"Nested dict field should have OBJECT type, got {config_prop.type}. "
+        "See https://github.com/langchain-ai/langchain-google/issues/1622"
+    )
+    assert config_prop.description == "Arbitrary config dict"
+
+
 def test_tool_field_enum_array() -> None:
     class ToolInfo(BaseModel):
         kind: list[Literal["foo", "bar"]]


### PR DESCRIPTION
## Bug

Nested `dict` fields in tool schemas are silently converted from `OBJECT` to `STRING` type when the field appears inside a nested model (e.g., `list[Step]` where `Step` has a `dict` field). This causes Gemini to send JSON strings instead of objects, breaking Pydantic validation.

Fixes #1622

## Root Cause

`_get_properties_from_schema` did not preserve the `additionalProperties` flag in its output. When the schema was processed a second time through `_format_json_schema_to_gapic` (via `_dict_to_genai_schema`'s recursive calls), the flag was lost. Without it, the OBJECT→STRING downgrade logic incorrectly triggered for `dict`-typed fields that have no explicit properties.

## Fix

When an OBJECT-typed field has `additionalProperties` set but no explicit `properties`, carry the flag forward in the output dict so subsequent processing passes retain the correct type.

## Test

Added `test_nested_dict_field_preserves_object_type` that verifies `dict` fields nested inside `list[Model]` retain `Type.OBJECT`.

All 28 existing unit tests pass.