### PR TITLE
fix(genai): propagate request timeout to media fetches

### DIFF
--- a/libs/genai/langchain_google_genai/_image_utils.py
+++ b/libs/genai/langchain_google_genai/_image_utils.py
@@ -50,6 +50,14 @@ class ImageBytesLoader:
         references
     """
 
+    def __init__(self, timeout: float | None = None) -> None:
+        """Initialize the loader.
+
+        Args:
+            timeout: Timeout in seconds for HTTP/HTTPS media fetches.
+        """
+        self.timeout = timeout
+
     def load_bytes(self, image_string: str) -> bytes:
         """Routes to the correct loader based on the `'image_string'`.
 
@@ -213,7 +221,10 @@ class ImageBytesLoader:
         Returns:
             Media bytes (images, PDFs, audio, video, etc.).
         """
-        response = requests.get(url)
+        if self.timeout is None:
+            response = requests.get(url)
+        else:
+            response = requests.get(url, timeout=self.timeout)
 
         if not response.ok:
             response.raise_for_status()

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -185,6 +185,7 @@ def _is_gemini_25_model(model_name: str) -> bool:
 def _convert_to_parts(
     raw_content: str | Sequence[str | dict],
     model: str | None = None,
+    media_fetch_timeout: float | None = None,
 ) -> list[Part]:
     """Converts LangChain message content into `generativelanguage_v1beta` parts.
 
@@ -194,7 +195,7 @@ def _convert_to_parts(
     objects.
     """
     content = [raw_content] if isinstance(raw_content, str) else raw_content
-    image_loader = ImageBytesLoader()
+    image_loader = ImageBytesLoader(timeout=media_fetch_timeout)
 
     parts = []
     # Iterate over each item in the content list, constructing a list of Parts
@@ -489,6 +490,7 @@ def _convert_tool_message_to_parts(
     message: ToolMessage | FunctionMessage,
     name: str | None = None,
     model: str | None = None,
+    media_fetch_timeout: float | None = None,
 ) -> list[Part]:
     """Converts a tool or function message to a Google `Part`."""
     # Legacy agent stores tool name in message.additional_kwargs instead of message.name
@@ -505,7 +507,13 @@ def _convert_tool_message_to_parts(
                 media_blocks.append(block)
             else:
                 other_blocks.append(block)
-        parts.extend(_convert_to_parts(media_blocks, model=model))
+        parts.extend(
+            _convert_to_parts(
+                media_blocks,
+                model=model,
+                media_fetch_timeout=media_fetch_timeout,
+            )
+        )
         response = other_blocks
 
     elif not isinstance(message.content, str):
@@ -531,6 +539,7 @@ def _get_ai_message_tool_messages_parts(
     tool_messages: Sequence[ToolMessage],
     ai_message: AIMessage,
     model: str | None = None,
+    media_fetch_timeout: float | None = None,
 ) -> list[Part]:
     """Conversion.
 
@@ -546,7 +555,10 @@ def _get_ai_message_tool_messages_parts(
         if message.tool_call_id in tool_calls_ids:
             tool_call = tool_calls_ids[message.tool_call_id]
             message_parts = _convert_tool_message_to_parts(
-                message, name=tool_call.get("name"), model=model
+                message,
+                name=tool_call.get("name"),
+                model=model,
+                media_fetch_timeout=media_fetch_timeout,
             )
             parts.extend(message_parts)
             # remove the id from the dict, so that we do not iterate over it again
@@ -582,6 +594,7 @@ def _parse_chat_history(
     input_messages: Sequence[BaseMessage],
     convert_system_message_to_human: bool = False,
     model: str | None = None,
+    media_fetch_timeout: float | None = None,
 ) -> tuple[Content | None, list[Content]]:
     """Parses sequence of `BaseMessage` into system instruction and formatted messages.
 
@@ -639,7 +652,11 @@ def _parse_chat_history(
     ]
     for i, message in enumerate(messages_without_tool_messages):
         if isinstance(message, SystemMessage):
-            system_parts = _convert_to_parts(message.content, model=model)
+            system_parts = _convert_to_parts(
+                message.content,
+                model=model,
+                media_fetch_timeout=media_fetch_timeout,
+            )
             if i == 0:
                 system_instruction = Content(parts=system_parts)
             elif system_instruction is not None:
@@ -713,7 +730,10 @@ def _parse_chat_history(
                     else:
                         ai_message_parts.append(Part(function_call=function_call))
                 tool_messages_parts = _get_ai_message_tool_messages_parts(
-                    tool_messages=tool_messages, ai_message=message, model=model
+                    tool_messages=tool_messages,
+                    ai_message=message,
+                    model=model,
+                    media_fetch_timeout=media_fetch_timeout,
                 )
                 formatted_messages.append(Content(role=role, parts=ai_message_parts))
                 # Only append tool response message if there are actual tool responses.
@@ -737,16 +757,28 @@ def _parse_chat_history(
                 parts = message.content  # type: ignore[assignment]
             else:
                 # Prepare request content parts from message.content field
-                parts = _convert_to_parts(message.content, model=model)
+                parts = _convert_to_parts(
+                    message.content,
+                    model=model,
+                    media_fetch_timeout=media_fetch_timeout,
+                )
         elif isinstance(message, HumanMessage):
             role = "user"
-            parts = _convert_to_parts(message.content, model=model)
+            parts = _convert_to_parts(
+                message.content,
+                model=model,
+                media_fetch_timeout=media_fetch_timeout,
+            )
             if i == 1 and convert_system_message_to_human and system_instruction:
                 parts = list(system_instruction.parts or []) + parts
                 system_instruction = None
         elif isinstance(message, FunctionMessage):
             role = "user"
-            parts = _convert_tool_message_to_parts(message, model=model)
+            parts = _convert_tool_message_to_parts(
+                message,
+                model=model,
+                media_fetch_timeout=media_fetch_timeout,
+            )
         else:
             msg = f"Unexpected message with type {type(message)} at the position {i}."
             raise ValueError(msg)
@@ -2741,6 +2773,10 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Prepare the request configuration for the API call."""
+        timeout_seconds = kwargs.pop("timeout", None)
+        if timeout_seconds is None:
+            timeout_seconds = self.timeout
+
         # Process tools and functions
         formatted_tools = self._format_tools(tools, functions)
 
@@ -2752,6 +2788,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             filtered_messages,
             convert_system_message_to_human=self.convert_system_message_to_human,
             model=self.model,
+            media_fetch_timeout=timeout_seconds,
         )
 
         # Process tool configuration
@@ -2764,11 +2801,9 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             safety_settings if safety_settings is not None else self.safety_settings
         )
 
-        timeout = kwargs.pop("timeout", None)
-        if timeout is not None:
-            timeout = int(timeout * 1000)
-        elif self.timeout is not None:
-            timeout = int(self.timeout * 1000)
+        timeout = None
+        if timeout_seconds is not None:
+            timeout = int(timeout_seconds * 1000)
 
         max_retries = kwargs.pop("max_retries", None)
         if max_retries is None:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -1320,6 +1320,64 @@ def test_timeout_streaming_parameter_handling(
 
 
 @pytest.mark.parametrize(
+    "instance_timeout,call_timeout,expected_timeout",
+    [
+        (5.0, None, 5.0),
+        (5.0, 1.5, 1.5),
+        (None, None, None),
+    ],
+)
+def test_prepare_request_passes_timeout_to_media_loader(
+    instance_timeout: float | None,
+    call_timeout: float | None,
+    expected_timeout: float | None,
+) -> None:
+    """Test that request timeout is propagated to remote media fetches."""
+    llm_kwargs: dict[str, Any] = {
+        "model": MODEL_NAME,
+        "google_api_key": SecretStr(FAKE_API_KEY),
+    }
+    if instance_timeout is not None:
+        llm_kwargs["timeout"] = instance_timeout
+
+    llm = ChatGoogleGenerativeAI(**llm_kwargs)
+    messages: list[BaseMessage] = [
+        HumanMessage(
+            content=[
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.png"},
+                }
+            ]
+        )
+    ]
+    mock_loader_instance = Mock()
+    mock_loader_instance.load_part.return_value = Part(
+        inline_data=Blob(data=b"fake-image-data", mime_type="image/png")
+    )
+
+    call_kwargs: dict[str, Any] = {}
+    if call_timeout is not None:
+        call_kwargs["timeout"] = call_timeout
+
+    with patch("langchain_google_genai.chat_models.ImageBytesLoader") as mock_loader:
+        mock_loader.return_value = mock_loader_instance
+        request = llm._prepare_request(messages, **call_kwargs)
+
+    mock_loader.assert_called_once_with(timeout=expected_timeout)
+    mock_loader_instance.load_part.assert_called_once_with(
+        "https://example.com/image.png"
+    )
+
+    config = request["config"]
+    if expected_timeout is not None:
+        assert config.http_options is not None
+        assert config.http_options.timeout == int(expected_timeout * 1000)
+    else:
+        assert config.http_options is None or config.http_options.timeout is None
+
+
+@pytest.mark.parametrize(
     "instance_max_retries,call_max_retries,expected_max_retries,should_have_max_retries",
     [
         (1, None, 1, True),  # Instance-level max_retries
@@ -3197,6 +3255,38 @@ def test_convert_tool_message_to_parts_list_content_with_media() -> None:
     # Second part should be the function response
     assert result[1].function_response is not None
     assert result[1].function_response.name == "test_tool"
+    assert result[1].function_response.response == {"output": ["Text response"]}
+
+
+def test_convert_tool_message_to_parts_list_content_with_media_timeout() -> None:
+    """Test `_convert_tool_message_to_parts` passes timeouts to media loading."""
+    message = ToolMessage(
+        name="test_tool",
+        content=[
+            "Text response",
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.png"},
+            },
+        ],
+        tool_call_id="123",
+    )
+    mock_loader_instance = Mock()
+    mock_loader_instance.load_part.return_value = Part(
+        inline_data=Blob(data=b"fake_image_data", mime_type="image/png")
+    )
+
+    with patch("langchain_google_genai.chat_models.ImageBytesLoader") as mock_loader:
+        mock_loader.return_value = mock_loader_instance
+        result = _convert_tool_message_to_parts(message, media_fetch_timeout=3.0)
+
+    mock_loader.assert_called_once_with(timeout=3.0)
+    mock_loader_instance.load_part.assert_called_once_with(
+        "https://example.com/image.png"
+    )
+    assert len(result) == 2
+    assert result[0].inline_data is not None
+    assert result[1].function_response is not None
     assert result[1].function_response.response == {"output": ["Text response"]}
 
 

--- a/libs/genai/tests/unit_tests/test_image_utils.py
+++ b/libs/genai/tests/unit_tests/test_image_utils.py
@@ -1,5 +1,7 @@
 """Tests for the _image_utils module."""
 
+from unittest.mock import Mock, patch
+
 import pytest
 
 from langchain_google_genai._image_utils import ImageBytesLoader, Route
@@ -82,3 +84,30 @@ class TestImageBytesLoader:
         assert part.inline_data is not None
         assert part.inline_data.mime_type == "image/png"
         assert part.file_data is None
+
+    def test_bytes_from_url_uses_configured_timeout(self) -> None:
+        """Test that HTTP media fetches honor the loader timeout."""
+        loader = ImageBytesLoader(timeout=5.0)
+        response = Mock(ok=True, content=b"image-bytes")
+
+        with patch(
+            "langchain_google_genai._image_utils.requests.get",
+            return_value=response,
+        ) as mock_get:
+            result = loader._bytes_from_url("https://example.com/image.png")
+
+        assert result == b"image-bytes"
+        mock_get.assert_called_once_with("https://example.com/image.png", timeout=5.0)
+
+    def test_bytes_from_url_without_timeout_uses_requests_default(self) -> None:
+        """Test that HTTP media fetches preserve the requests default timeout."""
+        response = Mock(ok=True, content=b"image-bytes")
+
+        with patch(
+            "langchain_google_genai._image_utils.requests.get",
+            return_value=response,
+        ) as mock_get:
+            result = self.loader._bytes_from_url("https://example.com/image.png")
+
+        assert result == b"image-bytes"
+        mock_get.assert_called_once_with("https://example.com/image.png")


### PR DESCRIPTION
## Description

Propagate `ChatGoogleGenerativeAI` request timeouts to remote HTTP/HTTPS media fetches during request preparation.

This adds an optional timeout to `ImageBytesLoader` and threads it through the message-to-parts conversion path, so `timeout=` passed at instance level or per call is also used for remote `image_url` fetching. It also adds unit tests covering timeout propagation to the loader and `requests.get(...)`.

## Relevant issues

Fixes #1692

## Type

🐛 Bug Fix
✅ Test

## Changes(optional)

- Added an optional `timeout` parameter to `ImageBytesLoader`
- Used that timeout in `_bytes_from_url()` when calling `requests.get(...)`
- Threaded `media_fetch_timeout` through `_convert_to_parts`, `_convert_tool_message_to_parts`, `_get_ai_message_tool_messages_parts`, `_parse_chat_history`, and `ChatGoogleGenerativeAI._prepare_request`
- Updated `_prepare_request()` to derive a single `timeout_seconds` value and use it for both media fetch and request config
- Added unit tests for loader-level timeout handling and request-timeout propagation

## Testing(optional)

Ran:

- `uv run --group test pytest tests/unit_tests/test_image_utils.py tests/unit_tests/test_chat_models.py`
- `uv run --group lint ruff check langchain_google_genai/_image_utils.py langchain_google_genai/chat_models.py tests/unit_tests/test_image_utils.py tests/unit_tests/test_chat_models.py`
- `uv run --group typing mypy langchain_google_genai/_image_utils.py langchain_google_genai/chat_models.py`

## Note(optional)

This PR only addresses timeout propagation for remote media fetches. It does not change the current blocking/synchronous fetch behavior.
