### PR TITLE
fix(genai): preserve AIMessage.content when tool_calls are present (#1706)

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -676,12 +676,18 @@ def _parse_chat_history(
             if message.tool_calls:
                 ai_message_parts = []
 
+                # Preserve non-empty textual content even when tool calls are present.
+                if isinstance(message.content, str) and message.content:
+                    ai_message_parts.append(Part(text=message.content))
+
                 # First, include thinking blocks from content if present.
                 # When include_thoughts=True, thinking blocks need to be preserved
                 # when passing messages back to the API.
                 if isinstance(message.content, list):
                     for content_block in message.content:
-                        if isinstance(content_block, dict):
+                        if isinstance(content_block, str) and content_block:
+                            ai_message_parts.append(Part(text=content_block))
+                        elif isinstance(content_block, dict):
                             block_type = content_block.get("type")
                             if block_type == "thinking":
                                 # v0 output_format thinking block
@@ -711,6 +717,12 @@ def _parse_chat_history(
                                         thought=True,
                                         thought_signature=thought_sig,
                                     )
+                                )
+                            elif block_type == "text" and isinstance(
+                                content_block.get("text"), str
+                            ):
+                                ai_message_parts.append(
+                                    Part(text=content_block["text"])
                                 )
 
                 # Then, add function call parts

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -431,6 +431,61 @@ def test_parse_history() -> None:
         assert system_instruction == Content(parts=[Part(text=system_input)])
 
 
+def test_parse_history_preserves_str_content_with_tool_calls() -> None:
+    function_call = {
+        "name": "calculator",
+        "args": {"arg1": "2", "arg2": "2", "op": "+"},
+        "id": "0",
+    }
+    message = AIMessage(content="I'll call a tool now", tool_calls=[function_call])
+
+    _, history = _parse_chat_history([message])
+
+    assert history == [
+        Content(
+            role="model",
+            parts=[
+                Part(text="I'll call a tool now"),
+                Part(
+                    function_call=FunctionCall(
+                        name="calculator",
+                        args=function_call["args"],
+                    )
+                ),
+            ],
+        )
+    ]
+
+
+def test_parse_history_preserves_list_text_content_with_tool_calls() -> None:
+    function_call = {
+        "name": "calculator",
+        "args": {"arg1": "3", "arg2": "4", "op": "*"},
+        "id": "1",
+    }
+    message = AIMessage(
+        content=[{"type": "text", "text": "Need to compute this."}],
+        tool_calls=[function_call],
+    )
+
+    _, history = _parse_chat_history([message])
+
+    assert history == [
+        Content(
+            role="model",
+            parts=[
+                Part(text="Need to compute this."),
+                Part(
+                    function_call=FunctionCall(
+                        name="calculator",
+                        args=function_call["args"],
+                    )
+                ),
+            ],
+        )
+    ]
+
+
 @pytest.mark.parametrize("content", ['["a"]', '{"a":"b"}', "function output"])
 def test_parse_function_history(content: str | list[str | dict]) -> None:
     function_message = FunctionMessage(name="search_tool", content=content)


### PR DESCRIPTION
## Summary
Preserve `AIMessage.content` when `tool_calls` are present in the genai chat history parser.

## What changed
- In `_parse_chat_history`, keep non-empty text content when processing an `AIMessage` that has `tool_calls`.
- Preserve text content for:
  - string content (`message.content: str`)
  - list content blocks with `{"type": "text", "text": ...}`
  - list entries that are plain strings
- Added regression tests to ensure text is not dropped when tool calls are present.

## Tests
Added/updated unit tests in `libs/genai/tests/unit_tests/test_chat_models.py`:
- `test_parse_history_preserves_str_content_with_tool_calls`
- `test_parse_history_preserves_list_text_content_with_tool_calls`

Targeted pytest run passed locally for parse-history tests.

Fixes #1706