### PR TITLE
fix(genai): handle Vertex AI single-content limit in batch embeddings

### DIFF
--- a/libs/genai/langchain_google_genai/embeddings.py
+++ b/libs/genai/langchain_google_genai/embeddings.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import string
@@ -5,7 +6,7 @@ from typing import Any
 
 from google.genai.client import Client
 from google.genai.errors import ClientError
-from google.genai.types import EmbedContentConfig, HttpOptions
+from google.genai.types import Content, EmbedContentConfig, HttpOptions, Part
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import from_env, secret_from_env
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
@@ -15,6 +16,8 @@ from langchain_google_genai._common import (
     GoogleGenerativeAIError,
     get_user_agent,
 )
+
+logger = logging.getLogger(__name__)
 
 _MAX_TOKENS_PER_BATCH = 20000
 _DEFAULT_BATCH_SIZE = 100
@@ -435,12 +438,42 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
                 output_dimensionality=effective_dimensionality,
             )
 
+            # Ensure compatibility with Vertex AI single-content
+            # limits for batch embeddings.
+            # Resolves silent data loss issue #1704
+            contents = [Content(parts=[Part(text=t)]) for t in batch]
+
             try:
                 result = self.client.models.embed_content(
                     model=self.model,
-                    contents=batch,
+                    contents=contents,
                     config=config,
                 )
+                embeddings.extend([list(e.values) for e in result.embeddings])
+            except ValueError as e:
+                if "only supports one content" not in str(e):
+                    raise
+                # Vertex AI embedContent only supports one content per request.
+                # Fall back to per-text requests.
+                logger.warning(
+                    "Batch embed_content not supported; falling back to "
+                    "per-text requests (batch size: %d).",
+                    len(contents),
+                )
+                for content in contents:
+                    try:
+                        result = self.client.models.embed_content(
+                            model=self.model,
+                            contents=[content],
+                            config=config,
+                        )
+                        embeddings.extend([list(e.values) for e in result.embeddings])
+                    except ClientError as e2:
+                        msg = f"Error embedding content ({e2.status}): {e2}"
+                        raise GoogleGenerativeAIError(msg) from e2
+                    except Exception as e2:
+                        msg = f"Error embedding content: {e2}"
+                        raise GoogleGenerativeAIError(msg) from e2
             except ClientError as e:
                 msg = f"Error embedding content ({e.status}): {e}"
                 raise GoogleGenerativeAIError(msg) from e
@@ -448,7 +481,6 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
                 msg = f"Error embedding content: {e}"
                 raise GoogleGenerativeAIError(msg) from e
 
-            embeddings.extend([list(e.values) for e in result.embeddings])
         return embeddings
 
     def embed_query(
@@ -553,12 +585,40 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
                 output_dimensionality=effective_dimensionality,
             )
 
+            # Ensure compatibility with Vertex AI single-content
+            # limits for batch embeddings.
+            # Resolves silent data loss issue #1704
+            contents = [Content(parts=[Part(text=t)]) for t in batch]
+
             try:
                 result = await self.client.aio.models.embed_content(
                     model=self.model,
-                    contents=batch,
+                    contents=contents,
                     config=config,
                 )
+                embeddings.extend([list(e.values) for e in result.embeddings])
+            except ValueError as e:
+                if "only supports one content" not in str(e):
+                    raise
+                logger.warning(
+                    "Batch embed_content not supported; falling back to "
+                    "per-text requests (batch size: %d).",
+                    len(contents),
+                )
+                for content in contents:
+                    try:
+                        result = await self.client.aio.models.embed_content(
+                            model=self.model,
+                            contents=[content],
+                            config=config,
+                        )
+                        embeddings.extend([list(e.values) for e in result.embeddings])
+                    except ClientError as e2:
+                        msg = f"Error embedding content ({e2.status}): {e2}"
+                        raise GoogleGenerativeAIError(msg) from e2
+                    except Exception as e2:
+                        msg = f"Error embedding content: {e2}"
+                        raise GoogleGenerativeAIError(msg) from e2
             except ClientError as e:
                 msg = f"Error embedding content ({e.status}): {e}"
                 raise GoogleGenerativeAIError(msg) from e
@@ -566,7 +626,6 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
                 msg = f"Error embedding content: {e}"
                 raise GoogleGenerativeAIError(msg) from e
 
-            embeddings.extend([list(e.values) for e in result.embeddings])
         return embeddings
 
     async def aembed_query(

--- a/libs/genai/tests/unit_tests/test_embeddings.py
+++ b/libs/genai/tests/unit_tests/test_embeddings.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from google.genai.types import Content
 from pydantic import SecretStr
 
 from langchain_google_genai.embeddings import GoogleGenerativeAIEmbeddings
@@ -118,7 +119,17 @@ def test_embed_documents() -> None:
         mock_embed.assert_called_once()
         call_kwargs = mock_embed.call_args.kwargs
         assert call_kwargs["model"] == MODEL_NAME
-        assert call_kwargs["contents"] == ["test text", "test text2"]
+        # Contents should be wrapped in Content objects (not bare strings)
+        # to ensure the SDK returns one embedding per text. See #1704.
+        contents = call_kwargs["contents"]
+        assert len(contents) == 2
+        assert isinstance(contents[0], Content)
+        first_parts = contents[0].parts
+        second_parts = contents[1].parts
+        assert first_parts is not None
+        assert second_parts is not None
+        assert first_parts[0].text == "test text"
+        assert second_parts[0].text == "test text2"
         assert call_kwargs["config"].task_type == "RETRIEVAL_DOCUMENT"
 
         # Verify the result
@@ -151,6 +162,65 @@ def test_embed_documents_with_numerous_texts() -> None:
 
         # Should be called once per batch
         assert mock_embed.call_count == test_corpus_size / test_batch_size
+
+
+def test_embed_documents_vertex_single_content_fallback() -> None:
+    """Test that embed_documents falls back to per-text requests on Vertex."""
+    with patch("langchain_google_genai.embeddings.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_embed = MagicMock()
+        mock_embed.side_effect = [
+            ValueError(
+                "The embedContent API for this model only supports one content at "
+                "a time."
+            ),
+            _mock_embedding_response([[1.0, 2.0]]),
+            _mock_embedding_response([[3.0, 4.0]]),
+        ]
+        mock_client.models.embed_content = mock_embed
+
+        llm = GoogleGenerativeAIEmbeddings(
+            model=MODEL_NAME,
+            google_api_key=SecretStr("test-key"),
+            project="test-project",
+            vertexai=True,
+        )
+
+        result = llm.embed_documents(["text a", "text b"])
+
+        assert mock_embed.call_count == 3
+        assert result == [[1.0, 2.0], [3.0, 4.0]]
+
+        first_call_contents = mock_embed.call_args_list[0].kwargs["contents"]
+        assert len(first_call_contents) == 2
+
+        second_call_contents = mock_embed.call_args_list[1].kwargs["contents"]
+        third_call_contents = mock_embed.call_args_list[2].kwargs["contents"]
+        assert len(second_call_contents) == 1
+        assert len(third_call_contents) == 1
+        assert second_call_contents[0].parts[0].text == "text a"
+        assert third_call_contents[0].parts[0].text == "text b"
+
+
+def test_embed_documents_unrelated_value_error_propagates() -> None:
+    """Ensure unrelated ValueErrors are not swallowed by the Vertex fallback."""
+    with patch("langchain_google_genai.embeddings.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_embed = MagicMock()
+        mock_embed.side_effect = ValueError("contents are required.")
+        mock_client.models.embed_content = mock_embed
+
+        llm = GoogleGenerativeAIEmbeddings(
+            model=MODEL_NAME,
+            google_api_key=SecretStr("test-key"),
+        )
+
+        with pytest.raises(ValueError, match=r"contents are required\."):
+            llm.embed_documents(["text a"])
 
 
 def test_base_url_support() -> None:
@@ -297,8 +367,78 @@ async def test_aembed_documents() -> None:
         mock_embed.assert_called_once()
         call_kwargs = mock_embed.call_args.kwargs
         assert call_kwargs["model"] == MODEL_NAME
-        assert call_kwargs["contents"] == ["test text", "test text2"]
+        # Contents should be wrapped in Content objects. See #1704.
+        contents = call_kwargs["contents"]
+        assert len(contents) == 2
+        assert isinstance(contents[0], Content)
+        first_parts = contents[0].parts
+        second_parts = contents[1].parts
+        assert first_parts is not None
+        assert second_parts is not None
+        assert first_parts[0].text == "test text"
+        assert second_parts[0].text == "test text2"
         assert call_kwargs["config"].task_type == "RETRIEVAL_DOCUMENT"
 
         # Verify the result
         assert result == [[1.0, 2.0], [3.0, 4.0]]
+
+
+@pytest.mark.asyncio
+async def test_aembed_documents_vertex_single_content_fallback() -> None:
+    """Test that aembed_documents falls back to per-text requests on Vertex."""
+    with patch("langchain_google_genai.embeddings.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_embed = AsyncMock()
+        mock_embed.side_effect = [
+            ValueError(
+                "The embedContent API for this model only supports one content at "
+                "a time."
+            ),
+            _mock_embedding_response([[1.0, 2.0]]),
+            _mock_embedding_response([[3.0, 4.0]]),
+        ]
+        mock_client.aio.models.embed_content = mock_embed
+
+        llm = GoogleGenerativeAIEmbeddings(
+            model=MODEL_NAME,
+            google_api_key=SecretStr("test-key"),
+            project="test-project",
+            vertexai=True,
+        )
+
+        result = await llm.aembed_documents(["text a", "text b"])
+
+        assert mock_embed.call_count == 3
+        assert result == [[1.0, 2.0], [3.0, 4.0]]
+
+        first_call_contents = mock_embed.call_args_list[0].kwargs["contents"]
+        assert len(first_call_contents) == 2
+
+        second_call_contents = mock_embed.call_args_list[1].kwargs["contents"]
+        third_call_contents = mock_embed.call_args_list[2].kwargs["contents"]
+        assert len(second_call_contents) == 1
+        assert len(third_call_contents) == 1
+        assert second_call_contents[0].parts[0].text == "text a"
+        assert third_call_contents[0].parts[0].text == "text b"
+
+
+@pytest.mark.asyncio
+async def test_aembed_documents_unrelated_value_error_propagates() -> None:
+    """Ensure unrelated ValueErrors propagate in the async path."""
+    with patch("langchain_google_genai.embeddings.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_embed = AsyncMock()
+        mock_embed.side_effect = ValueError("contents are required.")
+        mock_client.aio.models.embed_content = mock_embed
+
+        llm = GoogleGenerativeAIEmbeddings(
+            model=MODEL_NAME,
+            google_api_key=SecretStr("test-key"),
+        )
+
+        with pytest.raises(ValueError, match=r"contents are required\."):
+            await llm.aembed_documents(["text a"])


### PR DESCRIPTION
Resolves #1704

Problem
As reported in the issue, GoogleGenerativeAIEmbeddings.embed_documents() and aembed_documents() were failing silently when processing batches of text. The Google GenAI SDK interprets a bare list[str] as a single multi-part Content object, resulting in exactly one embedding vector regardless of the input size (Silent Data Loss).

Solution
Content Wrapping: Each text string is now explicitly wrapped in its own Content and Part objects before being passed to the SDK. This ensures the SDK treats them as separate requests.

Vertex AI Fallback: Since Vertex AI enforces a strict limit of one Content object per request (for certain models like gemini-embedding-2), the fix includes a ValueError fallback. If the batch request is rejected by Vertex, the code catches the error and automatically issues individual sequential requests.

Quality Assurance
Unit Tests: Updated test_embeddings.py to assert that Content objects are being passed instead of bare strings.

Fallback Tests: Added new sync and async tests specifically for the Vertex AI fallback logic, verifying that individual calls are made after a batch failure.

Error Propagation: Added tests to ensure unrelated ValueErrors are still propagated correctly.

Linting & Formatting: All checks passed via make format, make lint_package, and make lint_tests.

Global Tests: All 260 unit tests passed successfully.

Note: This implementation provides full test coverage for the Vertex AI fallback logic and ensures all CI checks pass locally, providing a robust solution for the silent data loss reported in #1704.