### PR TITLE
test(vertexai): xfail `llama-4-maverick` maas tests on `us-east5` quota

### DIFF
--- a/libs/vertexai/tests/integration_tests/test_maas.py
+++ b/libs/vertexai/tests/integration_tests/test_maas.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 import pytest
 from langchain_core.messages import (
@@ -16,7 +17,29 @@ from langchain_google_vertexai.model_garden_maas import (
     get_vertex_maas_model,
 )
 
-model_names = _LLAMA_MODELS + _MISTRAL_MODELS
+# `us-east5` quota for `llama-4-maverick` is regularly exhausted by the
+# parametrized sweep (429 `RESOURCE_EXHAUSTED`), and pytest-retry's short
+# backoff isn't enough to recover. xfail with `strict=False` so we still
+# get an XPASS signal when quota is available, without blocking unrelated PRs.
+_QUOTA_EXHAUSTED_MODELS = frozenset({"meta/llama-4-maverick-17b-128e-instruct-maas"})
+
+
+def _model_param(model_name: str) -> Any:
+    if model_name in _QUOTA_EXHAUSTED_MODELS:
+        return pytest.param(
+            model_name,
+            marks=pytest.mark.xfail(
+                reason=(
+                    "us-east5 quota for llama-4-maverick is consistently "
+                    "exhausted in the integration-test project (429)"
+                ),
+                strict=False,
+            ),
+        )
+    return model_name
+
+
+model_names = [_model_param(m) for m in _LLAMA_MODELS + _MISTRAL_MODELS]
 # Fix tool support for new Mistral and Llama models
 model_names_with_tools_support = [
     "mistral-medium-3",


### PR DESCRIPTION
Mark `meta/llama-4-maverick-17b-128e-instruct-maas` parametrizations in `test_maas.py` as `xfail` with `strict=False`. The `us-east5` quota for this model is consistently exhausted by the test sweep — every recent vertex Cloud Build run shows 429 `RESOURCE_EXHAUSTED` on it, and the existing `@pytest.mark.flaky(retries=3)` doesn't outlast the per-minute quota window.