### PR TITLE
fix(vertexai): tighten trailing-whitespace strip for Anthropic prefill

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
@@ -352,18 +352,20 @@ def _format_messages_anthropic(
             continue
         formatted_messages.append(fm)
 
-    # --- FIX: Sanitize trailing whitespace in prefill (last assistant msg) ---
-    if formatted_messages:
-        last_msg = formatted_messages[-1]
-        if last_msg["role"] == "assistant":
-            if isinstance(last_msg.get("content"), list):
-                for block in last_msg["content"]:
-                    if isinstance(block, dict):
-                        b_type = block.get("type")
-                        if b_type == "text" and "text" in block:
-                            block["text"] = block["text"].rstrip()
-                        elif b_type == "thinking" and "thinking" in block:
-                            block["thinking"] = block["thinking"].rstrip()
+    # Anthropic treats a trailing assistant message as a "prefill" and rejects
+    # requests whose final content ends with whitespace. Mirror langchain-anthropic
+    # and rstrip only the last text block of the last assistant message.
+    if formatted_messages and formatted_messages[-1]["role"] == "assistant":
+        content = formatted_messages[-1]["content"]
+        if isinstance(content, str):
+            formatted_messages[-1]["content"] = content.rstrip()
+        elif (
+            isinstance(content, list)
+            and content
+            and isinstance(content[-1], dict)
+            and content[-1].get("type") == "text"
+        ):
+            content[-1]["text"] = content[-1]["text"].rstrip()
 
     return system_messages, formatted_messages
 

--- a/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
@@ -1635,3 +1635,64 @@ def test_format_messages_anthropic_multiple_non_consecutive_system_raises() -> N
     ]
     with pytest.raises(ValueError, match="multiple non-consecutive system messages"):
         _format_messages_anthropic(messages, project="test-project")
+
+
+def test_format_messages_anthropic_strips_trailing_assistant_string_whitespace() -> (
+    None
+):
+    """Trailing assistant ``str`` content must be ``rstrip`` (#1514)."""
+    messages = [
+        HumanMessage(content="Ping?"),
+        AIMessage(content="Pong  \n\t"),
+    ]
+    _, formatted = _format_messages_anthropic(messages, project="test-project")
+    assert formatted[-1]["role"] == "assistant"
+    assert formatted[-1]["content"] == [{"type": "text", "text": "Pong"}]
+
+
+def test_format_messages_anthropic_strips_trailing_assistant_last_text_block() -> None:
+    """Only the final text block of the trailing assistant message is stripped."""
+    messages = [
+        HumanMessage(content="Ping?"),
+        AIMessage(
+            content=[
+                {"type": "text", "text": "first  "},
+                {"type": "text", "text": "last \t"},
+            ]
+        ),
+    ]
+    _, formatted = _format_messages_anthropic(messages, project="test-project")
+    assert formatted[-1]["content"] == [
+        {"type": "text", "text": "first  "},
+        {"type": "text", "text": "last"},
+    ]
+
+
+def test_format_messages_anthropic_does_not_strip_non_trailing_assistant() -> None:
+    """Whitespace in non-trailing assistant messages is preserved."""
+    messages = [
+        HumanMessage(content="Hi"),
+        AIMessage(content="Hello "),
+        HumanMessage(content="Continue"),
+    ]
+    _, formatted = _format_messages_anthropic(messages, project="test-project")
+    assert formatted[1]["role"] == "assistant"
+    assert formatted[1]["content"] == [{"type": "text", "text": "Hello "}]
+
+
+def test_format_messages_anthropic_preserves_trailing_thinking_block() -> None:
+    """A trailing ``thinking`` block is left untouched (signature-sensitive)."""
+    messages = [
+        HumanMessage(content="Ping?"),
+        AIMessage(
+            content=[
+                {
+                    "type": "thinking",
+                    "thinking": "considering...  ",
+                    "signature": "abc",
+                }
+            ]
+        ),
+    ]
+    _, formatted = _format_messages_anthropic(messages, project="test-project")
+    assert formatted[-1]["content"][0]["thinking"] == "considering...  "


### PR DESCRIPTION
## Why

Anthropic treats a trailing assistant message as a "prefill" and rejects requests whose final content ends with whitespace (`messages: final assistant content cannot end with trailing whitespace`). PR #1531 landed a fix for this, but its scope was overbroad: it stripped **every** text block **and** every thinking block of the trailing assistant message. That can mutate intra-message whitespace the user explicitly authored and risks invalidating signature-bearing thinking blocks.

This PR tightens the strip to mirror the well-tested [`langchain-anthropic` precedent](https://github.com/langchain-ai/langchain/blob/master/libs/partners/anthropic/langchain_anthropic/chat_models.py): only the **last text block** of the trailing assistant message is `rstrip`'d (and the string-content path is handled for symmetry, even though `_format_message_anthropic` currently always returns list content).

Closes #1514. Supersedes the now-closed #1516.

## What changed

`_format_messages_anthropic` in `libs/vertexai/langchain_google_vertexai/_anthropic_utils.py`:
- Strip only the final text block of the trailing assistant message (was: every text + every thinking block).
- Leave thinking / redacted_thinking / tool_use / image blocks untouched.
- Handle string content defensively to match the langchain-anthropic shape.