### PR TITLE
ci(infra): pass `--release --extended` in release pre-checks

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -330,7 +330,13 @@ jobs:
           GOOGLE_CSE_ID: ${{ secrets.GOOGLE_CSE_ID }}
           GOOGLE_VERTEX_AI_WEB_CREDENTIALS: ${{ secrets.GOOGLE_VERTEX_AI_WEB_CREDENTIALS }}
           LANGCHAIN_TESTS_USER_AGENT: ${{ secrets.LANGCHAIN_TESTS_USER_AGENT }}
-        run: make integration_tests
+        # `--release`/`--extended` opt in to tests gated by the matching
+        # markers in each package's tests/conftest.py (e.g.
+        # libs/community/tests/conftest.py). Without these, integration tests
+        # decorated with those markers are collect-skipped silently — community
+        # and genai use `extended`, vertexai uses both. The Makefiles thread
+        # EXTRA_PYTEST_ARGS through to pytest.
+        run: make integration_tests EXTRA_PYTEST_ARGS="--release --extended"
         working-directory: ${{ inputs.working-directory }}
 
       - name: Get minimum versions

--- a/libs/community/Makefile
+++ b/libs/community/Makefile
@@ -15,7 +15,7 @@ test tests:
 	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest --retries 3 --retry-delay 1 $(TEST_FILE)
+	uv run --group test --group test_integration pytest --retries 3 --retry-delay 1 $(EXTRA_PYTEST_ARGS) $(TEST_FILE)
 
 # Run unit tests and generate a coverage report.
 coverage:

--- a/libs/genai/Makefile
+++ b/libs/genai/Makefile
@@ -15,7 +15,7 @@ test tests:
 	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -n auto --retries 3 --retry-delay 1 $(TEST_FILE)
+	uv run --group test --group test_integration pytest -n auto --retries 3 --retry-delay 1 $(EXTRA_PYTEST_ARGS) $(TEST_FILE)
 
 check_imports: $(shell find langchain_google_genai -name '*.py')
 	uv run --all-groups python ./scripts/check_imports.py $^

--- a/libs/vertexai/Makefile
+++ b/libs/vertexai/Makefile
@@ -15,7 +15,7 @@ test tests:
 	uv run --group test pytest --disable-socket --allow-unix-socket --release $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest --retries 3 --retry-delay 1 --release $(TEST_FILE)
+	uv run --group test --group test_integration pytest --retries 3 --retry-delay 1 --release $(EXTRA_PYTEST_ARGS) $(TEST_FILE)
 
 test_watch:
 	uv run ptw --snapshot-update --now . -- -vv $(TEST_FILE)


### PR DESCRIPTION
Add `--release --extended` to the `make integration_tests` invocation in the release pre-checks job. Without these flags, every integration test wearing a `release`/`extended` marker was collect-skipped silently, so the pre-release-checks step ran zero integration tests.