### PR TITLE
docs(genai): fix deprecated safety settings documentation link

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2097,7 +2097,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         ```
 
         For an enumeration of the categories and thresholds available, see Google's
-        [safety setting types](https://ai.google.dev/api/python/google/generativeai/types/SafetySettingDict).
+        [safety settings](https://ai.google.dev/gemini-api/docs/safety-settings).
 
     ???+ example "Context caching"
 


### PR DESCRIPTION
## Description

Fixes a stale documentation link in the `ChatGoogleGenerativeAI` class docstring.

The previous link pointed to the deprecated `google-generativeai` SDK reference page:

`https://ai.google.dev/api/python/google/generativeai/types/SafetySettingDict`

This URL now redirects to a deprecated repository notice.

Updated the link to the canonical Gemini API safety settings documentation:

`https://ai.google.dev/gemini-api/docs/safety-settings`

## Type

📖 Documentation

## Testing

* Verified updated URL is live and relevant
* `make lint` passes
