### PR TITLE
fix(genai, vertexai): reflect per-call model overrides in traces

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2645,10 +2645,11 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         """Get standard params for tracing."""
         params = self._get_invocation_params(stop=stop, **kwargs)
         models_prefix = "models/"
+        raw_model = params.get("model") or self.model
         ls_model_name = (
-            self.model[len(models_prefix) :]
-            if self.model and self.model.startswith(models_prefix)
-            else self.model
+            raw_model[len(models_prefix) :]
+            if raw_model and raw_model.startswith(models_prefix)
+            else raw_model
         )
         ls_params = LangSmithParams(
             ls_provider="google_genai",

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -2089,7 +2089,9 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         params = self._get_invocation_params(stop=stop, **kwargs)
         ls_params = LangSmithParams(
             ls_provider="google_vertexai",
-            ls_model_name=params.get("model") or self.model_name,
+            ls_model_name=(
+                params.get("model") or params.get("model_name") or self.model_name
+            ),
             ls_model_type="chat",
             ls_temperature=params.get("temperature", self.temperature),
         )

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -2089,7 +2089,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         params = self._get_invocation_params(stop=stop, **kwargs)
         ls_params = LangSmithParams(
             ls_provider="google_vertexai",
-            ls_model_name=self.model_name,
+            ls_model_name=params.get("model") or self.model_name,
             ls_model_type="chat",
             ls_temperature=params.get("temperature", self.temperature),
         )


### PR DESCRIPTION
`ls_model_name` in tracing params now respects a model passed at invocation time instead of always reporting the model configured on the `ChatGoogleGenerativeAI` / `ChatVertexAI` instance.