### PR TITLE
feat(genai): surface traffic_type in response metadata

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1276,6 +1276,14 @@ def _response_to_result(
             generation_info["model_name"] = response.model_version or ""
             # Set for final chunk
             model_name_for_metadata = response.model_version
+
+            # Surface Vertex AI traffic type (e.g. ON_DEMAND, ON_DEMAND_PRIORITY)
+            # so observability tools can track which billing tier served the request.
+            tt = getattr(response.usage_metadata, "traffic_type", None)
+            if tt is not None:
+                generation_info["traffic_type"] = (
+                    tt.value if hasattr(tt, "value") else str(tt)
+                )
         generation_info["safety_ratings"] = (
             [safety_rating.model_dump() for safety_rating in candidate.safety_ratings]
             if candidate.safety_ratings

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -1577,6 +1577,111 @@ def test_response_to_result_grounding_metadata(
             assert generation.message.content == "Test response"
 
 
+@pytest.mark.parametrize(
+    "traffic_type_value, expected_traffic_type",
+    [
+        ("ON_DEMAND_PRIORITY", "ON_DEMAND_PRIORITY"),
+        ("ON_DEMAND", "ON_DEMAND"),
+        ("PROVISIONED_THROUGHPUT", "PROVISIONED_THROUGHPUT"),
+    ],
+)
+def test_response_to_result_traffic_type(
+    traffic_type_value: str, expected_traffic_type: str
+) -> None:
+    """Test that traffic_type from usage_metadata is surfaced in generation_info."""
+    raw_response = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello!"}]},
+                "finish_reason": "STOP",
+            }
+        ],
+        "usage_metadata": {
+            "prompt_token_count": 5,
+            "candidates_token_count": 3,
+            "total_token_count": 8,
+            "traffic_type": traffic_type_value,
+        },
+    }
+    response = GenerateContentResponse.model_validate(raw_response)
+    result = _response_to_result(response, stream=False)
+
+    assert len(result.generations) == 1
+    gen_info = result.generations[0].generation_info
+    assert gen_info is not None
+    assert gen_info["traffic_type"] == expected_traffic_type
+
+
+def test_response_to_result_traffic_type_absent() -> None:
+    """Test that missing traffic_type does not add the key to generation_info."""
+    raw_response = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello!"}]},
+                "finish_reason": "STOP",
+            }
+        ],
+        "usage_metadata": {
+            "prompt_token_count": 5,
+            "candidates_token_count": 3,
+            "total_token_count": 8,
+        },
+    }
+    response = GenerateContentResponse.model_validate(raw_response)
+    result = _response_to_result(response, stream=False)
+
+    gen_info = result.generations[0].generation_info
+    assert gen_info is not None
+    assert "traffic_type" not in gen_info
+
+
+def test_response_to_result_traffic_type_streaming() -> None:
+    """Test that traffic_type is surfaced in the final streaming chunk."""
+    raw_response = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello!"}]},
+                "finish_reason": "STOP",
+            }
+        ],
+        "usage_metadata": {
+            "prompt_token_count": 5,
+            "candidates_token_count": 3,
+            "total_token_count": 8,
+            "traffic_type": "ON_DEMAND_PRIORITY",
+        },
+    }
+    response = GenerateContentResponse.model_validate(raw_response)
+    result = _response_to_result(response, stream=True)
+
+    gen_info = result.generations[0].generation_info
+    assert gen_info is not None
+    assert gen_info["traffic_type"] == "ON_DEMAND_PRIORITY"
+
+
+def test_response_to_result_traffic_type_no_finish_reason() -> None:
+    """Test that traffic_type is NOT added to intermediate streaming chunks."""
+    raw_response = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hel"}]},
+            }
+        ],
+        "usage_metadata": {
+            "prompt_token_count": 5,
+            "candidates_token_count": 1,
+            "total_token_count": 6,
+            "traffic_type": "ON_DEMAND_PRIORITY",
+        },
+    }
+    response = GenerateContentResponse.model_validate(raw_response)
+    result = _response_to_result(response, stream=True)
+
+    gen_info = result.generations[0].generation_info
+    assert gen_info is not None
+    assert "traffic_type" not in gen_info
+
+
 def test_grounding_metadata_to_citations_conversion() -> None:
     """Test grounding metadata is properly converted to citations in content blocks."""
     raw_response = {


### PR DESCRIPTION
## Summary

- Surfaces the `traffic_type` field from Vertex AI's `usage_metadata` in `generation_info` (and by extension `response_metadata`), enabling observability tools like Langfuse to track which billing tier (e.g. `ON_DEMAND`, `ON_DEMAND_PRIORITY`, `PROVISIONED_THROUGHPUT`) served each request.
- The field is only present when the upstream SDK provides it and only on the final chunk (same pattern as `finish_reason` and `model_name`) to avoid duplication during streaming concatenation.
- Adds comprehensive unit tests covering parametrized traffic types, absent traffic type, streaming final chunks, and intermediate streaming chunks.

## Test plan

- [x] Unit tests pass (`make test` — 288 passed)
- [x] Lint passes (`make lint` — ruff + mypy clean)
- [x] Format passes (`make format` — no changes needed)
- [x] Import checks pass (`make check_imports`)