### PR TITLE
fix(genai): walrus operator precedence in v1 `image/file` url conversion

### DIFF
--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -184,12 +184,12 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                     }
                 }
                 new_content.append(new_block)
-            elif url := block_dict.get("url") and model_provider == "google_genai":
+            elif (url := block_dict.get("url")) and model_provider == "google_genai":
                 # Google file service
                 new_block = {
                     "file_data": {
                         "mime_type": block_dict.get("mime_type", "image/jpeg"),
-                        "file_uri": block_dict[str(url)],
+                        "file_uri": url,
                     }
                 }
                 new_content.append(new_block)
@@ -221,14 +221,14 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                     }
                 }
                 new_content.append(new_block)
-            elif url := block_dict.get("url") and model_provider == "google_genai":
+            elif (url := block_dict.get("url")) and model_provider == "google_genai":
                 # Google file service
                 new_block = {
                     "file_data": {
                         "mime_type": block_dict.get(
                             "mime_type", "application/octet-stream"
                         ),
-                        "file_uri": block_dict[str(url)],
+                        "file_uri": url,
                     }
                 }
                 new_content.append(new_block)

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -2466,6 +2466,52 @@ def test_compat() -> None:
     assert result == expected
 
 
+def test_compat_url_blocks() -> None:
+    """URL-based image/file blocks route to `file_data` for the google provider."""
+    image_block: types.ImageContentBlock = {
+        "type": "image",
+        "url": "https://example.com/cat.jpg",
+        "mime_type": "image/jpeg",
+    }
+    result = _convert_from_v1_to_generativelanguage_v1beta(
+        [image_block],
+        "google_genai",
+    )
+    assert result == [
+        {
+            "file_data": {
+                "mime_type": "image/jpeg",
+                "file_uri": "https://example.com/cat.jpg",
+            }
+        }
+    ]
+
+    file_block: types.FileContentBlock = {
+        "type": "file",
+        "url": "https://example.com/doc.pdf",
+        "mime_type": "application/pdf",
+    }
+    result = _convert_from_v1_to_generativelanguage_v1beta(
+        [file_block],
+        "google_genai",
+    )
+    assert result == [
+        {
+            "file_data": {
+                "mime_type": "application/pdf",
+                "file_uri": "https://example.com/doc.pdf",
+            }
+        }
+    ]
+
+    # Non-google provider: URL blocks are not routed through the file service.
+    result = _convert_from_v1_to_generativelanguage_v1beta(
+        [image_block],
+        "other_provider",
+    )
+    assert result == []
+
+
 def test_thought_signature_conversion() -> None:
     """Test comprehensive thought signature conversion scenarios."""
 


### PR DESCRIPTION
A walrus-operator precedence bug in `_convert_from_v1_to_generativelanguage_v1beta` made URL-based `ImageContentBlock` / `FileContentBlock` history unusable on `ChatGoogleGenerativeAI`: `elif url := block_dict.get("url") and model_provider == "google_genai":` parsed as `url := (... and ...)`, binding `url` to a bool and crashing on `block_dict[str(url)]` with `KeyError: 'True'`.