### PR TITLE
test(genai): force `google_search` use in structured-output test

### DIFF
--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -1715,12 +1715,15 @@ def test_structured_output_with_google_search(
         response_schema=MatchResult.model_json_schema(),
     )
 
+    prompt = (
+        "Use the google_search tool to find all details for the latest Euro "
+        "championship final match. Always call google_search before responding."
+    )
+
     if use_streaming:
         # Test streaming
         chunks: list[BaseMessageChunk] = []
-        for chunk in llm_with_search.stream(
-            "Search for all details for the latest Euro championship final match."
-        ):
+        for chunk in llm_with_search.stream(prompt):
             assert isinstance(chunk, AIMessageChunk)
             chunks.append(chunk)
 
@@ -1735,9 +1738,7 @@ def test_structured_output_with_google_search(
         assert isinstance(response, AIMessageChunk)
     else:
         # Test invoke
-        response = llm_with_search.invoke(  # type: ignore[assignment]
-            "Search for all details for the latest Euro championship final match."
-        )
+        response = llm_with_search.invoke(prompt)  # type: ignore[assignment]
         assert isinstance(response, AIMessage)
 
     # Extract JSON from response content


### PR DESCRIPTION
The integration test `test_structured_output_with_google_search` was flaky on `gemini-3.1-pro-preview`: the model would answer the Euro final question from training data without invoking `google_search`, leaving `grounding_metadata` absent from `response_metadata` and tripping the assertion. The prompt now explicitly instructs the model to call `google_search` before responding.