### PR TITLE
fix(community): correct inverted GOOGLE_APPLICATION_CREDENTIALS check in GoogleDriveLoader

### DIFF
--- a/libs/community/langchain_google_community/drive.py
+++ b/libs/community/langchain_google_community/drive.py
@@ -344,7 +344,7 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
         if not creds or not creds.valid:
             if creds and creds.expired and creds.refresh_token:
                 creds.refresh(Request())
-            elif "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
+            elif "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
                 creds, project = default()
                 creds = google.auth.credentials.with_scopes_if_required(
                     creds, self.scopes

--- a/libs/community/tests/unit_tests/test_drive.py
+++ b/libs/community/tests/unit_tests/test_drive.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -117,3 +118,81 @@ def test_load_documents_from_ids_dispatches_pdfs() -> None:
     mock_sheet.assert_not_called()
     mock_doc.assert_not_called()
     assert result == [pdf_doc]
+
+
+def _make_loader_with_writable_paths(tmp_path: Path) -> GoogleDriveLoader:
+    """Build a loader whose service_account_key / token_path do NOT exist
+    and whose credentials_path exists (so the field validator passes)."""
+    creds_file = tmp_path / "credentials.json"
+    creds_file.write_text("{}")
+    return GoogleDriveLoader(
+        folder_id="dummy_folder",
+        credentials_path=creds_file,
+        token_path=tmp_path / "token.json",
+        service_account_key=tmp_path / "service-account.json",
+    )
+
+
+def test_load_credentials_uses_installed_app_flow_when_adc_not_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Desktop OAuth path: with `GOOGLE_APPLICATION_CREDENTIALS` unset and a
+    `credentials_path` supplied, `_load_credentials` must drive `InstalledAppFlow`
+    and must NOT fall back to `google.auth.default()` (which requires ADC and
+    would crash for desktop OAuth users -- regression test for the inverted
+    `not in os.environ` check)."""
+    pytest.importorskip("google_auth_oauthlib")
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    loader = _make_loader_with_writable_paths(tmp_path)
+
+    fake_creds = MagicMock()
+    fake_creds.to_json.return_value = "{}"
+    fake_flow = MagicMock()
+    fake_flow.run_local_server.return_value = fake_creds
+
+    with (
+        patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file",
+            return_value=fake_flow,
+        ) as mock_from_file,
+        patch("google.auth.default") as mock_default,
+    ):
+        result = loader._load_credentials()
+
+    mock_from_file.assert_called_once()
+    mock_default.assert_not_called()
+    assert result is fake_creds
+    assert loader.token_path.exists()
+
+
+def test_load_credentials_uses_default_when_adc_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ADC path: with `GOOGLE_APPLICATION_CREDENTIALS` set, `_load_credentials`
+    must use `google.auth.default()` and must NOT trigger the InstalledAppFlow
+    browser-OAuth dance."""
+    pytest.importorskip("google_auth_oauthlib")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(tmp_path / "adc.json"))
+    loader = _make_loader_with_writable_paths(tmp_path)
+
+    fake_default_creds = MagicMock()
+    fake_scoped_creds = MagicMock()
+
+    with (
+        patch(
+            "google.auth.default",
+            return_value=(fake_default_creds, "test-project"),
+        ) as mock_default,
+        patch(
+            "google.auth.credentials.with_scopes_if_required",
+            return_value=fake_scoped_creds,
+        ),
+        patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file",
+        ) as mock_flow,
+    ):
+        result = loader._load_credentials()
+
+    mock_default.assert_called_once()
+    mock_flow.assert_not_called()
+    assert result is fake_scoped_creds


### PR DESCRIPTION
## Description

`GoogleDriveLoader._load_credentials` had the ADC check inverted: it called
`google.auth.default()` when `GOOGLE_APPLICATION_CREDENTIALS` was *not* set,
and only triggered the `InstalledAppFlow` desktop-OAuth path when ADC *was*
configured. This is backwards: `default()` is the helper that *requires* ADC,
and `InstalledAppFlow` is the helper that consumes the user's `credentials.json`.

As reported in #1751, users who follow the documented desktop-OAuth quickstart
(drop in `credentials.json`, no env var) crash with:

```
Your default credentials were not found. To set up Application Default
Credentials, see https://cloud.google.com/docs/authentication/external/set-up-adc
```

This PR swaps the condition so each branch matches the helper it calls, and
adds two regression tests that pin the routing for both env-var states.

## Relevant issues

Fixes #1751

## Type

🐛 Bug Fix

## Changes

- `libs/community/langchain_google_community/drive.py`: change
  `elif "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:` to
  `elif "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:` so the ADC branch runs
  only when ADC is configured.
- `libs/community/tests/unit_tests/test_drive.py`: add
  `test_load_credentials_uses_installed_app_flow_when_adc_not_set` and
  `test_load_credentials_uses_default_when_adc_set`.

## Testing

```
$ python -m pytest libs/community/tests/unit_tests/test_drive.py -v
...
test_load_credentials_uses_installed_app_flow_when_adc_not_set PASSED
test_load_credentials_uses_default_when_adc_set                PASSED
======================= 10 passed in 5.11s =======================
```

Reverting only the one-line `drive.py` change while keeping the new tests makes
both new tests fail, confirming they actually pin the buggy path.

`ruff check` and `ruff format --check` pass on both files.

## Note

The fix is intentionally minimal — a one-token swap that matches the existing
comment at the call site ("# no need to write to file" for the ADC branch,
which only makes sense if that branch corresponds to ADC). No behavior changes
in the service-account / cached-token / passed-in-`credentials` paths above.

---

_Disclaimer: this PR was prepared with the assistance of an AI agent (Claude Code). All code and test changes were reviewed by the author before submission._
