### PR TITLE
fix(genai): preserve non-ASCII in tool-call arguments JSON

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1118,7 +1118,8 @@ def _parse_response_candidate(
             args_dict = dict(part.function_call.args) if part.function_call.args else {}
             function_call_args_dict = _convert_integer_like_floats(args_dict)
             function_call["arguments"] = json.dumps(
-                {k: function_call_args_dict[k] for k in function_call_args_dict}
+                {k: function_call_args_dict[k] for k in function_call_args_dict},
+                ensure_ascii=False,
             )
             additional_kwargs["function_call"] = function_call
 

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -1003,6 +1003,39 @@ def test_parse_response_candidate(raw_candidate: dict, expected: AIMessage) -> N
                 assert res_kw == exp_kw
 
 
+def test_parse_response_candidate_preserves_non_ascii_in_function_call_arguments() -> (
+    None
+):
+    """Tool-call args with non-ASCII text (CJK, emoji, etc.) must land in
+    `additional_kwargs["function_call"]["arguments"]` as raw UTF-8, not as
+    escaped `\\uXXXX` sequences.
+
+    Existing tests round-trip through `json.loads` and so were blind to the
+    encoding difference. Regression test for #1789 -- matches the
+    `ensure_ascii=False` convention used by langchain-openai and langchain-core.
+    """
+    raw_candidate = {
+        "content": {
+            "parts": [
+                {
+                    "function_call": FunctionCall(
+                        name="echo",
+                        args={"text": "안녕하세요", "emoji": "🚀"},
+                    )
+                },
+            ]
+        }
+    }
+    response_candidate = Candidate.model_validate(raw_candidate)
+    result = _parse_response_candidate(response_candidate)
+    arguments = result.additional_kwargs["function_call"]["arguments"]
+
+    assert "안녕하세요" in arguments
+    assert "🚀" in arguments
+    assert "\\u" not in arguments
+    assert json.loads(arguments) == {"text": "안녕하세요", "emoji": "🚀"}
+
+
 def test_parse_response_candidate_includes_model_provider() -> None:
     """Test `_parse_response_candidate` has `model_provider` in `response_metadata`."""
     raw_candidate = {


### PR DESCRIPTION
## Description

`_parse_response_candidate` in [`libs/genai/langchain_google_genai/chat_models.py`](https://github.com/langchain-ai/langchain-google/blob/main/libs/genai/langchain_google_genai/chat_models.py) serialized `additional_kwargs["function_call"]["arguments"]` with the default `json.dumps(...)`. Python's `json` defaults to `ensure_ascii=True`, so every non-ASCII character is escaped to `\uXXXX`. CJK text, accented characters, and emoji in tool-call arguments became unreadable when written to JSON columns / log files.

The same arguments stay correct in `tool_calls[i]["args"]` (a clean dict, because `parse_tool_calls` round-trips through `json.loads`), so consumers see *different* content depending on which field they read. From #1789:

```python
msg.tool_calls[0]["args"]                              # → {'text': '안녕하세요'}        ✅
msg.additional_kwargs["function_call"]["arguments"]    # → '{"text": "\\uc548\\ub155\\ud558\\uc138\\uc694"}'  ❌
```

`langchain-openai` already passes `ensure_ascii=False` at the analogous call site in `langchain_openai/chat_models/base.py`, and `langchain-core` follows the same convention across its `json.dumps` sites that touch message content. This change makes `langchain-google-genai` match — one keyword argument.

## Relevant issues

Fixes #1789

## Type

🐛 Bug Fix

## Changes

- `libs/genai/langchain_google_genai/chat_models.py`: pass `ensure_ascii=False` to the `json.dumps` that produces `function_call["arguments"]`.
- `libs/genai/tests/unit_tests/test_chat_models.py`: add `test_parse_response_candidate_preserves_non_ascii_in_function_call_arguments` asserting on the raw string (not the json.loads round-trip — the existing parametrized tests round-trip and so were blind to the encoding difference).

## Testing

```
$ uv run --group test pytest tests/unit_tests/test_chat_models.py -k parse_response_candidate -v
...
test_parse_response_candidate_preserves_non_ascii_in_function_call_arguments PASSED
============= 17 passed, 203 deselected in 5.18s =============
```

Reverting only the one-line `chat_models.py` change while keeping the new test makes that test fail with the exact `'\\uc548\\ub155...'` escape sequence from the issue, confirming the test pins the buggy behavior.

`ruff check` and `ruff format --check` pass on both files.

## Note

Per `CLAUDE.md` PR guidelines: this fix was prepared with the assistance of an AI agent (Claude Code). All code and test changes were reviewed by the author before submission.