### PR TITLE
fix(genai): support Vertex AI multiregion endpoints

### DIFF
--- a/libs/genai/langchain_google_genai/_common.py
+++ b/libs/genai/langchain_google_genai/_common.py
@@ -1,6 +1,6 @@
 import os
 from importlib import metadata
-from typing import Any
+from typing import Any, cast
 
 from langchain_core.utils import from_env, secret_from_env
 from pydantic import BaseModel, Field, SecretStr, model_validator
@@ -15,6 +15,10 @@ from langchain_google_genai._enums import (
 
 _TELEMETRY_TAG = "remote_reasoning_engine"
 _TELEMETRY_ENV_VARIABLE_NAME = "GOOGLE_CLOUD_AGENT_ENGINE_ID"
+_VERTEXAI_MULTI_REGION_BASE_URLS = {
+    "us": "https://aiplatform.us.rep.googleapis.com",
+    "eu": "https://aiplatform.eu.rep.googleapis.com",
+}
 
 # Cache package version at module import time to avoid blocking I/O in async contexts
 try:
@@ -28,6 +32,53 @@ class GoogleGenerativeAIError(Exception):
 
 
 SafetySettingDict = dict[HarmCategory, HarmBlockThreshold]
+
+
+def _resolve_base_url(
+    base_url: str | dict | None,
+    *,
+    use_vertexai: bool,
+    location: str | None,
+) -> str | None:
+    """Resolve a custom base URL or Vertex AI multiregion endpoint.
+
+    Args:
+        base_url: The user-provided base URL or legacy `client_options` dict.
+        use_vertexai: Whether the client is using the Vertex AI backend.
+        location: Vertex AI location.
+
+    Returns:
+        Resolved base URL, if one should be passed to `HttpOptions`.
+
+    Raises:
+        ValueError: If legacy `client_options` does not contain only
+            `api_endpoint`.
+    """
+    if isinstance(base_url, dict):
+        if keys := list(base_url.keys()):
+            if "api_endpoint" in keys and len(keys) == 1:
+                base_url = cast("str", base_url["api_endpoint"])
+            elif "api_endpoint" in keys and len(keys) > 1:
+                msg = (
+                    "When providing base_url as a dict, it can only contain the "
+                    "api_endpoint key. Extra keys found: "
+                    f"{[k for k in keys if k != 'api_endpoint']}"
+                )
+                raise ValueError(msg)
+            else:
+                msg = (
+                    "When providing base_url as a dict, it must only contain the "
+                    "api_endpoint key."
+                )
+                raise ValueError(msg)
+        else:
+            msg = "base_url must be a string or a dict containing the api_endpoint key."
+            raise ValueError(msg)
+
+    if base_url is None and use_vertexai and location:
+        return _VERTEXAI_MULTI_REGION_BASE_URLS.get(location.lower())
+
+    return base_url
 
 
 class _BaseGoogleGenerativeAI(BaseModel):
@@ -261,7 +312,9 @@ class _BaseGoogleGenerativeAI(BaseModel):
         ): `https://generativelanguage.googleapis.com/`
     - **Vertex AI** (
         [`credentials`][langchain_google_genai.ChatGoogleGenerativeAI.credentials]):
-        `https://{location}-aiplatform.googleapis.com/`
+        `https://{location}-aiplatform.googleapis.com/` for regional locations,
+        or `https://aiplatform.{location}.rep.googleapis.com/` for the `us` and
+        `eu` multiregions.
 
     !!! note "Backwards compatibility"
 

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -104,6 +104,7 @@ from langchain_google_genai._common import (
     GoogleGenerativeAIError,
     SafetySettingDict,
     _BaseGoogleGenerativeAI,
+    _resolve_base_url,
     get_user_agent,
 )
 from langchain_google_genai._compat import (
@@ -2476,35 +2477,14 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             else:
                 google_api_key = self.google_api_key
 
-        base_url = self.base_url
-        if isinstance(self.base_url, dict):
-            # Handle case where base_url is provided as a dict
-            # (Backwards compatibility for deprecated client_options field)
-            if keys := list(self.base_url.keys()):
-                if "api_endpoint" in keys and len(keys) == 1:
-                    base_url = self.base_url["api_endpoint"]
-                elif "api_endpoint" in keys and len(keys) > 1:
-                    msg = (
-                        "When providing base_url as a dict, it can only contain the "
-                        "api_endpoint key. Extra keys found: "
-                        f"{[k for k in keys if k != 'api_endpoint']}"
-                    )
-                    raise ValueError(msg)
-                else:
-                    msg = (
-                        "When providing base_url as a dict, it must only contain the "
-                        "api_endpoint key."
-                    )
-                    raise ValueError(msg)
-            else:
-                msg = (
-                    "base_url must be a string or a dict containing the "
-                    "api_endpoint key."
-                )
-                raise ValueError(msg)
+        base_url = _resolve_base_url(
+            self.base_url,
+            use_vertexai=self._use_vertexai,  # type: ignore[attr-defined]
+            location=self.location,
+        )
 
         http_options = HttpOptions(
-            base_url=cast("str", base_url),
+            base_url=base_url,
             api_version=self.api_version,
             headers=headers,
             client_args=self.client_args,

--- a/libs/genai/langchain_google_genai/embeddings.py
+++ b/libs/genai/langchain_google_genai/embeddings.py
@@ -13,6 +13,7 @@ from typing_extensions import Self
 
 from langchain_google_genai._common import (
     GoogleGenerativeAIError,
+    _resolve_base_url,
     get_user_agent,
 )
 
@@ -259,8 +260,14 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
         if self.additional_headers:
             headers.update(self.additional_headers)
 
+        base_url = _resolve_base_url(
+            self.base_url,
+            use_vertexai=self._use_vertexai,  # type: ignore[attr-defined]
+            location=self.location,
+        )
+
         http_options = HttpOptions(
-            base_url=self.base_url,
+            base_url=base_url,
             api_version=self.api_version,
             headers=headers,
             client_args=self.client_args,

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -522,6 +522,42 @@ def test_base_url_passed_to_client() -> None:
         assert "langchain-google-genai" in call_http_options.headers["user-agent"]
 
 
+@pytest.mark.parametrize(
+    ("location", "expected_base_url"),
+    [
+        ("us", "https://aiplatform.us.rep.googleapis.com"),
+        ("eu", "https://aiplatform.eu.rep.googleapis.com"),
+    ],
+)
+def test_vertexai_multiregion_location_uses_rep_endpoint(
+    location: str, expected_base_url: str
+) -> None:
+    with patch("langchain_google_genai.chat_models.Client") as mock_client:
+        ChatGoogleGenerativeAI(
+            model="gemini-3.1-flash-lite",
+            vertexai=True,
+            project="test-project",
+            location=location,
+        )
+        call_kwargs = mock_client.call_args_list[0].kwargs
+        call_http_options = call_kwargs["http_options"]
+        assert call_kwargs["location"] == location
+        assert call_http_options.base_url == expected_base_url
+
+
+def test_vertexai_multiregion_location_preserves_custom_base_url() -> None:
+    with patch("langchain_google_genai.chat_models.Client") as mock_client:
+        ChatGoogleGenerativeAI(
+            model="gemini-3.1-flash-lite",
+            vertexai=True,
+            project="test-project",
+            location="us",
+            base_url="https://gateway.example.com/api/gemini",
+        )
+        call_http_options = mock_client.call_args_list[0].kwargs["http_options"]
+        assert call_http_options.base_url == "https://gateway.example.com/api/gemini"
+
+
 def test_api_version_defaults_to_none() -> None:
     """`api_version` is unset by default, deferring to the SDK's default."""
     with patch("langchain_google_genai.chat_models.Client") as mock_client:

--- a/libs/genai/tests/unit_tests/test_embeddings.py
+++ b/libs/genai/tests/unit_tests/test_embeddings.py
@@ -176,6 +176,46 @@ def test_base_url_support() -> None:
     assert "api_key" in call_kwargs
 
 
+@pytest.mark.parametrize(
+    ("location", "expected_base_url"),
+    [
+        ("us", "https://aiplatform.us.rep.googleapis.com"),
+        ("eu", "https://aiplatform.eu.rep.googleapis.com"),
+    ],
+)
+def test_vertexai_multiregion_location_uses_rep_endpoint(
+    location: str, expected_base_url: str
+) -> None:
+    with patch("langchain_google_genai.embeddings.Client") as mock_client:
+        GoogleGenerativeAIEmbeddings(
+            model=MODEL_NAME,
+            vertexai=True,
+            project="test-project",
+            location=location,
+        )
+
+    mock_client.assert_called_once()
+    call_kwargs = mock_client.call_args.kwargs
+    assert call_kwargs["location"] == location
+    assert call_kwargs["http_options"].base_url == expected_base_url
+
+
+def test_vertexai_multiregion_location_preserves_custom_base_url() -> None:
+    with patch("langchain_google_genai.embeddings.Client") as mock_client:
+        GoogleGenerativeAIEmbeddings(
+            model=MODEL_NAME,
+            vertexai=True,
+            project="test-project",
+            location="eu",
+            base_url="https://gateway.example.com/api/gemini",
+        )
+
+    call_kwargs = mock_client.call_args.kwargs
+    assert (
+        call_kwargs["http_options"].base_url == "https://gateway.example.com/api/gemini"
+    )
+
+
 def test_api_version_forwarded_to_http_options() -> None:
     """`api_version` is forwarded into `HttpOptions` for the embeddings client."""
     with patch("langchain_google_genai.embeddings.Client") as mock_client:


### PR DESCRIPTION
## Description

Support Vertex AI multiregion locations in `langchain-google-genai` by resolving `location="us"` and `location="eu"` to the Google mREP hostnames when no custom `base_url` is provided.

This keeps explicit `base_url` / legacy `client_options={"api_endpoint": ...}` behavior intact, while avoiding the SDK's regional hostname pattern for multiregion locations.

## Relevant issues

Fixes #1799

## Type

🐛 Bug Fix
✅ Test

## Changes(optional)

- Added shared base URL resolution for custom endpoints and Vertex AI multiregion endpoints.
- Applied the resolver to chat models and embeddings clients.
- Added unit coverage for `us` and `eu` mREP endpoint selection and custom `base_url` precedence.

## Testing(optional)

- `uv run --group test pytest tests/unit_tests/test_chat_models.py::test_vertexai_multiregion_location_uses_rep_endpoint tests/unit_tests/test_chat_models.py::test_vertexai_multiregion_location_preserves_custom_base_url tests/unit_tests/test_embeddings.py::test_vertexai_multiregion_location_uses_rep_endpoint tests/unit_tests/test_embeddings.py::test_vertexai_multiregion_location_preserves_custom_base_url`
- `uv run --group test pytest tests/unit_tests/test_chat_models.py tests/unit_tests/test_embeddings.py`
- `uv run --group lint ruff check langchain_google_genai/_common.py langchain_google_genai/chat_models.py langchain_google_genai/embeddings.py tests/unit_tests/test_chat_models.py tests/unit_tests/test_embeddings.py`
- `uv run --group typing mypy langchain_google_genai`

## Note(optional)

This contribution was prepared with assistance from an AI coding agent; the changes and test results were reviewed before submission.
