### PR TITLE
fix(genai): resolve single aggregated embedding bug for gemini-embedding models

### DIFF
--- a/libs/genai/langchain_google_genai/embeddings.py
+++ b/libs/genai/langchain_google_genai/embeddings.py
@@ -576,7 +576,9 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
         if is_gemini_embedding:
             import asyncio
 
-            async def _aembed_single(text: str, title: str | None = None) -> list[float]:
+            async def _aembed_single(
+                text: str, title: str | None = None
+            ) -> list[float]:
                 config = self._build_config(
                     task_type=effective_task_type,
                     title=title,

--- a/libs/genai/langchain_google_genai/embeddings.py
+++ b/libs/genai/langchain_google_genai/embeddings.py
@@ -413,14 +413,46 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
         Returns:
             List of embeddings, one for each text.
         """
-        embeddings: list[list[float]] = []
-        batch_start_index = 0
-
         # Use RETRIEVAL_DOCUMENT as default for documents
         effective_task_type = task_type or self.task_type or "RETRIEVAL_DOCUMENT"
 
         # Use instance default if no explicit value provided
         effective_dimensionality = output_dimensionality or self.output_dimensionality
+
+        is_gemini_embedding = "gemini-embedding" in self.model.lower()
+
+        if is_gemini_embedding:
+            from concurrent.futures import ThreadPoolExecutor
+
+            def _embed_single(text: str, title: str | None = None) -> list[float]:
+                config = self._build_config(
+                    task_type=effective_task_type,
+                    title=title,
+                    output_dimensionality=effective_dimensionality,
+                )
+                try:
+                    result = self.client.models.embed_content(
+                        model=self.model,
+                        contents=text,
+                        config=config,
+                    )
+                    return list(result.embeddings[0].values)
+                except ClientError as e:
+                    msg = f"Error embedding content ({e.status}): {e}"
+                    raise GoogleGenerativeAIError(msg) from e
+                except Exception as e:
+                    msg = f"Error embedding content: {e}"
+                    raise GoogleGenerativeAIError(msg) from e
+
+            with ThreadPoolExecutor() as executor:
+                futures = []
+                for i, text in enumerate(texts):
+                    title = titles[i] if titles else None
+                    futures.append(executor.submit(_embed_single, text, title))
+                return [f.result() for f in futures]
+
+        embeddings: list[list[float]] = []
+        batch_start_index = 0
 
         for batch in GoogleGenerativeAIEmbeddings._prepare_batches(texts, batch_size):
             # Handle titles for this batch
@@ -534,13 +566,44 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
         Returns:
             List of embeddings, one for each text.
         """
-        embeddings: list[list[float]] = []
-        batch_start_index = 0
-
         # Use RETRIEVAL_DOCUMENT as default for documents
         effective_task_type = task_type or self.task_type or "RETRIEVAL_DOCUMENT"
 
         effective_dimensionality = output_dimensionality or self.output_dimensionality
+
+        is_gemini_embedding = "gemini-embedding" in self.model.lower()
+
+        if is_gemini_embedding:
+            import asyncio
+
+            async def _aembed_single(text: str, title: str | None = None) -> list[float]:
+                config = self._build_config(
+                    task_type=effective_task_type,
+                    title=title,
+                    output_dimensionality=effective_dimensionality,
+                )
+                try:
+                    result = await self.client.aio.models.embed_content(
+                        model=self.model,
+                        contents=text,
+                        config=config,
+                    )
+                    return list(result.embeddings[0].values)
+                except ClientError as e:
+                    msg = f"Error embedding content ({e.status}): {e}"
+                    raise GoogleGenerativeAIError(msg) from e
+                except Exception as e:
+                    msg = f"Error embedding content: {e}"
+                    raise GoogleGenerativeAIError(msg) from e
+
+            tasks = []
+            for i, text in enumerate(texts):
+                title = titles[i] if titles else None
+                tasks.append(_aembed_single(text, title))
+            return list(await asyncio.gather(*tasks))
+
+        embeddings: list[list[float]] = []
+        batch_start_index = 0
 
         for batch in GoogleGenerativeAIEmbeddings._prepare_batches(texts, batch_size):
             # Handle titles for this batch

--- a/libs/genai/tests/unit_tests/test_embeddings.py
+++ b/libs/genai/tests/unit_tests/test_embeddings.py
@@ -334,7 +334,7 @@ async def test_aembed_documents() -> None:
 
 
 def test_embed_documents_gemini_embedding_2() -> None:
-    """Test sync embed_documents with gemini-embedding-2 which uses ThreadPoolExecutor."""
+    """Test sync embed_documents with gemini-embedding-2 (ThreadPoolExecutor)."""
     gemini_model = "gemini-embedding-2-preview"
     with patch("langchain_google_genai.embeddings.Client") as mock_client_class:
         mock_client = MagicMock()
@@ -368,7 +368,7 @@ def test_embed_documents_gemini_embedding_2() -> None:
 
 @pytest.mark.asyncio
 async def test_aembed_documents_gemini_embedding_2() -> None:
-    """Test async embed_documents with gemini-embedding-2 which uses asyncio.gather."""
+    """Test async embed_documents with gemini-embedding-2 (asyncio.gather)."""
     gemini_model = "gemini-embedding-2-preview"
     with patch("langchain_google_genai.embeddings.Client") as mock_client_class:
         mock_client = MagicMock()

--- a/libs/genai/tests/unit_tests/test_embeddings.py
+++ b/libs/genai/tests/unit_tests/test_embeddings.py
@@ -7,7 +7,7 @@ from pydantic import SecretStr
 
 from langchain_google_genai.embeddings import GoogleGenerativeAIEmbeddings
 
-MODEL_NAME = "gemini-embedding-2-preview"
+MODEL_NAME = "text-embedding-004"
 
 
 def _mock_embedding_response(values_list: list[list[float]]) -> MagicMock:
@@ -330,4 +330,71 @@ async def test_aembed_documents() -> None:
         assert call_kwargs["config"].task_type == "RETRIEVAL_DOCUMENT"
 
         # Verify the result
+        assert result == [[1.0, 2.0], [3.0, 4.0]]
+
+
+def test_embed_documents_gemini_embedding_2() -> None:
+    """Test sync embed_documents with gemini-embedding-2 which uses ThreadPoolExecutor."""
+    gemini_model = "gemini-embedding-2-preview"
+    with patch("langchain_google_genai.embeddings.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_embed = MagicMock()
+        mock_embed.side_effect = [
+            _mock_embedding_response([[1.0, 2.0]]),
+            _mock_embedding_response([[3.0, 4.0]]),
+        ]
+        mock_client.models.embed_content = mock_embed
+
+        llm = GoogleGenerativeAIEmbeddings(
+            model=gemini_model,
+            google_api_key=SecretStr("test-key"),
+        )
+
+        result = llm.embed_documents(["test text", "test text2"])
+
+        # Should make 2 individual calls
+        assert mock_embed.call_count == 2
+        calls = mock_embed.call_args_list
+        assert calls[0].kwargs["model"] == gemini_model
+        assert calls[0].kwargs["contents"] == "test text"
+        assert calls[1].kwargs["model"] == gemini_model
+        assert calls[1].kwargs["contents"] == "test text2"
+
+        # Verify the merged result
+        assert result == [[1.0, 2.0], [3.0, 4.0]]
+
+
+@pytest.mark.asyncio
+async def test_aembed_documents_gemini_embedding_2() -> None:
+    """Test async embed_documents with gemini-embedding-2 which uses asyncio.gather."""
+    gemini_model = "gemini-embedding-2-preview"
+    with patch("langchain_google_genai.embeddings.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_embed = AsyncMock()
+        mock_embed.side_effect = [
+            _mock_embedding_response([[1.0, 2.0]]),
+            _mock_embedding_response([[3.0, 4.0]]),
+        ]
+        mock_client.aio.models.embed_content = mock_embed
+
+        llm = GoogleGenerativeAIEmbeddings(
+            model=gemini_model,
+            google_api_key=SecretStr("test-key"),
+        )
+
+        result = await llm.aembed_documents(["test text", "test text2"])
+
+        # Should make 2 individual calls
+        assert mock_embed.call_count == 2
+        calls = mock_embed.call_args_list
+        assert calls[0].kwargs["model"] == gemini_model
+        assert calls[0].kwargs["contents"] == "test text"
+        assert calls[1].kwargs["model"] == gemini_model
+        assert calls[1].kwargs["contents"] == "test text2"
+
+        # Verify the merged result
         assert result == [[1.0, 2.0], [3.0, 4.0]]


### PR DESCRIPTION
### Description
This Pull Request resolves a critical integration issue ([#37728](https://github.com/langchain-ai/langchain/issues/37728)) where calling `GoogleGenerativeAIEmbeddings.embed_documents` (or `aembed_documents`) with `gemini-embedding-2` always returns a list of exactly **1 vector**, regardless of how many documents are passed.

### Root Cause
Unlike traditional text embeddings (e.g., `text-embedding-004`), multimodal gemini-embedding models (such as `gemini-embedding-2`) treat list inputs in standard `embed_content` calls as parts of a **single aggregated multimodal document** (designed for cross-modal retrieval, combining text/images/video/etc.). Consequently, they return exactly one merged vector for the entire batch.

### Solution
1. **Parallelized Individual Embedding:** Checks if the target model is a `gemini-embedding` model. If so, it embeds each document individually in parallel to prevent aggregation:
   - Synchronous path uses a standard `ThreadPoolExecutor` for concurrent network requests.
   - Asynchronous path uses `asyncio.gather` for non-blocking concurrent awaits.
2. **Backward Compatibility:** Retains standard sequential/prepared batching for non-Gemini models (like `text-embedding-004`) to maximize network efficiency for those models.
3. **Comprehensive Unit Tests:** 
   - Updates legacy tests to use `text-embedding-004` to preserve test coverage of the traditional batching logic.
   - Adds new `test_embed_documents_gemini_embedding_2` and `test_aembed_documents_gemini_embedding_2` unit tests targeting `gemini-embedding-2-preview` to verify correct multi-call dispatching and output reconstruction.