### PR TITLE
fix(vertexai): recognize "adaptive" thinking in `_thinking_in_params`

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
@@ -640,7 +640,7 @@ def _tools_in_params(params: dict) -> bool:
 
 
 def _thinking_in_params(params: dict) -> bool:
-    return params.get("thinking", {}).get("type") == "enabled"
+    return params.get("thinking", {}).get("type") in ("enabled", "adaptive")
 
 
 def _documents_in_params(params: dict) -> bool:

--- a/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
@@ -958,6 +958,17 @@ def test_thinking_in_params_false_different_type() -> None:
     assert not _thinking_in_params(params)
 
 
+def test_thinking_in_params_adaptive() -> None:
+    """`adaptive` is Anthropic's recommended thinking mode for Claude 4.6+;
+    Claude Opus 4.7 supports it exclusively. `_thinking_in_params` must
+    treat it as thinking-enabled so callers (e.g. `_stream` / `_generate`
+    in `model_garden`) keep `coerce_content_to_string` set to `False` and
+    preserve the response's structured thinking blocks."""
+    params = {"thinking": {"type": "adaptive"}}
+
+    assert _thinking_in_params(params)
+
+
 def test_documents_in_params_true() -> None:
     """Test _documents_in_params when document with citations is enabled."""
     params = {


### PR DESCRIPTION
## Description

`_thinking_in_params` in [`libs/vertexai/langchain_google_vertexai/_anthropic_utils.py`](https://github.com/langchain-ai/langchain-google/blob/main/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py#L642) only matched `thinking.type == "enabled"`. When callers set `thinking.type = "adaptive"` — Anthropic's recommended thinking mode for Claude 4.6+, and the **only** mode supported by Claude Opus 4.7 — the helper returns `False`. In [`model_garden.py`](https://github.com/langchain-ai/langchain-google/blob/main/libs/vertexai/langchain_google_vertexai/model_garden.py#L474) (and the streaming counterpart at L520), that flips `coerce_content_to_string` to `True` for both `_generate` and `_stream`, so the response's structured thinking blocks get silently flattened to a plain string. Net effect: `ChatAnthropicVertex` cannot return thinking blocks for Claude Opus 4.7 at all.

The fix is to match `"adaptive"` alongside `"enabled"`:

```python
def _thinking_in_params(params: dict) -> bool:
    return params.get("thinking", {}).get("type") in ("enabled", "adaptive")
```

## Relevant issues

Fixes #1711

## Type

🐛 Bug Fix

## Changes

- `libs/vertexai/langchain_google_vertexai/_anthropic_utils.py`: accept both `"enabled"` and `"adaptive"`.
- `libs/vertexai/tests/unit_tests/test_anthropic_utils.py`: add `test_thinking_in_params_adaptive` next to the existing `enabled` / `disabled` cases.

## Testing

```
$ uv run pytest libs/vertexai/tests/unit_tests/test_anthropic_utils.py -k thinking_in_params -v
test_thinking_in_params_true                  PASSED
test_thinking_in_params_false_different_type  PASSED
test_thinking_in_params_adaptive              PASSED
3 passed in 11.90s
```

Reverting only the one-line `_anthropic_utils.py` change while keeping the new test makes that test fail with `AssertionError`, confirming the regression coverage pins the buggy behavior.

`ruff check` and `ruff format --check` pass on both files.

## Note

The fix is intentionally minimal — a tuple-membership check that mirrors what the issue reporter proposed. No behavior changes for callers using `"enabled"` or any other value.

_Disclaimer: this PR was prepared with the assistance of an AI agent (Claude Code). All code and test changes were reviewed by the author before submission._