### PR TITLE
fix(vertexai): preserve non-ASCII in tool-call arguments JSON

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -816,7 +816,8 @@ def _parse_response_candidate(
             # dump to match other function calling llm for now
             function_call_args_dict = proto.Message.to_dict(part.function_call)["args"]
             function_call["arguments"] = json.dumps(
-                {k: function_call_args_dict[k] for k in function_call_args_dict}
+                {k: function_call_args_dict[k] for k in function_call_args_dict},
+                ensure_ascii=False,
             )
             additional_kwargs["function_call"] = function_call
 

--- a/libs/vertexai/langchain_google_vertexai/model_garden_maas/llama.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden_maas/llama.py
@@ -293,7 +293,9 @@ class VertexModelGardenLlama(_BaseVertexMaasModelGarden, BaseChatModel):
                             "id": tool_call["id"],
                             "function": {
                                 "name": tool_call["name"],
-                                "arguments": json.dumps(tool_call.get("args", {})),
+                                "arguments": json.dumps(
+                                    tool_call.get("args", {}), ensure_ascii=False
+                                ),
                             },
                         }
                     )

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -1621,6 +1621,42 @@ def test_parse_response_candidate(raw_candidate, expected) -> None:
                 assert res_kw == exp_kw
 
 
+def test_parse_response_candidate_preserves_non_ascii_in_function_call_arguments() -> (
+    None
+):
+    """Tool-call args with non-ASCII text (CJK, emoji, etc.) must land in
+    `additional_kwargs["function_call"]["arguments"]` as raw UTF-8, not as
+    escaped `\\uXXXX` sequences.
+
+    Mirrors the langchain-google-genai regression that PR #1804 fixes:
+    the existing parametrized `test_parse_response_candidate` round-trips
+    arguments through `json.loads` for equality, so it is blind to the
+    encoding difference. The convention is already established in
+    `langchain-openai`'s chat model and `langchain-core`'s
+    `messages/utils.py:1810`.
+    """
+    candidate = Candidate(
+        content=Content(
+            role="model",
+            parts=[
+                Part(
+                    function_call=FunctionCall(
+                        name="echo",
+                        args={"text": "你好", "emoji": "🚀"},
+                    )
+                ),
+            ],
+        )
+    )
+    result = _parse_response_candidate(candidate)
+    arguments = result.additional_kwargs["function_call"]["arguments"]
+
+    assert "你好" in arguments
+    assert "🚀" in arguments
+    assert "\\u" not in arguments
+    assert json.loads(arguments) == {"text": "你好", "emoji": "🚀"}
+
+
 def test_parser_multiple_tools() -> None:
     """Test parsing of multiple function calls into Pydantic models.
 


### PR DESCRIPTION
## Description

Two sites in \`langchain-google-vertexai\` serialize tool-call arguments with bare \`json.dumps(...)\`. Python's \`json\` defaults to \`ensure_ascii=True\`, so every non-ASCII character is escaped to \`\uXXXX\`. CJK text, emoji, and accented characters in tool-call args end up unreadable in \`AIMessage.additional_kwargs["function_call"]["arguments"]\` (the \`_parse_response_candidate\` path used by \`ChatVertexAI\` / Gemini on Vertex) and in the OpenAI-style payload built for Llama Model Garden.

This mirrors the langchain-google-genai fix in [#1804](https://github.com/langchain-ai/langchain-google/pull/1804) (which addresses the same pattern on the genai side) and the convention already established in \`langchain-openai\`'s chat model and \`langchain-core\`'s [\`messages/utils.py:1810\`](https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/messages/utils.py#L1810).

## Relevant issues

None filed for the vertexai sites specifically; this is the vertexai analog of the langchain-google-genai issue #1789 / PR #1804.

## Type

🐛 Bug Fix

## Changes

- [\`libs/vertexai/langchain_google_vertexai/chat_models.py\`](https://github.com/langchain-ai/langchain-google/blob/main/libs/vertexai/langchain_google_vertexai/chat_models.py#L818): pass \`ensure_ascii=False\` to the \`json.dumps\` that produces \`function_call["arguments"]\` in \`_parse_response_candidate\`.
- [\`libs/vertexai/langchain_google_vertexai/model_garden_maas/llama.py\`](https://github.com/langchain-ai/langchain-google/blob/main/libs/vertexai/langchain_google_vertexai/model_garden_maas/llama.py#L296): pass \`ensure_ascii=False\` to the \`json.dumps\` that serializes tool-call args into the OpenAI-style payload.
- \`libs/vertexai/tests/unit_tests/test_chat_models.py\`: add \`test_parse_response_candidate_preserves_non_ascii_in_function_call_arguments\` asserting on the raw string. The existing parametrized \`test_parse_response_candidate\` round-trips arguments through \`json.loads\` for equality and so was blind to the encoding difference.

## Testing

\`\`\`
$ uv run pytest libs/vertexai/tests/unit_tests/test_chat_models.py -k parse_response_candidate -q
..............
14 passed, 96 deselected in 6.48s
\`\`\`

Reverting only the one-keyword \`chat_models.py\` change while keeping the new test makes the test fail (\`assert "你好" in '{"text": "\\\\u4f60\\\\u597d", ...}'\` → AssertionError), confirming the regression test pins the buggy behavior.

\`ruff check\` and \`ruff format --check\` pass on all three files.

## Note

The fix is intentionally minimal — a single keyword in each of two \`json.dumps\` calls. No behavior changes for callers reading \`tool_calls[i]["args"]\` (which already round-trips through \`parse_tool_calls\` and so has always been a clean dict). The change only affects the legacy \`additional_kwargs["function_call"]["arguments"]\` string and the OpenAI-style \`tool_calls[*].function.arguments\` field.

_Disclaimer: this PR was prepared with the assistance of an AI agent (Claude Code). All code and test changes were reviewed by the author before submission._