### PR TITLE
fix(vertexai): don't force tool_choice in structured output when thinking is on

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/model_garden.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Sequence
 from operator import itemgetter
 from typing import (
@@ -13,6 +14,7 @@ from langchain_core.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
 )
+from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import (
     BaseChatModel,
@@ -565,7 +567,31 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
     ) -> Runnable[LanguageModelInput, dict | BaseModel]:
         """Model wrapper that returns outputs formatted to match the given schema."""
         tool_name = convert_to_anthropic_tool(schema)["name"]
-        llm = self.bind_tools([schema], tool_choice=tool_name)
+        if _thinking_in_params(self.model_kwargs):
+            # The Anthropic API rejects requests that combine `thinking` with a
+            # forced `tool_choice` ("Thinking may not be enabled when
+            # tool_choice forces tool use."). Mirror the langchain-anthropic
+            # behavior: bind the tool without forcing tool_choice, warn the
+            # caller that the model is not guaranteed to call the tool, and
+            # raise an `OutputParserException` if it does not.
+            thinking_admonition = (
+                "You are attempting to use structured output via forced tool "
+                "calling, which is not guaranteed when `thinking` is enabled. "
+                "This method will raise an OutputParserException if tool "
+                "calls are not generated. Consider disabling `thinking` or "
+                "adjust your prompt to ensure the tool is called."
+            )
+            warnings.warn(thinking_admonition, stacklevel=2)
+            llm = self.bind_tools([schema])
+
+            def _raise_if_no_tool_calls(message: AIMessage) -> AIMessage:
+                if not message.tool_calls:
+                    raise OutputParserException(thinking_admonition)
+                return message
+
+            llm = llm | _raise_if_no_tool_calls
+        else:
+            llm = self.bind_tools([schema], tool_choice=tool_name)
         if isinstance(schema, type) and issubclass(schema, BaseModel):
             output_parser = ToolsOutputParser(
                 first_tool_only=True, pydantic_schemas=[schema]

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -443,6 +443,58 @@ def test_anthropic_profiles_smoke() -> None:
     assert "max_output_tokens" in sample
 
 
+def test_anthropic_vertex_structured_output_thinking_no_tool_choice() -> None:
+    """When `thinking` is enabled, the Anthropic API rejects forcing
+    `tool_choice` with `"Thinking may not be enabled when tool_choice forces
+    tool use."`. `with_structured_output` must avoid passing `tool_choice`
+    in that case, mirroring `langchain-anthropic`'s
+    `_get_llm_for_structured_output_when_thinking_is_enabled`."""
+
+    class Movie(BaseModel):
+        title: str
+        year: int
+
+    llm = ChatAnthropicVertex(
+        model_name="claude-sonnet-4-5",
+        project="test-project",
+        location="test-location",
+        model_kwargs={"thinking": {"type": "enabled", "budget_tokens": 1024}},
+    )
+
+    with patch.object(ChatAnthropicVertex, "bind_tools", autospec=True) as mock_bind:
+        mock_bind.return_value = MagicMock()
+        with pytest.warns(UserWarning, match="thinking"):
+            llm.with_structured_output(Movie)
+
+    mock_bind.assert_called_once()
+    # autospec passes the instance as the first positional arg
+    _, call_kwargs = mock_bind.call_args
+    assert call_kwargs.get("tool_choice") is None
+
+
+def test_anthropic_vertex_structured_output_no_thinking_forces_tool_choice() -> None:
+    """Sanity check that the non-thinking path is unchanged: `tool_choice` is
+    still forced to the schema's tool name when `thinking` is not enabled."""
+
+    class Movie(BaseModel):
+        title: str
+        year: int
+
+    llm = ChatAnthropicVertex(
+        model_name="claude-sonnet-4-5",
+        project="test-project",
+        location="test-location",
+    )
+
+    with patch.object(ChatAnthropicVertex, "bind_tools", autospec=True) as mock_bind:
+        mock_bind.return_value = MagicMock()
+        llm.with_structured_output(Movie)
+
+    mock_bind.assert_called_once()
+    _, call_kwargs = mock_bind.call_args
+    assert call_kwargs.get("tool_choice") == "Movie"
+
+
 def test_anthropic_vertex_profile_missing_max_output_tokens(
     monkeypatch: Any,
 ) -> None:


### PR DESCRIPTION
## Description

\`ChatAnthropicVertex.with_structured_output(...)\` at [\`libs/vertexai/langchain_google_vertexai/model_garden.py\`](https://github.com/langchain-ai/langchain-google/blob/main/libs/vertexai/langchain_google_vertexai/model_garden.py#L568) unconditionally calls \`self.bind_tools([schema], tool_choice=tool_name)\`. When the model is configured with \`thinking\` enabled, the Anthropic API rejects the request with:

\`\`\`
BadRequestError: 400 - Thinking may not be enabled when tool_choice forces tool use.
\`\`\`

This is exactly the scenario \`langchain-anthropic.ChatAnthropic.with_structured_output\` already handles in [\`_get_llm_for_structured_output_when_thinking_is_enabled\`](https://github.com/langchain-ai/langchain/blob/master/libs/partners/anthropic/langchain_anthropic/chat_models.py#L1779): bind the tool without \`tool_choice\`, warn the caller that the tool is not guaranteed to be called, and raise \`OutputParserException\` if no tool calls come back. This PR mirrors that behavior.

Detection uses \`_thinking_in_params(self.model_kwargs)\` so adaptive thinking is naturally covered once [#1820](https://github.com/langchain-ai/langchain-google/pull/1820) lands (which extends that helper to recognize \`\"adaptive\"\` in addition to \`\"enabled\"\`).

## Relevant issues

Fixes #1712

## Type

🐛 Bug Fix

## Changes

- \`libs/vertexai/langchain_google_vertexai/model_garden.py\`: branch in \`with_structured_output\` on \`_thinking_in_params(self.model_kwargs)\`. When thinking is on, bind without \`tool_choice\`, warn, and wrap the result with a post-check that raises \`OutputParserException\` if no tool calls are produced.
- \`libs/vertexai/tests/unit_tests/test_chat_models.py\`: add
  - \`test_anthropic_vertex_structured_output_thinking_no_tool_choice\`: when thinking is enabled, \`bind_tools\` is called *without* \`tool_choice\` and a warning is issued.
  - \`test_anthropic_vertex_structured_output_no_thinking_forces_tool_choice\`: sanity check that the non-thinking path still forces \`tool_choice=<schema_name>\` (no regression).

## Testing

\`\`\`
$ uv run pytest libs/vertexai/tests/unit_tests/test_chat_models.py -k anthropic_vertex -q
17 passed, 94 deselected in 8.31s
\`\`\`

Reverting only the \`model_garden.py\` change while keeping the new tests makes the thinking test fail (\`tool_choice\` still set, no warning), confirming the regression test pins the buggy behavior. \`ruff check\` and \`ruff format --check\` pass on both files.

## Note

This intentionally mirrors langchain-anthropic's pattern — same warning text shape, same post-check behavior — so users moving between \`ChatAnthropic\` and \`ChatAnthropicVertex\` see consistent semantics. The non-thinking code path is preserved verbatim, so no behavior changes for existing callers without \`thinking\` in \`model_kwargs\`.

_Disclaimer: this PR was prepared with the assistance of an AI agent (Claude Code). All code and test changes were reviewed by the author before submission._