### PR TITLE
fix(genai): merge per-request http options into chat config

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -182,6 +182,35 @@ def _base64_to_bytes(input_str: str) -> bytes:
     return base64.b64decode(input_str.encode("utf-8"))
 
 
+def _merge_http_options(base: HttpOptions | None, override: HttpOptions) -> HttpOptions:
+    """Merge a per-request `HttpOptions` over internally-derived options.
+
+    `timeout` and `retry_options` are derived internally (from the model config
+    or call-time `timeout`/`max_retries`); those are preserved unless the
+    per-request `override` explicitly sets them.
+    Any field explicitly set on `override` (e.g. `base_url`, `api_version`) wins,
+    and `headers` from both are merged with `override` keys taking precedence.
+
+    Args:
+        base: Options derived from the model config (`timeout`/`retry_options`),
+            or `None` when neither is set.
+        override: Per-request options supplied at invocation time.
+
+    Returns:
+        The merged `HttpOptions`.
+    """
+    if base is None:
+        return override
+    merged = base.model_copy(deep=True)
+    for field in override.model_fields_set:
+        value = getattr(override, field)
+        if field == "headers":
+            merged.headers = {**(merged.headers or {}), **(value or {})}
+        else:
+            setattr(merged, field, value)
+    return merged
+
+
 class ChatGoogleGenerativeAIError(GoogleGenerativeAIError):
     """Wrapper exception class for errors associated with the `Google GenAI` API.
 
@@ -3128,6 +3157,14 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     ) -> GenerateContentConfig:
         """Build the final request configuration."""
 
+        # Pop any per-request `http_options` so it can be merged with the
+        # internally-derived timeout/retry options below. Passing it through to
+        # `GenerateContentConfig` directly would collide with the explicit
+        # `http_options` keyword argument and raise a duplicate-keyword error.
+        per_request_http_options = kwargs.pop("http_options", None)
+        if isinstance(per_request_http_options, dict):
+            per_request_http_options = HttpOptions(**per_request_http_options)
+
         retry_options = None
         if max_retries is not None:
             retry_options = HttpRetryOptions(attempts=max_retries)
@@ -3138,6 +3175,9 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 timeout=timeout,
                 retry_options=retry_options,
             )
+
+        if per_request_http_options is not None:
+            http_options = _merge_http_options(http_options, per_request_http_options)
 
         image_config_dict = (
             image_config if image_config is not None else self.image_config

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -20,6 +20,8 @@ from google.genai.types import (
     FunctionResponse,
     GenerateContentResponse,
     GenerateContentResponseUsageMetadata,
+    HttpOptions,
+    HttpRetryOptions,
     Language,
     Part,
     ThinkingLevel,
@@ -61,6 +63,7 @@ from langchain_google_genai.chat_models import (
     _get_ai_message_tool_messages_parts,
     _is_gemini_3_or_later,
     _is_gemini_25_model,
+    _merge_http_options,
     _parse_chat_history,
     _parse_response_candidate,
     _response_to_result,
@@ -495,6 +498,191 @@ def test_additional_headers_support(headers: dict[str, str] | None) -> None:
     if headers:
         for key, value in headers.items():
             assert call_http_options.headers[key] == value
+
+
+def _mock_chat(**model_kwargs: Any) -> tuple[ChatGoogleGenerativeAI, Mock]:
+    """Build a `ChatGoogleGenerativeAI` whose client is mocked.
+
+    Returns the chat model and the `generate_content` mock so callers can
+    inspect the `config` forwarded to the API.
+    """
+    mock_client = Mock()
+    mock_models = Mock()
+    mock_generate_content = Mock(
+        return_value=GenerateContentResponse(
+            candidates=[Candidate(content=Content(parts=[Part(text="test response")]))],
+        )
+    )
+    mock_models.generate_content = mock_generate_content
+    mock_client.return_value.models = mock_models
+    with patch("langchain_google_genai.chat_models.Client", mock_client):
+        chat = ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            google_api_key=SecretStr(FAKE_API_KEY),
+            **model_kwargs,
+        )
+    return chat, mock_generate_content
+
+
+def test_per_request_http_options_dict_injects_headers() -> None:
+    """A per-invocation `http_options` dict reaches the request config."""
+    chat, mock_generate_content = _mock_chat()
+
+    chat.invoke(
+        "test",
+        http_options={"headers": {"Authorization": "Bearer token"}},
+    )
+
+    config = mock_generate_content.call_args.kwargs["config"]
+    assert config.http_options is not None
+    assert config.http_options.headers == {"Authorization": "Bearer token"}
+
+
+def test_per_request_http_options_object_injects_headers() -> None:
+    """A per-invocation `HttpOptions` object is accepted as well as a dict."""
+    chat, mock_generate_content = _mock_chat()
+
+    chat.invoke(
+        "test",
+        http_options=HttpOptions(headers={"Authorization": "Bearer token"}),
+    )
+
+    config = mock_generate_content.call_args.kwargs["config"]
+    assert config.http_options is not None
+    assert config.http_options.headers == {"Authorization": "Bearer token"}
+
+
+def test_per_request_http_options_preserves_model_timeout() -> None:
+    """Per-request headers merge without clobbering the model's timeout.
+
+    The `timeout` derived from the model config must survive when the
+    per-request `http_options` only sets headers (previously this collided and
+    raised a duplicate-keyword error).
+    """
+    chat, mock_generate_content = _mock_chat(timeout=30)
+
+    chat.invoke(
+        "test",
+        http_options={"headers": {"Authorization": "Bearer token"}},
+    )
+
+    http_options = mock_generate_content.call_args.kwargs["config"].http_options
+    assert http_options.headers == {"Authorization": "Bearer token"}
+    assert http_options.timeout == 30 * 1000  # seconds -> milliseconds
+
+
+def test_merge_http_options_precedence() -> None:
+    """Explicit per-request fields win; headers merge; base fields persist."""
+    base = HttpOptions(timeout=5000, base_url="https://internal")
+    override = HttpOptions(
+        base_url="https://gateway",
+        headers={"Authorization": "Bearer token"},
+    )
+
+    merged = _merge_http_options(base, override)
+
+    assert merged.base_url == "https://gateway"  # override wins
+    assert merged.timeout == 5000  # base persists (not set on override)
+    assert merged.headers == {"Authorization": "Bearer token"}
+
+
+def test_merge_http_options_merges_header_dicts() -> None:
+    """Headers from base and override combine, with override keys winning."""
+    base = HttpOptions(headers={"X-Base": "1", "X-Shared": "base"})
+    override = HttpOptions(headers={"X-Override": "2", "X-Shared": "override"})
+
+    merged = _merge_http_options(base, override)
+
+    assert merged.headers == {
+        "X-Base": "1",
+        "X-Override": "2",
+        "X-Shared": "override",
+    }
+
+
+def test_merge_http_options_preserves_nested_retry_model() -> None:
+    """Per-request `retry_options` remain SDK model objects after merging."""
+    override_retry_options = HttpRetryOptions(attempts=9)
+    base = HttpOptions(retry_options=HttpRetryOptions(attempts=3))
+    override = HttpOptions(retry_options=override_retry_options)
+
+    merged = _merge_http_options(base, override)
+
+    assert merged.retry_options is override_retry_options
+    assert merged.retry_options.attempts == 9
+
+
+async def test_per_request_http_options_async_injects_headers() -> None:
+    """Per-invocation `http_options` reaches the request config via `ainvoke`.
+
+    The async path threads kwargs through separate runnable plumbing than the
+    sync path, so it is verified independently.
+    """
+    with patch(
+        "langchain_google_genai.chat_models.ChatGoogleGenerativeAI.client", create=True
+    ):
+        llm = ChatGoogleGenerativeAI(
+            model=MODEL_NAME, google_api_key=SecretStr(FAKE_API_KEY)
+        )
+        mock_method = AsyncMock(
+            return_value=GenerateContentResponse(
+                candidates=[Candidate(content=Content(parts=[Part(text="ok")]))]
+            )
+        )
+        # `llm.client` is typed `Client | None`; treat the mock as `Any` so
+        # attribute assignment on the async path isn't flagged by mypy.
+        mock_client: Any = llm.client
+        mock_client.aio.models.generate_content = mock_method
+
+        await llm.ainvoke(
+            "test",
+            http_options={"headers": {"Authorization": "Bearer token"}},
+        )
+
+    config = mock_method.call_args.kwargs["config"]
+    assert config.http_options is not None
+    assert config.http_options.headers == {"Authorization": "Bearer token"}
+
+
+def test_per_request_http_options_preserves_model_retries() -> None:
+    """Per-request headers merge without clobbering the model's `retry_options`.
+
+    Mirrors the timeout case for the second half of the merge contract.
+    """
+    chat, mock_generate_content = _mock_chat(max_retries=3)
+
+    chat.invoke(
+        "test",
+        http_options={"headers": {"Authorization": "Bearer token"}},
+    )
+
+    http_options = mock_generate_content.call_args.kwargs["config"].http_options
+    assert http_options.headers == {"Authorization": "Bearer token"}
+    assert http_options.retry_options is not None
+    assert http_options.retry_options.attempts == 3
+
+
+def test_per_request_http_options_overrides_model_retries() -> None:
+    """Per-request `retry_options` win over the model-derived retry default."""
+    retry_options = HttpRetryOptions(attempts=9)
+    chat, mock_generate_content = _mock_chat(max_retries=3)
+
+    chat.invoke("test", http_options=HttpOptions(retry_options=retry_options))
+
+    http_options = mock_generate_content.call_args.kwargs["config"].http_options
+    assert http_options.retry_options is retry_options
+    assert http_options.retry_options.attempts == 9
+
+
+def test_per_request_http_options_overrides_model_timeout() -> None:
+    """An explicit per-request `timeout` wins over the model-derived one."""
+    chat, mock_generate_content = _mock_chat(timeout=30)
+
+    # `HttpOptions.timeout` is in milliseconds (native google-genai unit).
+    chat.invoke("test", http_options={"timeout": 99_000})
+
+    http_options = mock_generate_content.call_args.kwargs["config"].http_options
+    assert http_options.timeout == 99_000
 
 
 def test_base_url_set_in_constructor() -> None:


### PR DESCRIPTION
`ChatGoogleGenerativeAI` now accepts invocation-level `http_options` without conflicting with internally derived request config. Per-request options can add headers or override explicit fields while preserving model-level `timeout` and `max_retries` defaults unless the caller overrides them.

## Changes
- Added `_merge_http_options` to layer per-request `HttpOptions` over internally derived options, with header dictionaries merged and explicit override fields taking precedence.
- Updated `ChatGoogleGenerativeAI._build_request_config` to consume `http_options` from invocation kwargs before constructing `GenerateContentConfig`, avoiding duplicate `http_options` keyword collisions.
- Supported both dict-based and `HttpOptions` object inputs for per-request `http_options`.
- Preserved model-derived `timeout` and `retry_options` when per-request options only provide unrelated fields such as headers.