### PR TITLE
feat(genai): support multimodal file inputs and `display_name` in function responses

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -692,7 +692,9 @@ def _convert_tool_message_to_parts(
                 )
                 if display_name:
                     file_data.display_name = display_name
-                function_response_parts.append(FunctionResponsePart(file_data=file_data))
+                function_response_parts.append(
+                    FunctionResponsePart(file_data=file_data)
+                )
 
         response = other_blocks
 

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -672,7 +672,7 @@ def _convert_tool_message_to_parts(
                 media_blocks.append(block)
             else:
                 other_blocks.append(block)
-                
+
         base_parts = _convert_to_parts(media_blocks, model=model)
         for i, p in enumerate(base_parts):
             original_block = media_blocks[i]
@@ -699,7 +699,7 @@ def _convert_tool_message_to_parts(
                 )
                 if display_name:
                     function_response_parts[-1].file_data.display_name = display_name
-                    
+
         response = other_blocks
 
     elif not isinstance(message.content, str):
@@ -709,10 +709,10 @@ def _convert_tool_message_to_parts(
             response = json.loads(message.content)
         except json.JSONDecodeError:
             response = message.content  # leave as str representation
-            
+    response_dict = {"output": response} if not isinstance(response, dict) else response
     function_response_kwargs: dict[str, Any] = {
         "name": name,
-        "response": {"output": response} if not isinstance(response, dict) else response,
+        "response": response_dict,
     }
     if function_response_parts:
         function_response_kwargs["parts"] = function_response_parts

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -678,27 +678,21 @@ def _convert_tool_message_to_parts(
             original_block = media_blocks[i]
             display_name = original_block.get("display_name")
             if p.inline_data:
-                function_response_parts.append(
-                    FunctionResponsePart(
-                        inline_data=FunctionResponseBlob(
-                            data=p.inline_data.data,
-                            mime_type=p.inline_data.mime_type,
-                        )
-                    )
+                blob = FunctionResponseBlob(
+                    data=p.inline_data.data,
+                    mime_type=p.inline_data.mime_type,
                 )
                 if display_name:
-                    function_response_parts[-1].inline_data.display_name = display_name
+                    blob.display_name = display_name
+                function_response_parts.append(FunctionResponsePart(inline_data=blob))
             elif p.file_data:
-                function_response_parts.append(
-                    FunctionResponsePart(
-                        file_data=FunctionResponseFileData(
-                            file_uri=p.file_data.file_uri,
-                            mime_type=p.file_data.mime_type,
-                        )
-                    )
+                file_data = FunctionResponseFileData(
+                    file_uri=p.file_data.file_uri,
+                    mime_type=p.file_data.mime_type,
                 )
                 if display_name:
-                    function_response_parts[-1].file_data.display_name = display_name
+                    file_data.display_name = display_name
+                function_response_parts.append(FunctionResponsePart(file_data=file_data))
 
         response = other_blocks
 

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -33,6 +33,9 @@ from google.genai.types import (
     FunctionCall,
     FunctionDeclaration,
     FunctionResponse,
+    FunctionResponseBlob,
+    FunctionResponseFileData,
+    FunctionResponsePart,
     GenerateContentConfig,
     GenerateContentResponse,
     GenerationConfig,
@@ -656,17 +659,47 @@ def _convert_tool_message_to_parts(
     name = message.name or name or message.additional_kwargs.get("name")
     response: Any
     parts: list[Part] = []
+    function_response_parts: list[FunctionResponsePart] = []
     if isinstance(message.content, list):
         media_blocks = []
         other_blocks = []
         for block in message.content:
             if isinstance(block, dict) and (
-                is_data_content_block(block) or is_openai_data_block(block)
+                is_data_content_block(block)
+                or is_openai_data_block(block)
+                or block.get("type") in ("media", "file", "image_url")
             ):
                 media_blocks.append(block)
             else:
                 other_blocks.append(block)
-        parts.extend(_convert_to_parts(media_blocks, model=model))
+                
+        base_parts = _convert_to_parts(media_blocks, model=model)
+        for i, p in enumerate(base_parts):
+            original_block = media_blocks[i]
+            display_name = original_block.get("display_name")
+            if p.inline_data:
+                function_response_parts.append(
+                    FunctionResponsePart(
+                        inline_data=FunctionResponseBlob(
+                            data=p.inline_data.data,
+                            mime_type=p.inline_data.mime_type,
+                        )
+                    )
+                )
+                if display_name:
+                    function_response_parts[-1].inline_data.display_name = display_name
+            elif p.file_data:
+                function_response_parts.append(
+                    FunctionResponsePart(
+                        file_data=FunctionResponseFileData(
+                            file_uri=p.file_data.file_uri,
+                            mime_type=p.file_data.mime_type,
+                        )
+                    )
+                )
+                if display_name:
+                    function_response_parts[-1].file_data.display_name = display_name
+                    
         response = other_blocks
 
     elif not isinstance(message.content, str):
@@ -676,14 +709,15 @@ def _convert_tool_message_to_parts(
             response = json.loads(message.content)
         except json.JSONDecodeError:
             response = message.content  # leave as str representation
-    part = Part(
-        function_response=FunctionResponse(
-            name=name,
-            response=(
-                {"output": response} if not isinstance(response, dict) else response
-            ),
-        )
-    )
+            
+    function_response_kwargs: dict[str, Any] = {
+        "name": name,
+        "response": {"output": response} if not isinstance(response, dict) else response,
+    }
+    if function_response_parts:
+        function_response_kwargs["parts"] = function_response_parts
+
+    part = Part(function_response=FunctionResponse(**function_response_kwargs))
     parts.append(part)
     return parts
 

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -33,6 +33,9 @@ from google.genai.types import (
     FunctionCall,
     FunctionDeclaration,
     FunctionResponse,
+    FunctionResponseBlob,
+    FunctionResponseFileData,
+    FunctionResponsePart,
     GenerateContentConfig,
     GenerateContentResponse,
     GenerationConfig,
@@ -686,17 +689,69 @@ def _convert_tool_message_to_parts(
     name = message.name or name or message.additional_kwargs.get("name")
     response: Any
     parts: list[Part] = []
+    function_response_parts: list[FunctionResponsePart] = []
     if isinstance(message.content, list):
         media_blocks = []
         other_blocks = []
         for block in message.content:
-            if isinstance(block, dict) and (
-                is_data_content_block(block) or is_openai_data_block(block)
-            ):
+            is_media = isinstance(block, dict) and (
+                is_data_content_block(block)
+                or is_openai_data_block(block)
+                or block.get("type") in ("media", "image_url")
+                or (
+                    block.get("type") == "file"
+                    and any(
+                        k in block
+                        for k in ("file_uri", "file_id", "data", "url", "base64")
+                    )
+                )
+            )
+            if is_media:
                 media_blocks.append(block)
             else:
                 other_blocks.append(block)
-        parts.extend(_convert_to_parts(media_blocks, model=model))
+
+        base_parts = _convert_to_parts(media_blocks, model=model)
+        for i, p in enumerate(base_parts):
+            original_block = media_blocks[i]
+            display_name = (
+                original_block.get("display_name")
+                if isinstance(original_block, dict)
+                else None
+            )
+            dropped_metadata = []
+            if getattr(p, "video_metadata", None) is not None:
+                dropped_metadata.append("video_metadata")
+            if getattr(p, "media_resolution", None) is not None:
+                dropped_metadata.append("media_resolution")
+            if getattr(p, "thought_signature", None) is not None:
+                dropped_metadata.append("thought_signature")
+            if dropped_metadata:
+                warnings.warn(
+                    f"Part-level metadata {dropped_metadata} on media block is not "
+                    "supported in FunctionResponsePart and was omitted.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            if p.inline_data:
+                blob = FunctionResponseBlob(
+                    data=p.inline_data.data,
+                    mime_type=p.inline_data.mime_type,
+                )
+                if display_name:
+                    blob.display_name = display_name
+                function_response_parts.append(FunctionResponsePart(inline_data=blob))
+            elif p.file_data:
+                file_data = FunctionResponseFileData(
+                    file_uri=p.file_data.file_uri,
+                    mime_type=p.file_data.mime_type,
+                )
+                if display_name:
+                    file_data.display_name = display_name
+                function_response_parts.append(
+                    FunctionResponsePart(file_data=file_data)
+                )
+
         response = other_blocks
 
     elif not isinstance(message.content, str):
@@ -706,14 +761,15 @@ def _convert_tool_message_to_parts(
             response = json.loads(message.content)
         except json.JSONDecodeError:
             response = message.content  # leave as str representation
-    part = Part(
-        function_response=FunctionResponse(
-            name=name,
-            response=(
-                {"output": response} if not isinstance(response, dict) else response
-            ),
-        )
-    )
+    response_dict = {"output": response} if not isinstance(response, dict) else response
+    function_response_kwargs: dict[str, Any] = {
+        "name": name,
+        "response": response_dict,
+    }
+    if function_response_parts:
+        function_response_kwargs["parts"] = function_response_parts
+
+    part = Part(function_response=FunctionResponse(**function_response_kwargs))
     parts.append(part)
     return parts
 

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3623,13 +3623,38 @@ def test_convert_tool_message_to_parts_list_content_with_media() -> None:
         tool_call_id="123",
     )
     result = _convert_tool_message_to_parts(message)
-    assert len(result) == 2
-    # First part should be the media (image)
-    assert result[0].inline_data is not None
-    # Second part should be the function response
-    assert result[1].function_response is not None
-    assert result[1].function_response.name == "test_tool"
-    assert result[1].function_response.response == {"output": ["Text response"]}
+    assert len(result) == 1
+    # Function response should contain parts with media
+    assert result[0].function_response is not None
+    assert result[0].function_response.name == "test_tool"
+    assert result[0].function_response.response == {"output": ["Text response"]}
+    assert result[0].function_response.parts is not None
+    assert len(result[0].function_response.parts) == 1
+    assert result[0].function_response.parts[0].inline_data is not None
+
+
+def test_convert_tool_message_to_parts_with_display_name() -> None:
+    """Test `_convert_tool_message_to_parts` preserves `display_name`."""
+    message = ToolMessage(
+        name="test_tool",
+        content=[
+            {
+                "type": "media",
+                "mime_type": "application/pdf",
+                "file_uri": "gs://bucket/file.pdf",
+                "display_name": "My Document",
+            },
+        ],
+        tool_call_id="123",
+    )
+    result = _convert_tool_message_to_parts(message)
+    assert len(result) == 1
+    assert result[0].function_response is not None
+    assert result[0].function_response.parts is not None
+    assert len(result[0].function_response.parts) == 1
+    assert result[0].function_response.parts[0].file_data is not None
+    assert result[0].function_response.parts[0].file_data.file_uri == "gs://bucket/file.pdf"
+    assert result[0].function_response.parts[0].file_data.display_name == "My Document"
 
 
 def test_convert_tool_message_to_parts_with_name_parameter() -> None:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3653,7 +3653,10 @@ def test_convert_tool_message_to_parts_with_display_name() -> None:
     assert result[0].function_response.parts is not None
     assert len(result[0].function_response.parts) == 1
     assert result[0].function_response.parts[0].file_data is not None
-    assert result[0].function_response.parts[0].file_data.file_uri == "gs://bucket/file.pdf"
+    assert (
+        result[0].function_response.parts[0].file_data.file_uri
+        == "gs://bucket/file.pdf"
+    )
     assert result[0].function_response.parts[0].file_data.display_name == "My Document"
 
 

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3767,13 +3767,133 @@ def test_convert_tool_message_to_parts_list_content_with_media() -> None:
         tool_call_id="123",
     )
     result = _convert_tool_message_to_parts(message)
-    assert len(result) == 2
-    # First part should be the media (image)
-    assert result[0].inline_data is not None
-    # Second part should be the function response
-    assert result[1].function_response is not None
-    assert result[1].function_response.name == "test_tool"
-    assert result[1].function_response.response == {"output": ["Text response"]}
+    assert len(result) == 1
+    # Function response should contain parts with media
+    assert result[0].function_response is not None
+    assert result[0].function_response.name == "test_tool"
+    assert result[0].function_response.response == {"output": ["Text response"]}
+    assert result[0].function_response.parts is not None
+    assert len(result[0].function_response.parts) == 1
+    assert result[0].function_response.parts[0].inline_data is not None
+
+
+def test_convert_tool_message_to_parts_with_display_name() -> None:
+    """Test `_convert_tool_message_to_parts` preserves `display_name`."""
+    message = ToolMessage(
+        name="test_tool",
+        content=[
+            {
+                "type": "media",
+                "mime_type": "application/pdf",
+                "file_uri": "gs://bucket/file.pdf",
+                "display_name": "My Document",
+            },
+        ],
+        tool_call_id="123",
+    )
+    result = _convert_tool_message_to_parts(message)
+    assert len(result) == 1
+    assert result[0].function_response is not None
+    assert result[0].function_response.parts is not None
+    assert len(result[0].function_response.parts) == 1
+    assert result[0].function_response.parts[0].file_data is not None
+    assert (
+        result[0].function_response.parts[0].file_data.file_uri
+        == "gs://bucket/file.pdf"
+    )
+    assert result[0].function_response.parts[0].file_data.display_name == "My Document"
+
+
+def test_convert_tool_message_to_parts_inline_data_with_display_name() -> None:
+    """Test `_convert_tool_message_to_parts` preserves `display_name` on inline_data."""
+    img_url = (
+        "data:image/png;base64,"
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    )
+    message = ToolMessage(
+        name="test_tool",
+        content=[
+            {
+                "type": "image_url",
+                "image_url": {"url": img_url},
+                "display_name": "Inline Image",
+            },
+        ],
+        tool_call_id="123",
+    )
+    result = _convert_tool_message_to_parts(message)
+    assert len(result) == 1
+    assert result[0].function_response is not None
+    assert result[0].function_response.parts is not None
+    assert len(result[0].function_response.parts) == 1
+    assert result[0].function_response.parts[0].inline_data is not None
+    assert (
+        result[0].function_response.parts[0].inline_data.display_name == "Inline Image"
+    )
+
+
+def test_convert_tool_message_to_parts_multiple_media_blocks_ordering() -> None:
+    """Test `_convert_tool_message_to_parts` preserves 1:1 order
+    for multiple media blocks.
+    """
+    img_url = (
+        "data:image/png;base64,"
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    )
+    message = ToolMessage(
+        name="test_tool",
+        content=[
+            {
+                "type": "image_url",
+                "image_url": {"url": img_url},
+                "display_name": "Image 1",
+            },
+            {
+                "type": "media",
+                "mime_type": "application/pdf",
+                "file_uri": "gs://bucket/file2.pdf",
+                "display_name": "File 2",
+            },
+        ],
+        tool_call_id="123",
+    )
+    result = _convert_tool_message_to_parts(message)
+    assert len(result) == 1
+    assert result[0].function_response is not None
+    assert result[0].function_response.parts is not None
+    assert len(result[0].function_response.parts) == 2
+    assert result[0].function_response.parts[0].inline_data is not None
+    assert result[0].function_response.parts[0].inline_data.display_name == "Image 1"
+    assert result[0].function_response.parts[1].file_data is not None
+    assert result[0].function_response.parts[1].file_data.display_name == "File 2"
+
+
+def test_convert_tool_message_to_parts_structured_tool_output_file_type() -> None:
+    """Test structured tool output containing type='file' is not
+    misclassified as media.
+    """
+    message = ToolMessage(
+        name="test_tool",
+        content=[
+            {
+                "type": "file",
+                "path": "/docs/paper.pdf",
+                "status": "success",
+            },
+        ],
+        tool_call_id="123",
+    )
+    result = _convert_tool_message_to_parts(message)
+    assert len(result) == 1
+    assert result[0].function_response is not None
+    # Structured output remains in output without throwing or creating media parts
+    assert (
+        result[0].function_response.parts is None
+        or len(result[0].function_response.parts) == 0
+    )
+    assert result[0].function_response.response == {
+        "output": [{"type": "file", "path": "/docs/paper.pdf", "status": "success"}]
+    }
 
 
 def test_convert_tool_message_to_parts_with_name_parameter() -> None:


### PR DESCRIPTION
### Description
This PR resolves the issue where multimodal files were disconnected from the `FunctionResponse` and stripped of their metadata. It updates `_convert_tool_message_to_parts` to accurately parse `file`, `media`, and `image_url` blocks from a `ToolMessage` and maps them into `FunctionResponsePart` objects. 

By natively integrating `FunctionResponseFileData` and `FunctionResponseBlob` from the `google-genai` SDK, this strictly maintains data associations and preserves the `display_name`, ensuring the Gemini API can successfully distinguish between multiple files generated by a single tool call.

### Testing
- Updated `test_convert_tool_message_to_parts_list_content_with_media` to assert the correct bundled `Part` structure.
- Added `test_convert_tool_message_to_parts_with_display_name` to explicitly verify `display_name` metadata preservation.
- Verified all 230 PyTest unit tests pass successfully.

---
Sir, if anything misses out, please let me know and I will fix it according to your expectation. Thank you so much for looking into it!