### PR TITLE
feat(genai): add support for thought_signature in image content blocks

### DIFF
--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -183,6 +183,14 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                         else base64,
                     }
                 }
+                # Preserve thought_signature when present in extras for Google
+                if (
+                    model_provider == "google_genai"
+                    and "extras" in block_dict
+                    and isinstance(block_dict["extras"], dict)
+                    and "signature" in block_dict["extras"]
+                ):
+                    new_block["thought_signature"] = block_dict["extras"]["signature"]
                 new_content.append(new_block)
             elif (url := block_dict.get("url")) and model_provider == "google_genai":
                 # Google file service
@@ -192,6 +200,13 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                         "file_uri": url,
                     }
                 }
+                # Preserve thought_signature when present in extras for Google
+                if (
+                    "extras" in block_dict
+                    and isinstance(block_dict["extras"], dict)
+                    and "signature" in block_dict["extras"]
+                ):
+                    new_block["thought_signature"] = block_dict["extras"]["signature"]
                 new_content.append(new_block)
 
         # TODO: AudioContentBlock -> audio once models support passing back in

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -432,7 +432,7 @@ def _convert_to_parts(
                             thought_signature = sig
 
                         if thought_signature:
-                            pass
+                            part_kwargs["thought_signature"] = thought_signature
 
                     parts.append(Part(**part_kwargs))
                 elif part["type"] == "image_url":

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -2794,6 +2794,79 @@ def test_compat_image_url_block_non_google_provider() -> None:
     assert result == []
 
 
+def test_image_file_uri_signature_roundtrip_via_content_blocks() -> None:
+    """Roundtrip an image file URI thought signature through content_blocks and back."""
+    sig_b64 = "roundtrip-fileuri-signature"
+
+    block = {
+        "type": "image",
+        "url": "https://example.com/image.png",
+        "mime_type": "image/png",
+        "extras": {"signature": sig_b64},
+    }
+
+    msg = AIMessage(content=[block])
+    blocks = msg.content_blocks
+
+    assert isinstance(blocks, list)
+    assert len(blocks) == 1
+    image_block = blocks[0]
+    assert image_block["type"] == "image"
+    assert image_block["url"] == "https://example.com/image.png"
+    assert image_block["mime_type"] == "image/png"
+    assert "extras" in image_block and image_block["extras"].get("signature") == sig_b64
+
+    converted = _convert_from_v1_to_generativelanguage_v1beta(blocks, "google_genai")
+    assert isinstance(converted, list)
+    assert len(converted) == 1
+    assert "file_data" in converted[0]
+    assert converted[0]["file_data"]["file_uri"] == "https://example.com/image.png"
+    assert converted[0]["file_data"]["mime_type"] == "image/png"
+    assert converted[0].get("thought_signature") == sig_b64
+
+
+def test_image_signature_roundtrip_via_content_blocks() -> None:
+    """Roundtrip an image thought signature through content_blocks and back.
+
+    This verifies that a parsed image part with a thought_signature is exposed
+    via AIMessage.content_blocks and then converted back to Google GenAI format
+    with the same signature preserved.
+    """
+    sig = b"roundtrip-signature"
+    sig_b64 = base64.b64encode(sig).decode("ascii")
+
+    png_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA"
+        "60e6kgAAAABJRU5ErkJggg=="
+    )
+    png_bytes = base64.b64decode(png_b64)
+
+    part = Part(
+        inline_data=Blob(mime_type="image/png", data=png_bytes),
+        thought_signature=sig,
+    )
+    candidate = Candidate(content=Content(parts=[part]))
+
+    message = _parse_response_candidate(candidate, streaming=False)
+    assert isinstance(message, AIMessage)
+    assert message.response_metadata.get("model_provider") == "google_genai"
+
+    blocks = message.content_blocks
+    assert isinstance(blocks, list)
+    assert len(blocks) == 1
+    image_block = blocks[0]
+    assert image_block["type"] == "image"
+    assert image_block["mime_type"] == "image/png"
+    assert image_block["base64"] == png_b64
+    assert "extras" in image_block and image_block["extras"].get("signature") == sig_b64
+
+    converted = _convert_from_v1_to_generativelanguage_v1beta(blocks, "google_genai")
+    assert isinstance(converted, list)
+    assert len(converted) == 1
+    assert converted[0].get("thought_signature") == sig_b64
+    assert "inline_data" in converted[0]
+
+
 def test_thought_signature_extraction_from_response() -> None:
     """Test thought signature extraction from API response Parts."""
 
@@ -3434,6 +3507,46 @@ def test_convert_to_parts_thinking() -> None:
     assert len(result) == 1
     assert result[0].text == "I need to think about this..."
     assert result[0].thought is True
+
+
+def test_convert_to_parts_image_base64_thought_signature() -> None:
+    """_convert_to_parts passes thought_signature from extras into the Part."""
+    sig = b"test-signature-bytes"
+    sig_b64 = base64.b64encode(sig).decode("ascii")
+    png_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA"
+        "60e6kgAAAABJRU5ErkJggg=="
+    )
+    content = [
+        {
+            "type": "image",
+            "base64": png_b64,
+            "mime_type": "image/png",
+            "extras": {"signature": sig_b64},
+        }
+    ]
+    result = _convert_to_parts(content)
+    assert len(result) == 1
+    assert result[0].inline_data is not None
+    assert result[0].inline_data.mime_type == "image/png"
+    assert result[0].thought_signature == sig
+
+
+def test_convert_to_parts_image_url_thought_signature() -> None:
+    """_convert_to_parts passes thought_signature from extras on image_url blocks."""
+    sig = b"url-sig-bytes"
+    sig_b64 = base64.b64encode(sig).decode("ascii")
+    content = [
+        {
+            "type": "image_url",
+            "image_url": {"url": SMALL_VIEWABLE_BASE64_IMAGE},
+            "extras": {"signature": sig_b64},
+        }
+    ]
+    result = _convert_to_parts(content)
+    assert len(result) == 1
+    assert result[0].inline_data is not None
+    assert result[0].thought_signature == sig
 
 
 def test_convert_to_parts_mixed_content() -> None:


### PR DESCRIPTION
<!--
# Thank you for contributing to LangChain-google!
-->

<!--
## Checklist for PR Creation

- [ ] PR Title: "<type>[optional scope]: <description>"

  - Where type is one of: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, release
  - Scope is used to specifiy the package targeted. Options are: genai, vertex, community, infra (repo-level)

- [ ] PR Description and Relevant issues:

  - Description of the change
  - Relevant issues (if applicable)
  - Any dependencies required for this change

- [ ] Add Tests and Docs:

  - If adding a new integration:
    1. Include a test for the integration (preferably unit tests that do not rely on network access)
    2. Add an example notebook showing its use (place in the `docs/docs/integrations` directory)

- [ ] Lint and Test:
  - Run `make format`, `make lint`, and `make test` from the root of the package(s) you've modified
  - See contribution guidelines for more: https://github.com/langchain-ai/langchain-google/blob/main/README.md#contribute-code
-->

<!--
## Additional guidelines

- [ ] PR title and description are appropriate
- [ ] Necessary tests and documentation have been added
- [ ] Lint and tests pass successfully
- [ ] The following additional guidelines are adhered to:
  - Optional dependencies are imported within functions
  - No unnecessary dependencies added to pyproject.toml files (except those required for unit tests)
  - PR doesn't touch more than one package
  - Changes are backwards compatible
-->

## Description

Gemini image generation models return a thought_signature alongside generated images. This signature must be sent back in subsequent requests for multi-turn image refinement — without it, the API rejects the request with INVALID_ARGUMENT: Image part is missing a thought_signature.

Two bugs prevented this from working:

1. thought_signature on image Parts was not exposed through AIMessage.content_blocks (it was being dropped during parsing)
2. Even when extras.signature was present on a content block, _convert_to_parts had a pass stub instead of actually setting thought_signature on the outgoing Part

Both paths are now fixed: inline base64 images and file URI images correctly round-trip their thought_signature through content_blocks.

## Relevant issues

#1837

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes(optional)

- _compat.py: preserve thought_signature from extras.signature when converting content blocks back to Google GenAI format (both inline inline_data and file_data paths)
- chat_models.py: wire thought_signature into Part kwargs for image blocks (was a pass stub)
- Tests: roundtrip tests via content_blocks for both base64 and file URI image blocks; direct _convert_to_parts unit tests for both image block types

## Testing(optional)

New unit tests in tests/unit_tests/test_chat_models.py:

- test_image_signature_roundtrip_via_content_blocks
- test_image_file_uri_signature_roundtrip_via_content_blocks
- test_convert_to_parts_image_base64_thought_signature
- test_convert_to_parts_image_url_thought_signature
Integration tested manually against gemini-3-pro-image using the repro script from the issue — Turn 2 now succeeds.

## Note(optional)

The issue also mentions skip_thought_signature_validator as a fallback. This PR does not add that — if the signature is present in content_blocks, it will be sent; if not (e.g. older messages), the caller is responsible. Addressing the validator flag is a separate concern.

> AI involvement: This PR was developed with the assistance of Claude Code (Anthropic).
