### PR TITLE
feat(genai,vertexai): add package version metadata

### DIFF
--- a/libs/genai/langchain_google_genai/__init__.py
+++ b/libs/genai/langchain_google_genai/__init__.py
@@ -44,6 +44,7 @@ from langchain_google_genai._enums import (
     MediaResolution,
     Modality,
 )
+from langchain_google_genai._version import __version__
 from langchain_google_genai.chat_models import ChatGoogleGenerativeAI
 from langchain_google_genai.embeddings import GoogleGenerativeAIEmbeddings
 from langchain_google_genai.llms import GoogleGenerativeAI
@@ -59,5 +60,6 @@ __all__ = [
     "HarmCategory",
     "MediaResolution",
     "Modality",
+    "__version__",
     "create_context_cache",
 ]

--- a/libs/genai/langchain_google_genai/__init__.py
+++ b/libs/genai/langchain_google_genai/__init__.py
@@ -60,5 +60,6 @@ __all__ = [
     "HarmCategory",
     "MediaResolution",
     "Modality",
+    "__version__",
     "create_context_cache",
 ]

--- a/libs/genai/langchain_google_genai/__init__.py
+++ b/libs/genai/langchain_google_genai/__init__.py
@@ -60,6 +60,5 @@ __all__ = [
     "HarmCategory",
     "MediaResolution",
     "Modality",
-    "__version__",
     "create_context_cache",
 ]

--- a/libs/genai/langchain_google_genai/_version.py
+++ b/libs/genai/langchain_google_genai/_version.py
@@ -1,0 +1,8 @@
+"""Package version for `langchain-google-genai`."""
+
+from importlib import metadata
+
+try:
+    __version__ = metadata.version(__package__)
+except metadata.PackageNotFoundError:
+    __version__ = ""

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -121,6 +121,7 @@ from langchain_google_genai._image_utils import (
     ImageBytesLoader,
     image_bytes_to_b64_string,
 )
+from langchain_google_genai._version import __version__
 from langchain_google_genai.data._profiles import _PROFILES
 
 logger = logging.getLogger(__name__)
@@ -2464,6 +2465,12 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         """
         all_required_field_names = get_pydantic_field_names(cls)
         return _build_model_kwargs(values, all_required_field_names)
+
+    @model_validator(mode="after")
+    def _set_langchain_google_genai_version(self) -> Self:
+        """Set package version in metadata."""
+        self._add_version("langchain-google-genai", __version__)
+        return self
 
     @model_validator(mode="after")
     def validate_environment(self) -> Self:

--- a/libs/genai/langchain_google_genai/llms.py
+++ b/libs/genai/langchain_google_genai/llms.py
@@ -18,6 +18,7 @@ from typing_extensions import Self
 from langchain_google_genai._common import (
     _BaseGoogleGenerativeAI,
 )
+from langchain_google_genai._version import __version__
 from langchain_google_genai.chat_models import ChatGoogleGenerativeAI
 
 logger = logging.getLogger(__name__)
@@ -62,6 +63,12 @@ class GoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseLLM):
                     f"provided to GoogleGenerativeAI.{suggestion}"
                 )
         super().__init__(**kwargs)
+
+    @model_validator(mode="after")
+    def _set_langchain_google_genai_version(self) -> Self:
+        """Set package version in metadata."""
+        self._add_version("langchain-google-genai", __version__)
+        return self
 
     @model_validator(mode="after")
     def validate_environment(self) -> Self:

--- a/libs/genai/pyproject.toml
+++ b/libs/genai/pyproject.toml
@@ -12,7 +12,7 @@ authors = []
 version = "4.2.5"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.4,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "google-genai>=1.65.0,<3.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "filetype>=1.2.0,<2.0.0",

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -99,6 +99,7 @@ def test_integration_initialization() -> None:
         "ls_model_type": "chat",
         "ls_temperature": 0.7,
     }
+    assert llm.metadata is not None
     assert llm.metadata["lc_versions"]["langchain-google-genai"] == __version__
 
     # Ensure temperature is propagated to request config

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -50,7 +50,12 @@ from langchain_core.outputs import ChatGeneration, ChatResult
 from pydantic import BaseModel, Field, SecretStr
 from pydantic_core._pydantic_core import ValidationError
 
-from langchain_google_genai import HarmBlockThreshold, HarmCategory, Modality
+from langchain_google_genai import (
+    HarmBlockThreshold,
+    HarmCategory,
+    Modality,
+    __version__,
+)
 from langchain_google_genai._compat import (
     _convert_from_v1_to_generativelanguage_v1beta,
 )
@@ -94,6 +99,7 @@ def test_integration_initialization() -> None:
         "ls_model_type": "chat",
         "ls_temperature": 0.7,
     }
+    assert llm.metadata["lc_versions"]["langchain-google-genai"] == __version__
 
     # Ensure temperature is propagated to request config
     msg = HumanMessage(content="test")

--- a/libs/genai/tests/unit_tests/test_imports.py
+++ b/libs/genai/tests/unit_tests/test_imports.py
@@ -10,6 +10,7 @@ EXPECTED_ALL = [
     "HarmCategory",
     "MediaResolution",
     "Modality",
+    "__version__",
     "create_context_cache",
 ]
 

--- a/libs/genai/tests/unit_tests/test_llms.py
+++ b/libs/genai/tests/unit_tests/test_llms.py
@@ -24,6 +24,7 @@ def test_tracing_params() -> None:
         "ls_model_name": MODEL_NAME,
         "ls_temperature": 0.7,
     }
+    assert llm.metadata is not None
     assert llm.metadata["lc_versions"]["langchain-google-genai"] == __version__
 
     llm = GoogleGenerativeAI(

--- a/libs/genai/tests/unit_tests/test_llms.py
+++ b/libs/genai/tests/unit_tests/test_llms.py
@@ -8,6 +8,7 @@ from google.genai.types import (
 )
 from pydantic import SecretStr
 
+from langchain_google_genai import __version__
 from langchain_google_genai.llms import GoogleGenerativeAI
 
 MODEL_NAME = "gemini-2.5-flash"
@@ -23,6 +24,7 @@ def test_tracing_params() -> None:
         "ls_model_name": MODEL_NAME,
         "ls_temperature": 0.7,
     }
+    assert llm.metadata["lc_versions"]["langchain-google-genai"] == __version__
 
     llm = GoogleGenerativeAI(
         model=MODEL_NAME,

--- a/libs/genai/uv.lock
+++ b/libs/genai/uv.lock
@@ -459,7 +459,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.4"
+version = "1.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -472,9 +472,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/76/bbae1ed44a1362504d2b8a11a947890aeee7075b6e0649235de9d150d982/langchain_core-1.4.4.tar.gz", hash = "sha256:30409ffa24da1dd984a4164c4266dc8079e5379e41cb36d00356130e80be0405", size = 937710, upload-time = "2026-06-10T21:24:02.904Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/2b/fffaff399d20a56d40b9562fa19701e91abd72d8c9d9bc8c2673077b56b6/langchain_core-1.4.7.tar.gz", hash = "sha256:7a825d77de0a3f39adbd9d09612a75e85527e14a52c1601089bcc062972d9f2b", size = 952522, upload-time = "2026-06-12T19:23:57.588Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/1f/1c8b89b116ae979af829c2e0f4cde984fd674dc0fa58ee5e69c0af1d3606/langchain_core-1.4.4-py3-none-any.whl", hash = "sha256:36c2eb73e67bfab28455016f7a4044ffde4343485b8dad104a2b194ff21319d2", size = 551732, upload-time = "2026-06-10T21:24:01.765Z" },
+    { url = "https://files.pythonhosted.org/packages/de/3e/dcdffa60078ae7b3a00ebb4cbbf1a204a14c3609983c604886523a7d4418/langchain_core-1.4.7-py3-none-any.whl", hash = "sha256:bcadd51951140ecdcba98311dbd931ba5de02a5ba8a2288dad5069c1eea2a13d", size = 554941, upload-time = "2026-06-12T19:23:55.826Z" },
 ]
 
 [[package]]
@@ -523,7 +523,7 @@ typing = [
 requires-dist = [
     { name = "filetype", specifier = ">=1.2.0,<2.0.0" },
     { name = "google-genai", specifier = ">=1.65.0,<3.0.0" },
-    { name = "langchain-core", specifier = ">=1.4.4,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.4.7,<2.0.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
 ]
 

--- a/libs/vertexai/langchain_google_vertexai/__init__.py
+++ b/libs/vertexai/langchain_google_vertexai/__init__.py
@@ -46,6 +46,7 @@ from langchain_google_vertexai._enums import (
     Modality,
     SafetySetting,
 )
+from langchain_google_vertexai._version import __version__
 from langchain_google_vertexai.chains import create_structured_runnable
 from langchain_google_vertexai.chat_models import ChatVertexAI
 from langchain_google_vertexai.embeddings import VertexAIEmbeddings
@@ -102,6 +103,7 @@ __all__ = [
     "VertexAIVisualQnAChat",
     "VertexPairWiseStringEvaluator",
     "VertexStringEvaluator",
+    "__version__",
     "create_context_cache",
     "create_structured_runnable",
     "get_vertex_maas_model",

--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -51,6 +51,7 @@ from langchain_google_vertexai._utils import (
     get_client_info,
     get_user_agent,
 )
+from langchain_google_vertexai._version import __version__
 
 _DEFAULT_LOCATION = "us-central1"
 
@@ -299,6 +300,12 @@ class _VertexAICommon(_VertexAIBase):
         description="Timeout for API requests.",
     )
     """The timeout for requests to the Vertex AI API, in seconds."""
+
+    @model_validator(mode="after")
+    def _set_langchain_google_vertexai_version(self) -> Self:
+        """Set package version in metadata."""
+        self._add_version("langchain-google-vertexai", __version__)
+        return self
 
     @property
     def _llm_type(self) -> str:

--- a/libs/vertexai/langchain_google_vertexai/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/_base.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     ClassVar,
     Literal,
+    Protocol,
     cast,
 )
 
@@ -54,6 +55,18 @@ from langchain_google_vertexai._utils import (
 from langchain_google_vertexai._version import __version__
 
 _DEFAULT_LOCATION = "us-central1"
+
+
+class _VersionedLanguageModel(Protocol):
+    # LangChain language models provide this private helper at runtime, but the
+    # public base type used here does not expose it for mypy.
+    def _add_version(self, pkg: str, version: str) -> None: ...
+
+
+def _add_langchain_google_vertexai_version(model: Any) -> None:
+    cast("_VersionedLanguageModel", model)._add_version(
+        "langchain-google-vertexai", __version__
+    )
 
 
 class _VertexAIBase(BaseModel):
@@ -304,7 +317,7 @@ class _VertexAICommon(_VertexAIBase):
     @model_validator(mode="after")
     def _set_langchain_google_vertexai_version(self) -> Self:
         """Set package version in metadata."""
-        self._add_version("langchain-google-vertexai", __version__)
+        _add_langchain_google_vertexai_version(self)
         return self
 
     @property

--- a/libs/vertexai/langchain_google_vertexai/_version.py
+++ b/libs/vertexai/langchain_google_vertexai/_version.py
@@ -1,0 +1,8 @@
+"""Package version for `langchain-google-vertexai`."""
+
+from importlib import metadata
+
+try:
+    __version__ = metadata.version(__package__)
+except metadata.PackageNotFoundError:
+    __version__ = ""

--- a/libs/vertexai/langchain_google_vertexai/functions_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/functions_utils.py
@@ -198,11 +198,15 @@ def _format_base_tool_to_function_declaration(
             ),
         )
 
-    if hasattr(tool.args_schema, "model_json_schema"):
-        schema = tool.args_schema.model_json_schema(mode="serialization")
+    args_schema = tool.args_schema
+    if isinstance(args_schema, dict):
+        schema = args_schema
+        pydantic_version = "v2"
+    elif hasattr(args_schema, "model_json_schema"):
+        schema = args_schema.model_json_schema(mode="serialization")
         pydantic_version = "v2"
     else:
-        schema = tool.args_schema.schema()  # type: ignore[attr-defined]
+        schema = args_schema.schema()
         pydantic_version = "v1"
 
     parameters = _dict_to_gapic_schema(schema, pydantic_version=pydantic_version)

--- a/libs/vertexai/langchain_google_vertexai/model_garden.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden.py
@@ -55,9 +55,12 @@ from langchain_google_vertexai._anthropic_utils import (
     _tools_in_params,
     convert_to_anthropic_tool,
 )
-from langchain_google_vertexai._base import _BaseVertexAIModelGarden, _VertexAICommon
+from langchain_google_vertexai._base import (
+    _add_langchain_google_vertexai_version,
+    _BaseVertexAIModelGarden,
+    _VertexAICommon,
+)
 from langchain_google_vertexai._retry import create_base_retry_decorator
-from langchain_google_vertexai._version import __version__
 from langchain_google_vertexai.data.anthropic._profiles import (
     _PROFILES as _ANTHROPIC_PROFILES,
 )
@@ -105,7 +108,7 @@ class VertexAIModelGarden(_BaseVertexAIModelGarden, BaseLLM):
     @model_validator(mode="after")
     def _set_langchain_google_vertexai_version(self) -> Self:
         """Set package version in metadata."""
-        self._add_version("langchain-google-vertexai", __version__)
+        _add_langchain_google_vertexai_version(self)
         return self
 
     def _generate(

--- a/libs/vertexai/langchain_google_vertexai/model_garden.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden.py
@@ -57,6 +57,7 @@ from langchain_google_vertexai._anthropic_utils import (
 )
 from langchain_google_vertexai._base import _BaseVertexAIModelGarden, _VertexAICommon
 from langchain_google_vertexai._retry import create_base_retry_decorator
+from langchain_google_vertexai._version import __version__
 from langchain_google_vertexai.data.anthropic._profiles import (
     _PROFILES as _ANTHROPIC_PROFILES,
 )
@@ -100,6 +101,12 @@ class VertexAIModelGarden(_BaseVertexAIModelGarden, BaseLLM):
     # Needed so that mypy doesn't flag missing aliased init args.
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
+
+    @model_validator(mode="after")
+    def _set_langchain_google_vertexai_version(self) -> Self:
+        """Set package version in metadata."""
+        self._add_version("langchain-google-vertexai", __version__)
+        return self
 
     def _generate(
         self,

--- a/libs/vertexai/langchain_google_vertexai/model_garden_maas/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden_maas/_base.py
@@ -23,8 +23,10 @@ from langchain_core.language_models.llms import create_base_retry_decorator
 from pydantic import ConfigDict, model_validator
 from typing_extensions import Self
 
-from langchain_google_vertexai._base import _VertexAIBase
-from langchain_google_vertexai._version import __version__
+from langchain_google_vertexai._base import (
+    _add_langchain_google_vertexai_version,
+    _VertexAIBase,
+)
 
 _MISTRAL_MODELS: list[str] = ["mistral-medium-3", "mistral-small-2503", "codestral-2"]
 _LLAMA_MODELS: list[str] = [
@@ -144,7 +146,7 @@ class _BaseVertexMaasModelGarden(_VertexAIBase):
     @model_validator(mode="after")
     def _set_langchain_google_vertexai_version(self) -> Self:
         """Set package version in metadata."""
-        self._add_version("langchain-google-vertexai", __version__)
+        _add_langchain_google_vertexai_version(self)
         return self
 
     @model_validator(mode="after")

--- a/libs/vertexai/langchain_google_vertexai/model_garden_maas/_base.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden_maas/_base.py
@@ -24,6 +24,7 @@ from pydantic import ConfigDict, model_validator
 from typing_extensions import Self
 
 from langchain_google_vertexai._base import _VertexAIBase
+from langchain_google_vertexai._version import __version__
 
 _MISTRAL_MODELS: list[str] = ["mistral-medium-3", "mistral-small-2503", "codestral-2"]
 _LLAMA_MODELS: list[str] = [
@@ -139,6 +140,12 @@ class _BaseVertexMaasModelGarden(_VertexAIBase):
             headers=headers,
             timeout=self.timeout,
         )
+
+    @model_validator(mode="after")
+    def _set_langchain_google_vertexai_version(self) -> Self:
+        """Set package version in metadata."""
+        self._add_version("langchain-google-vertexai", __version__)
+        return self
 
     @model_validator(mode="after")
     def validate_environment_model_garden(self) -> Self:

--- a/libs/vertexai/pyproject.toml
+++ b/libs/vertexai/pyproject.toml
@@ -12,7 +12,7 @@ authors = []
 version = "3.2.4"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.4,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "google-cloud-aiplatform>=1.97.0,<2.0.0",
     "google-cloud-storage>=2.18.0,<4.0.0",
     "httpx>=0.28.0,<1.0.0",

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -100,6 +100,7 @@ def test_init() -> None:
             "ls_max_tokens": 10,
             "ls_stop": ["bar"],
         }
+        assert llm.metadata is not None
         assert llm.metadata["lc_versions"]["langchain-google-vertexai"] == __version__
 
     # Test initialization with an invalid argument to check warning

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -41,6 +41,7 @@ from vertexai.language_models import (
     InputOutputTextPair,
 )
 
+from langchain_google_vertexai import __version__
 from langchain_google_vertexai._base import _get_prediction_client
 from langchain_google_vertexai._compat import _convert_from_v1_to_vertex
 from langchain_google_vertexai._image_utils import ImageBytesLoader
@@ -99,6 +100,7 @@ def test_init() -> None:
             "ls_max_tokens": 10,
             "ls_stop": ["bar"],
         }
+        assert llm.metadata["lc_versions"]["langchain-google-vertexai"] == __version__
 
     # Test initialization with an invalid argument to check warning
     with patch("langchain_google_vertexai.chat_models.logger.warning") as mock_warning:

--- a/libs/vertexai/tests/unit_tests/test_imports.py
+++ b/libs/vertexai/tests/unit_tests/test_imports.py
@@ -28,6 +28,7 @@ EXPECTED_ALL = [
     "VertexAIVisualQnAChat",
     "VertexPairWiseStringEvaluator",
     "VertexStringEvaluator",
+    "__version__",
     "create_context_cache",
     "get_vertex_maas_model",
 ]

--- a/libs/vertexai/tests/unit_tests/test_llm.py
+++ b/libs/vertexai/tests/unit_tests/test_llm.py
@@ -41,6 +41,7 @@ def test_model_name() -> None:
     ]:
         assert llm.model_name == _DEFAULT_MODEL_NAME
         assert llm.max_output_tokens == 10
+        assert llm.metadata is not None
         assert llm.metadata["lc_versions"]["langchain-google-vertexai"] == __version__
 
     # Test initialization with an invalid argument to check warning
@@ -76,6 +77,7 @@ def test_model_garden_sets_version(_mock_client: Any, _mock_async_client: Any) -
         endpoint_id="test-endpoint",
         location="us-central1",
     )
+    assert llm.metadata is not None
     assert llm.metadata["lc_versions"]["langchain-google-vertexai"] == __version__
     assert "langchain-core" in llm.metadata["lc_versions"]
 

--- a/libs/vertexai/tests/unit_tests/test_llm.py
+++ b/libs/vertexai/tests/unit_tests/test_llm.py
@@ -13,11 +13,13 @@ from google.cloud.aiplatform_v1beta1.types import (
 from pydantic import model_validator
 from typing_extensions import Self
 
+from langchain_google_vertexai import __version__
 from langchain_google_vertexai._base import (
     _BaseVertexAIModelGarden,
     _get_prediction_client,
 )
 from langchain_google_vertexai.llms import VertexAI
+from langchain_google_vertexai.model_garden import VertexAIModelGarden
 from tests.integration_tests.conftest import (
     _DEFAULT_MODEL_NAME,
 )
@@ -39,6 +41,7 @@ def test_model_name() -> None:
     ]:
         assert llm.model_name == _DEFAULT_MODEL_NAME
         assert llm.max_output_tokens == 10
+        assert llm.metadata["lc_versions"]["langchain-google-vertexai"] == __version__
 
     # Test initialization with an invalid argument to check warning
     with patch("langchain_google_vertexai.llms.logger.warning") as mock_warning:
@@ -59,6 +62,22 @@ def test_model_name() -> None:
         call_args = mock_warning.call_args[0][0]
         assert "Unexpected argument 'safety_setting'" in call_args
         assert "Did you mean: 'safety_settings'?" in call_args
+
+
+@patch("langchain_google_vertexai._base.PredictionServiceAsyncClient")
+@patch("langchain_google_vertexai._base.PredictionServiceClient")
+def test_model_garden_sets_version(_mock_client: Any, _mock_async_client: Any) -> None:
+    # VertexAIModelGarden defines its own ``_set_*_version`` validator (it does not
+    # inherit ``_VertexAICommon``), so it needs dedicated coverage. Asserting the
+    # ``langchain-core`` entry also coexists guards against a same-named validator
+    # silently clobbering core's seeded entry.
+    llm = VertexAIModelGarden(
+        project="test-project",
+        endpoint_id="test-endpoint",
+        location="us-central1",
+    )
+    assert llm.metadata["lc_versions"]["langchain-google-vertexai"] == __version__
+    assert "langchain-core" in llm.metadata["lc_versions"]
 
 
 def test_tuned_model_name() -> None:

--- a/libs/vertexai/tests/unit_tests/test_maas.py
+++ b/libs/vertexai/tests/unit_tests/test_maas.py
@@ -6,6 +6,7 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, Tool
 from langchain_core.tools import tool
 from langchain_core.utils.function_calling import convert_to_openai_function
 
+from langchain_google_vertexai import __version__
 from langchain_google_vertexai.model_garden_maas import get_vertex_maas_model
 from langchain_google_vertexai.model_garden_maas.llama import (
     _parse_response_candidate_llama,
@@ -26,6 +27,7 @@ def test_llama_init(mock_auth: Any) -> None:
     )
     assert llm._llm_type == "vertexai_model_garden_maas_llama"
     assert llm.model_name == _MODEL_NAME
+    assert llm.metadata["lc_versions"]["langchain-google-vertexai"] == __version__
 
     assert (
         llm.get_url()

--- a/libs/vertexai/uv.lock
+++ b/libs/vertexai/uv.lock
@@ -1081,7 +1081,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.4"
+version = "1.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1094,9 +1094,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/76/bbae1ed44a1362504d2b8a11a947890aeee7075b6e0649235de9d150d982/langchain_core-1.4.4.tar.gz", hash = "sha256:30409ffa24da1dd984a4164c4266dc8079e5379e41cb36d00356130e80be0405", size = 937710, upload-time = "2026-06-10T21:24:02.904Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/2b/fffaff399d20a56d40b9562fa19701e91abd72d8c9d9bc8c2673077b56b6/langchain_core-1.4.7.tar.gz", hash = "sha256:7a825d77de0a3f39adbd9d09612a75e85527e14a52c1601089bcc062972d9f2b", size = 952522, upload-time = "2026-06-12T19:23:57.588Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/1f/1c8b89b116ae979af829c2e0f4cde984fd674dc0fa58ee5e69c0af1d3606/langchain_core-1.4.4-py3-none-any.whl", hash = "sha256:36c2eb73e67bfab28455016f7a4044ffde4343485b8dad104a2b194ff21319d2", size = 551732, upload-time = "2026-06-10T21:24:01.765Z" },
+    { url = "https://files.pythonhosted.org/packages/de/3e/dcdffa60078ae7b3a00ebb4cbbf1a204a14c3609983c604886523a7d4418/langchain_core-1.4.7-py3-none-any.whl", hash = "sha256:bcadd51951140ecdcba98311dbd931ba5de02a5ba8a2288dad5069c1eea2a13d", size = 554941, upload-time = "2026-06-12T19:23:55.826Z" },
 ]
 
 [[package]]
@@ -1181,7 +1181,7 @@ requires-dist = [
     { name = "google-cloud-vectorsearch", marker = "extra == 'vectorsearch-v2'" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "httpx-sse", specifier = ">=0.4.0,<1.0.0" },
-    { name = "langchain-core", specifier = ">=1.4.4,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.4.7,<2.0.0" },
     { name = "langchain-mistralai", marker = "extra == 'mistral'", specifier = ">=0.2.0,<2.0.0" },
     { name = "numexpr", specifier = ">=2.8.6,<3.0.0" },
     { name = "pyarrow", specifier = ">=19.0.1,<24.0.0" },


### PR DESCRIPTION
Google GenAI and Vertex AI model instances now record their integration package versions in `metadata["lc_versions"]`. The packages also expose `__version__` from their public module exports so tests and downstream code can reference the installed integration version directly.

## Changes
- Added package-local `_version` modules for `langchain-google-genai` and `langchain-google-vertexai` using `importlib.metadata`.
- Exported `__version__` from both integration package roots.
- Added post-init validators that call `_add_version(...)` for `ChatGoogleGenerativeAI`, `GoogleGenerativeAI`, `_VertexAICommon`, `VertexAIModelGarden`, and MaaS model garden base classes.
- Bumped the `langchain-core` lower bound to `>=1.4.7` so both integrations can rely on the metadata version helper.