### PR TITLE
test(vertexai): stabilize search & anthropic beta integration tests

### DIFF
--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -1734,10 +1734,13 @@ def test_search_builtin(output_version: str) -> None:
     assert isinstance(full, AIMessageChunk)
     _check_web_search_output(full, output_version)
 
-    # Test we can process chat history
+    # Test we can process chat history while still verifying grounding on
+    # `invoke`. Use a self-contained current-events query rather than a
+    # context-dependent follow-up (e.g. "that last story"), which the model
+    # may answer with a clarification and thus return no grounding metadata.
     next_message = {
         "role": "user",
-        "content": "Tell me more about that last story.",
+        "content": "What is today's top news story in technology?",
     }
     response = llm.invoke([input_message, full, next_message])
     _check_web_search_output(response, output_version)

--- a/libs/vertexai/tests/integration_tests/test_model_garden.py
+++ b/libs/vertexai/tests/integration_tests/test_model_garden.py
@@ -1,6 +1,8 @@
 import json
 import os
+from typing import NoReturn
 
+import anthropic
 import pytest
 from langchain_core.messages import (
     AIMessage,
@@ -21,6 +23,22 @@ from langchain_google_vertexai.model_garden import (
 
 _ANTHROPIC_LOCATION = "us-east5"
 _ANTHROPIC_CLAUDE_MODEL_NAME = "claude-sonnet-4-5@20250929"
+# Beta header used to verify `betas` propagation. Beta values are rotated and
+# may not be enabled for every project/model, so callers should treat a
+# rejected beta header as a skip rather than a failure (see
+# `_skip_if_beta_rejected`).
+_ANTHROPIC_BETA = "context-1m-2025-08-07"
+
+
+def _skip_if_beta_rejected(exc: anthropic.BadRequestError) -> NoReturn:
+    """Skip when the live endpoint rejects the beta header value.
+
+    Re-raises anything that is not an `anthropic-beta` header rejection so real
+    propagation regressions still surface.
+    """
+    if "anthropic-beta" in str(exc):
+        pytest.skip(f"Beta header {_ANTHROPIC_BETA!r} not accepted by endpoint: {exc}")
+    raise exc
 
 
 @pytest.mark.extended
@@ -390,12 +408,15 @@ async def test_anthropic_async_invoke_with_betas() -> None:
     )
     message = HumanMessage(content="What is 2+2?")
 
-    # This should work but currently fails because _agenerate doesn't handle betas
-    response = await model.ainvoke(
-        [message],
-        model_name=_ANTHROPIC_CLAUDE_MODEL_NAME,
-        betas=["context-1m-2025-08-07"],
-    )
+    # `_agenerate` should route `betas` through the Anthropic beta client.
+    try:
+        response = await model.ainvoke(
+            [message],
+            model_name=_ANTHROPIC_CLAUDE_MODEL_NAME,
+            betas=[_ANTHROPIC_BETA],
+        )
+    except anthropic.BadRequestError as exc:
+        _skip_if_beta_rejected(exc)
     assert isinstance(response, AIMessage)
     assert isinstance(response.content, str)
 
@@ -411,14 +432,17 @@ async def test_anthropic_async_stream_with_betas() -> None:
     )
     message = HumanMessage(content="Say hello")
 
-    # This should work but currently fails because _astream doesn't handle betas
+    # `_astream` should route `betas` through the Anthropic beta client.
     chunks = []
-    async for chunk in model.astream(
-        [message],
-        model=_ANTHROPIC_CLAUDE_MODEL_NAME,
-        betas=["context-1m-2025-08-07"],
-    ):
-        chunks.append(chunk)
-        assert isinstance(chunk, AIMessageChunk)
+    try:
+        async for chunk in model.astream(
+            [message],
+            model=_ANTHROPIC_CLAUDE_MODEL_NAME,
+            betas=[_ANTHROPIC_BETA],
+        ):
+            chunks.append(chunk)
+            assert isinstance(chunk, AIMessageChunk)
+    except anthropic.BadRequestError as exc:
+        _skip_if_beta_rejected(exc)
 
     assert len(chunks) > 0

--- a/libs/vertexai/tests/unit_tests/test_model_garden_betas.py
+++ b/libs/vertexai/tests/unit_tests/test_model_garden_betas.py
@@ -1,0 +1,100 @@
+"""Deterministic unit tests for `betas` propagation in `ChatAnthropicVertex`.
+
+These verify, without any live API calls, that passing `betas` routes the
+request through the Anthropic *beta* client for both async invoke
+(`_agenerate`) and async streaming (`_astream`).
+"""
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+from langchain_google_vertexai.model_garden import ChatAnthropicVertex
+
+_BETA = "context-1m-2025-08-07"
+_MODEL = "claude-sonnet-4-5@20250929"
+
+
+class _FakeUsage:
+    input_tokens = 10
+    output_tokens = 5
+
+
+class _FakeResponse:
+    usage = _FakeUsage()
+
+    def model_dump(self) -> dict[str, Any]:
+        return {
+            "content": [{"type": "text", "text": "4"}],
+            "role": "assistant",
+            "type": "message",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+
+
+class _FakeTextDelta:
+    type = "text_delta"
+    text = "hello"
+
+
+class _FakeDeltaEvent:
+    type = "content_block_delta"
+    index = 0
+    delta = _FakeTextDelta()
+
+
+async def _text_event_stream() -> AsyncIterator[Any]:
+    yield _FakeDeltaEvent()
+
+
+def _build_chat() -> ChatAnthropicVertex:
+    with (
+        patch("anthropic.AnthropicVertex") as mock_sync_client,
+        patch("anthropic.AsyncAnthropicVertex") as mock_async_client,
+    ):
+        mock_sync_client.return_value = Mock()
+        mock_async_client.return_value = Mock()
+        return ChatAnthropicVertex(project="test-project", model_name=_MODEL)
+
+
+async def test_async_invoke_routes_betas_to_beta_client() -> None:
+    """`ainvoke` with `betas` must call the async beta client."""
+    chat = _build_chat()
+    chat.async_client.beta.messages.create = AsyncMock(return_value=_FakeResponse())
+    chat.async_client.messages.create = AsyncMock(return_value=_FakeResponse())
+
+    await chat.ainvoke("What is 2+2?", model_name=_MODEL, betas=[_BETA])
+
+    chat.async_client.beta.messages.create.assert_awaited_once()
+    chat.async_client.messages.create.assert_not_awaited()
+    assert chat.async_client.beta.messages.create.call_args.kwargs["betas"] == [_BETA]
+
+
+async def test_async_stream_routes_betas_to_beta_client() -> None:
+    """`astream` with `betas` must call the async beta client."""
+    chat = _build_chat()
+    chat.async_client.beta.messages.create = AsyncMock(
+        return_value=_text_event_stream()
+    )
+    chat.async_client.messages.create = AsyncMock(return_value=_text_event_stream())
+
+    async for _ in chat.astream("Say hello", model=_MODEL, betas=[_BETA]):
+        pass
+
+    chat.async_client.beta.messages.create.assert_awaited_once()
+    chat.async_client.messages.create.assert_not_awaited()
+    call_kwargs = chat.async_client.beta.messages.create.call_args.kwargs
+    assert call_kwargs["betas"] == [_BETA]
+    assert call_kwargs["stream"] is True
+
+
+async def test_async_invoke_without_betas_uses_standard_client() -> None:
+    """Without `betas`, the standard (non-beta) async client is used."""
+    chat = _build_chat()
+    chat.async_client.beta.messages.create = AsyncMock(return_value=_FakeResponse())
+    chat.async_client.messages.create = AsyncMock(return_value=_FakeResponse())
+
+    await chat.ainvoke("What is 2+2?", model_name=_MODEL)
+
+    chat.async_client.messages.create.assert_awaited_once()
+    chat.async_client.beta.messages.create.assert_not_awaited()


### PR DESCRIPTION
## Description
The Google Cloud Build `langchain-google-vertexai-us` (llm-integration-tests) job was failing on tests unrelated to the package-version metadata feature (#1841), which only adds `_add_version(...)` validators and does not touch Anthropic beta handling or Vertex search. This makes those live tests deterministic while preserving their intent.

- `test_search_builtin`: replaced the context-dependent follow-up ("that last story"), which the model could answer with a clarification (no grounding), with a self-contained current-events query. Still asserts grounding metadata/annotations for both streaming and invoke.
- Anthropic async beta tests: hard-coded beta header `context-1m-2025-08-07` was rejected (`BadRequestError`). Now skips when the live endpoint rejects the beta header, and adds deterministic unit tests verifying `betas` route through the Anthropic beta client for async invoke and stream.

> Authored with the help of an AI agent (Open SWE).

## Release Note
none

## Test Plan
- [ ] `uv run --group test pytest tests/unit_tests/test_model_garden_betas.py` (passes locally)
- [ ] Integration job re-runs green / skips gracefully when the beta header is unavailable

Made by [Open SWE](https://openswe.vercel.app)