### PR TITLE
test(vertexai): use content blocks in integration tests

### DIFF
--- a/libs/vertexai/tests/integration_tests/conftest.py
+++ b/libs/vertexai/tests/integration_tests/conftest.py
@@ -8,8 +8,9 @@ _DEFAULT_IMAGE_GENERATION_MODEL_NAME = "gemini-2.5-flash-image"
 
 def _get_text_content(message: BaseMessage) -> str:
     content_blocks = message.content_blocks
-    assert all(block["type"] == "text" for block in content_blocks)
-    return " ".join(block["text"] for block in content_blocks)
+    text_blocks = [block for block in content_blocks if block["type"] == "text"]
+    assert len(text_blocks) == len(content_blocks)
+    return " ".join(block["text"] for block in text_blocks)
 
 
 @pytest.fixture

--- a/libs/vertexai/tests/integration_tests/conftest.py
+++ b/libs/vertexai/tests/integration_tests/conftest.py
@@ -1,8 +1,15 @@
 import pytest
+from langchain_core.messages import BaseMessage
 
 _DEFAULT_MODEL_NAME = "gemini-2.5-flash"
 _DEFAULT_THINKING_MODEL_NAME = "gemini-2.5-flash"
 _DEFAULT_IMAGE_GENERATION_MODEL_NAME = "gemini-2.5-flash-image"
+
+
+def _get_text_content(message: BaseMessage) -> str:
+    content_blocks = message.content_blocks
+    assert all(block["type"] == "text" for block in content_blocks)
+    return " ".join(block["text"] for block in content_blocks)
 
 
 @pytest.fixture

--- a/libs/vertexai/tests/integration_tests/conftest.py
+++ b/libs/vertexai/tests/integration_tests/conftest.py
@@ -7,9 +7,7 @@ _DEFAULT_IMAGE_GENERATION_MODEL_NAME = "gemini-2.5-flash-image"
 
 
 def _get_text_content(message: BaseMessage) -> str:
-    content_blocks = message.content_blocks
-    text_blocks = [block for block in content_blocks if block["type"] == "text"]
-    assert len(text_blocks) == len(content_blocks)
+    text_blocks = [block for block in message.content_blocks if block["type"] == "text"]
     return " ".join(block["text"] for block in text_blocks)
 
 

--- a/libs/vertexai/tests/integration_tests/test_anthropic_cache.py
+++ b/libs/vertexai/tests/integration_tests/test_anthropic_cache.py
@@ -7,6 +7,7 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.prompts import ChatPromptTemplate
 
 from langchain_google_vertexai.model_garden import ChatAnthropicVertex
+from tests.integration_tests.conftest import _get_text_content
 
 
 @pytest.mark.extended
@@ -27,7 +28,7 @@ def test_anthropic_system_cache() -> None:
 
     response = model.invoke([context, message], model_name="claude-sonnet-4-6")
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
+    assert isinstance(_get_text_content(response), str)
     assert response.usage_metadata is not None
     assert "cache_creation_input_tokens" in response.response_metadata["usage"]
 
@@ -63,7 +64,7 @@ def test_anthropic_mixed_cache() -> None:
 
     response = model.invoke([context, message], model_name="claude-sonnet-4-6")
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
+    assert isinstance(_get_text_content(response), str)
     assert response.usage_metadata is not None
 
 
@@ -106,8 +107,7 @@ def test_anthropic_conversation_cache() -> None:
 
     response = model.invoke(messages, model_name="claude-sonnet-4-6")
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
-    assert "peter" in response.content.lower()  # Should remember the name
+    assert "peter" in _get_text_content(response).lower()
 
 
 @pytest.mark.extended
@@ -140,5 +140,4 @@ def test_anthropic_chat_template_cache() -> None:
     )
 
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
-    assert "Paris" in response.content
+    assert "Paris" in _get_text_content(response)

--- a/libs/vertexai/tests/integration_tests/test_anthropic_files.py
+++ b/libs/vertexai/tests/integration_tests/test_anthropic_files.py
@@ -7,6 +7,7 @@ import pytest
 from langchain_google_vertexai._image_utils import image_bytes_to_b64_string
 from langchain_google_vertexai._utils import load_image_from_gcs
 from langchain_google_vertexai.model_garden import ChatAnthropicVertex
+from tests.integration_tests.conftest import _get_text_content
 
 
 @pytest.mark.extended
@@ -30,7 +31,7 @@ def test_pdf_gcs_uri() -> None:
             }
         ]
     )
-    assert len(res.content) > 100
+    assert len(_get_text_content(res)) > 100
 
 
 @pytest.mark.extended
@@ -56,7 +57,7 @@ def test_pdf_byts() -> None:
             }
         ]
     )
-    assert len(res.content) > 100
+    assert len(_get_text_content(res)) > 100
 
 
 @pytest.mark.extended
@@ -81,4 +82,4 @@ def test_https_image() -> None:
             }
         ]
     )
-    assert len(res.content) > 10
+    assert len(_get_text_content(res)) > 10

--- a/libs/vertexai/tests/integration_tests/test_anthropic_long_context.py
+++ b/libs/vertexai/tests/integration_tests/test_anthropic_long_context.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from langchain_google_vertexai.model_garden import ChatAnthropicVertex
+from tests.integration_tests.conftest import _get_text_content
 
 AVG_CHARS_PER_TOKEN = 4
 
@@ -63,7 +64,7 @@ def test_long_context_init():
     )
 
     response = llm.invoke(long_prompt, model_name="claude-sonnet-4@20250514")
-    print(response.content)
+    print(_get_text_content(response))
 
 
 @pytest.mark.skip(reason="too long & expensive")
@@ -81,4 +82,4 @@ def test_long_context_args():
         model_name="claude-sonnet-4@20250514",
         betas=["context-1m-2025-08-07"],
     )
-    print(response.content)
+    print(_get_text_content(response))

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -56,6 +56,7 @@ from tests.integration_tests.conftest import (
     _DEFAULT_IMAGE_GENERATION_MODEL_NAME,
     _DEFAULT_MODEL_NAME,
     _DEFAULT_THINKING_MODEL_NAME,
+    _get_text_content,
 )
 
 model_names_to_test = [_DEFAULT_MODEL_NAME]
@@ -82,8 +83,7 @@ def _check_usage_metadata(message: AIMessage) -> None:
 def _check_tool_calls(response: BaseMessage, expected_name: str) -> None:
     """Check tool calls are as expected."""
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
-    assert response.content == ""
+    assert _get_text_content(response) == ""
     function_call = response.additional_kwargs.get("function_call")
     assert function_call
     assert function_call["name"] == expected_name
@@ -141,7 +141,7 @@ def test_vertexai_single_call(model_name: str | None, endpoint_version: str) -> 
     message = HumanMessage(content="Hello")
     response = model.invoke([message])
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
+    assert isinstance(_get_text_content(response), str)
     _check_usage_metadata(response)
 
 
@@ -259,7 +259,7 @@ def test_multimodal() -> None:
     }
     message = HumanMessage(content=[text_message, image_message])
     output = llm.invoke([message])
-    assert isinstance(output.content, str)
+    assert isinstance(_get_text_content(output), str)
     assert isinstance(output, AIMessage)
     _check_usage_metadata(output)
 
@@ -302,7 +302,7 @@ def test_multimodal_media_file_uri(file_uri, mime_type) -> None:
     }
     message = HumanMessage(content=[text_message, media_message])
     output = llm.invoke([message])
-    assert isinstance(output.content, str)
+    assert isinstance(_get_text_content(output), str)
 
 
 @pytest.mark.release
@@ -325,7 +325,7 @@ def test_multimodal_media_inline_base64(file_uri, mime_type) -> None:
     }
     message = HumanMessage(content=[text_message, media_message])
     output = llm.invoke([message])
-    assert isinstance(output.content, str)
+    assert isinstance(_get_text_content(output), str)
 
 
 @pytest.mark.release
@@ -360,7 +360,7 @@ def test_multimodal_media_inline_base64_template() -> None:
     media_base64 = base64.b64encode(blob.download_as_bytes()).decode()
     chain = prompt_template | llm
     output = chain.invoke({"media_base64": media_base64, "mime_type": mime_type})
-    assert isinstance(output.content, str)
+    assert isinstance(_get_text_content(output), str)
 
 
 @pytest.mark.extended
@@ -426,9 +426,10 @@ def test_audio_timestamp() -> None:
 
     message = HumanMessage(content=[media_message, text_message])
     output = llm.invoke([message], audio_timestamp=True)
+    content_text = _get_text_content(output)
 
-    assert isinstance(output.content, str)
-    assert re.search(r"(\d{2}:\d{2}:?|\[\d{2}:\d{2}:\d{2}\])", output.content)
+    assert isinstance(content_text, str)
+    assert re.search(r"(\d{2}:\d{2}:?|\[\d{2}:\d{2}:\d{2}\])", content_text)
 
 
 def test_parse_history_gemini_multimodal_FC() -> None:
@@ -485,7 +486,7 @@ def test_multimodal_video_metadata(file_uri, mime_type) -> None:
 
     message = HumanMessage(content=[text_message, media_message])
     output = llm.invoke([message])
-    assert isinstance(output.content, str)
+    assert isinstance(_get_text_content(output), str)
 
 
 @pytest.mark.release
@@ -499,7 +500,7 @@ def test_vertexai_single_call_with_history(model_name: str | None) -> None:
     message3 = HumanMessage(content=text_question2)
     response = model.invoke([message1, message2, message3])
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
+    assert isinstance(_get_text_content(response), str)
 
 
 @pytest.mark.release
@@ -512,8 +513,7 @@ def test_vertexai_system_message() -> None:
     response = model.invoke([sys_message, message1])
 
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
-    assert "london" in response.content.lower()
+    assert "london" in _get_text_content(response).lower()
 
 
 @pytest.mark.release
@@ -526,7 +526,7 @@ def test_vertexai_single_call_with_no_system_messages() -> None:
     message3 = HumanMessage(content=text_question2)
     response = model.invoke([message1, message2, message3])
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
+    assert isinstance(_get_text_content(response), str)
 
 
 @pytest.mark.release
@@ -559,7 +559,7 @@ def test_vertexai_single_call_previous_blocked_response() -> None:
     message2 = HumanMessage(content=text_question2)
     response = model.invoke([message1, message2])
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
+    assert isinstance(_get_text_content(response), str)
 
 
 @pytest.mark.release
@@ -658,8 +658,7 @@ def test_chat_vertexai_gemini_function_calling_tool_config_any() -> None:
     message = HumanMessage(content="My name is Erick and I am 27 years old")
     response = model.invoke([message])
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
-    assert response.content == ""
+    assert _get_text_content(response) == ""
     function_call = response.additional_kwargs.get("function_call")
     assert function_call
     assert function_call["name"] == "MyModel"
@@ -692,8 +691,7 @@ def test_chat_vertexai_gemini_function_calling_tool_config_none() -> None:
     message = HumanMessage(content="My name is Erick and I am 27 years old")
     response = model.invoke([message])
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
-    assert response.content != ""
+    assert _get_text_content(response) != ""
     function_call = response.additional_kwargs.get("function_call")
     assert function_call is None
 
@@ -852,8 +850,20 @@ def test_chat_vertexai_gemini_function_calling_with_multiple_parts() -> None:
     result = llm_with_search.invoke([request, response, *tool_messages])
 
     assert isinstance(result, AIMessage)
-    assert "brown" in result.content[0]["text"]  # type: ignore
+    text_blocks = [block for block in result.content_blocks if block["type"] == "text"]
+    assert any("brown" in block["text"] for block in text_blocks)
     assert len(result.tool_calls) == 0
+
+
+def _check_gemini_image_output(message: AIMessage) -> None:
+    content_blocks = message.content_blocks
+
+    image_blocks = [block for block in content_blocks if block["type"] == "image"]
+    assert image_blocks, f"Did not find the expected image content: {content_blocks}"
+
+    text_blocks = [block for block in content_blocks if block["type"] == "text"]
+    for block in text_blocks:
+        assert isinstance(block["text"], str)
 
 
 # Image Generation is knwown to be flaky.
@@ -867,24 +877,7 @@ def test_chat_vertexai_gemini_image_output() -> None:
     result = model.invoke("Generate an image of a cat. Then, say meow!")
 
     assert isinstance(result, AIMessage)
-    assert isinstance(result.content, list)
-
-    image_element = None
-    for item in result.content:
-        if isinstance(item, dict) and item.get("type") == "image_url":
-            image_element = item
-            break
-    assert image_element is not None, "Did not find the expected image content"
-
-    text_element = None
-    for item in result.content:
-        if isinstance(item, str):
-            text_element = item
-            break
-        elif isinstance(item, dict) and item.get("type") == "text":
-            text_element = item.get("text")
-            break
-    assert text_element is not None, "Did not find the expected text content"
+    _check_gemini_image_output(result)
 
 
 # Image Generation is knwown to be flaky.
@@ -898,24 +891,7 @@ def test_chat_vertexai_gemini_image_output_with_generation_config() -> None:
     )
 
     assert isinstance(result, AIMessage)
-    assert isinstance(result.content, list)
-
-    image_element = None
-    for item in result.content:
-        if isinstance(item, dict) and item.get("type") == "image_url":
-            image_element = item
-            break
-    assert image_element is not None, "Did not find the expected image content"
-
-    text_element = None
-    for item in result.content:
-        if isinstance(item, str):
-            text_element = item
-            break
-        elif isinstance(item, dict) and item.get("type") == "text":
-            text_element = item.get("text")
-            break
-    assert text_element is not None, "Did not find the expected text content"
+    _check_gemini_image_output(result)
 
 
 # Marking the following 6 as flaky because it has been observed that gemini 2.5 models
@@ -953,27 +929,28 @@ def test_chat_vertexai_gemini_thinking_configured() -> None:
     )
 
 
-def _check_thinking_output(content: list, output_version: str) -> None:
+def _check_thinking_output(message: AIMessageChunk, output_version: str) -> None:
+    content_blocks = message.content_blocks
+    assert content_blocks[-1]["type"] == "text"
+    assert isinstance(content_blocks[-1]["text"], str)
+
     if output_version == "v0":
-        thinking_key = "thinking"
-        assert isinstance(content[-1], str)
-
+        thinking_blocks = [
+            block
+            for block in content_blocks
+            if block["type"] == "non_standard"
+            and block["value"].get("type") == "thinking"
+        ]
+        assert thinking_blocks
+        for block in thinking_blocks:
+            assert isinstance(block["value"]["thinking"], str)
     else:
-        # v1
-        thinking_key = "reasoning"
-        assert isinstance(content[-1], dict)
-        assert content[-1].get("type") == "text"
-        assert isinstance(content[-1].get("text"), str)
-
-    assert isinstance(content, list)
-    thinking_blocks = [
-        item
-        for item in content
-        if isinstance(item, dict) and item.get("type") == thinking_key
-    ]
-    assert thinking_blocks
-    for block in thinking_blocks:
-        assert isinstance(block[thinking_key], str)
+        thinking_blocks = [
+            block for block in content_blocks if block["type"] == "reasoning"
+        ]
+        assert thinking_blocks
+        for block in thinking_blocks:
+            assert isinstance(block["reasoning"], str)
 
 
 @pytest.mark.flaky(retries=3, delay=1)
@@ -999,7 +976,7 @@ def test_chat_vertexai_gemini_thinking_auto_include_thoughts(
         full = chunk if full is None else full + chunk
     assert isinstance(full, AIMessageChunk)
 
-    _check_thinking_output(cast("list", full.content), output_version)
+    _check_thinking_output(full, output_version)
 
     assert full.usage_metadata is not None
     assert full.usage_metadata["output_token_details"]["reasoning"] > 0
@@ -1120,8 +1097,7 @@ def test_structured_output_schema_json() -> None:
     response = model.invoke("List a few popular cookie recipes")
 
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
-    parsed_response = json.loads(response.content)
+    parsed_response = json.loads(_get_text_content(response))
     assert isinstance(parsed_response, list)
     assert len(parsed_response) > 0
     assert "recipe_name" in parsed_response[0]
@@ -1192,9 +1168,7 @@ def test_structured_output_schema_enum() -> None:
     )
 
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
-
-    assert response.content in ("drama", "comedy", "documentary")
+    assert _get_text_content(response) in ("drama", "comedy", "documentary")
 
 
 @pytest.mark.extended
@@ -1247,14 +1221,9 @@ def test_context_catching() -> None:
     response = chat.invoke("What is the secret number?")
 
     assert isinstance(response, AIMessage)
-    if isinstance(response.content, str):
-        content_text = response.content
-    else:
-        content_text = " ".join(
-            block.get("text", "")
-            for block in response.content
-            if isinstance(block, dict) and block.get("type") == "text"
-        )
+    content_text = " ".join(
+        block["text"] for block in response.content_blocks if block["type"] == "text"
+    )
     assert isinstance(content_text, str)
 
     # Using cached content in request
@@ -1262,14 +1231,9 @@ def test_context_catching() -> None:
     response = chat.invoke("What is the secret number?", cached_content=cached_content)
 
     assert isinstance(response, AIMessage)
-    if isinstance(response.content, str):
-        content_text = response.content
-    else:
-        content_text = " ".join(
-            block.get("text", "")
-            for block in response.content
-            if isinstance(block, dict) and block.get("type") == "text"
-        )
+    content_text = " ".join(
+        block["text"] for block in response.content_blocks if block["type"] == "text"
+    )
     assert isinstance(content_text, str)
 
 
@@ -1679,7 +1643,7 @@ def test_vertexai_global_location_single_call(
     message = HumanMessage(content="Hello")
     response = model.invoke([message])
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
+    assert isinstance(_get_text_content(response), str)
     _check_usage_metadata(response)
 
 
@@ -1701,21 +1665,14 @@ def test_nested_bind_tools() -> None:
     assert response.tool_calls[0]["name"] == "People"
 
 
-def _check_web_search_output(message: AIMessage, output_version: str) -> None:
+def _check_web_search_output(message: BaseMessage) -> None:
     assert "grounding_metadata" in message.response_metadata
 
-    # Lazy parsing
     content_blocks = message.content_blocks
     text_blocks = [block for block in content_blocks if block["type"] == "text"]
     assert len(text_blocks) == 1
     text_block = text_blocks[0]
     assert text_block["annotations"]
-
-    if output_version == "v1":
-        text_blocks = [block for block in message.content if block["type"] == "text"]  # type: ignore[misc,index]
-        assert len(text_blocks) == 1
-        text_block = text_blocks[0]
-        assert text_block["annotations"]
 
 
 @pytest.mark.parametrize("output_version", ["v0", "v1"])
@@ -1735,7 +1692,7 @@ def test_search_builtin(output_version: str) -> None:
         assert isinstance(chunk, AIMessageChunk)
         full = chunk if full is None else full + chunk
     assert isinstance(full, AIMessageChunk)
-    _check_web_search_output(full, output_version)
+    _check_web_search_output(full)
 
     # Test we can process chat history
     next_message = {
@@ -1743,21 +1700,10 @@ def test_search_builtin(output_version: str) -> None:
         "content": "Tell me more about that last story.",
     }
     response = llm.invoke([input_message, full, next_message])
-    _check_web_search_output(response, output_version)
+    _check_web_search_output(response)
 
 
-def _check_code_execution_output(message: AIMessage, output_version: str) -> None:
-    if output_version == "v0":
-        blocks = [block for block in message.content if isinstance(block, dict)]
-        expected_block_types = {"executable_code", "code_execution_result"}
-        assert {block.get("type") for block in blocks} == expected_block_types
-
-    else:
-        # v1
-        expected_block_types = {"server_tool_call", "server_tool_result", "text"}
-        assert {block["type"] for block in message.content} == expected_block_types  # type: ignore[index]
-
-    # Lazy parsing
+def _check_code_execution_output(message: BaseMessage) -> None:
     expected_block_types = {"server_tool_call", "server_tool_result", "text"}
     assert {block["type"] for block in message.content_blocks} == expected_block_types
 
@@ -1778,7 +1724,7 @@ def test_code_execution_builtin(output_version: str) -> None:
         full = chunk if full is None else full + chunk
     assert isinstance(full, AIMessageChunk)
 
-    _check_code_execution_output(full, output_version)
+    _check_code_execution_output(full)
 
     # Test passing back in chat history without raising errors
     next_message = {
@@ -1786,7 +1732,7 @@ def test_code_execution_builtin(output_version: str) -> None:
         "content": "Can you show me the calculation again with comments?",
     }
     response = llm.invoke([input_message, full, next_message])
-    _check_code_execution_output(response, output_version)
+    _check_code_execution_output(response)
 
 
 @pytest.mark.release

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -942,15 +942,15 @@ def _check_thinking_output(message: AIMessageChunk, output_version: str) -> None
             and block["value"].get("type") == "thinking"
         ]
         assert thinking_blocks
-        for block in thinking_blocks:
-            assert isinstance(block["value"]["thinking"], str)
+        for thinking_block in thinking_blocks:
+            assert isinstance(thinking_block["value"]["thinking"], str)
     else:
-        thinking_blocks = [
+        reasoning_blocks = [
             block for block in content_blocks if block["type"] == "reasoning"
         ]
-        assert thinking_blocks
-        for block in thinking_blocks:
-            assert isinstance(block["reasoning"], str)
+        assert reasoning_blocks
+        for reasoning_block in reasoning_blocks:
+            assert isinstance(reasoning_block["reasoning"], str)
 
 
 @pytest.mark.flaky(retries=3, delay=1)

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -929,28 +929,17 @@ def test_chat_vertexai_gemini_thinking_configured() -> None:
     )
 
 
-def _check_thinking_output(message: AIMessageChunk, output_version: str) -> None:
+def _check_thinking_output(message: AIMessageChunk) -> None:
     content_blocks = message.content_blocks
     assert content_blocks[-1]["type"] == "text"
     assert isinstance(content_blocks[-1]["text"], str)
 
-    if output_version == "v0":
-        thinking_blocks = [
-            block
-            for block in content_blocks
-            if block["type"] == "non_standard"
-            and block["value"].get("type") == "thinking"
-        ]
-        assert thinking_blocks
-        for thinking_block in thinking_blocks:
-            assert isinstance(thinking_block["value"]["thinking"], str)
-    else:
-        reasoning_blocks = [
-            block for block in content_blocks if block["type"] == "reasoning"
-        ]
-        assert reasoning_blocks
-        for reasoning_block in reasoning_blocks:
-            assert isinstance(reasoning_block["reasoning"], str)
+    reasoning_blocks = [
+        block for block in content_blocks if block["type"] == "reasoning"
+    ]
+    assert reasoning_blocks
+    for reasoning_block in reasoning_blocks:
+        assert isinstance(reasoning_block["reasoning"], str)
 
 
 @pytest.mark.flaky(retries=3, delay=1)
@@ -976,7 +965,7 @@ def test_chat_vertexai_gemini_thinking_auto_include_thoughts(
         full = chunk if full is None else full + chunk
     assert isinstance(full, AIMessageChunk)
 
-    _check_thinking_output(full, output_version)
+    _check_thinking_output(full)
 
     assert full.usage_metadata is not None
     assert full.usage_metadata["output_token_details"]["reasoning"] > 0

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -1689,7 +1689,8 @@ def test_search_builtin(output_version: str) -> None:
         "content": "Tell me more about that last story.",
     }
     response = llm.invoke([input_message, full, next_message])
-    _check_web_search_output(response)
+    assert isinstance(response, AIMessage)
+    assert isinstance(_get_text_content(response), str)
 
 
 def _check_code_execution_output(message: BaseMessage) -> None:

--- a/libs/vertexai/tests/integration_tests/test_maas.py
+++ b/libs/vertexai/tests/integration_tests/test_maas.py
@@ -16,6 +16,7 @@ from langchain_google_vertexai.model_garden_maas import (
     _MISTRAL_MODELS,
     get_vertex_maas_model,
 )
+from tests.integration_tests.conftest import _get_text_content
 
 # `us-east5` quota for `llama-4-maverick` is regularly exhausted by the
 # parametrized sweep (429 `RESOURCE_EXHAUSTED`), and pytest-retry's short
@@ -153,5 +154,5 @@ async def test_tools(model_name: str) -> None:
 
     assert isinstance(result, AIMessage)
     if model_name in _MISTRAL_MODELS:
-        assert "brown" in result.content
+        assert "brown" in _get_text_content(result)
     assert len(result.tool_calls) == 0

--- a/libs/vertexai/tests/integration_tests/test_model_garden.py
+++ b/libs/vertexai/tests/integration_tests/test_model_garden.py
@@ -18,6 +18,7 @@ from langchain_google_vertexai.model_garden import (
     ChatAnthropicVertex,
     VertexAIModelGarden,
 )
+from tests.integration_tests.conftest import _get_text_content
 
 _ANTHROPIC_LOCATION = "us-east5"
 _ANTHROPIC_CLAUDE_MODEL_NAME = "claude-sonnet-4-5@20250929"
@@ -122,7 +123,7 @@ def test_anthropic() -> None:
     message = HumanMessage(content=question)
     response = model.invoke([context, message], model_name=_ANTHROPIC_CLAUDE_MODEL_NAME)
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
+    assert isinstance(_get_text_content(response), str)
 
 
 @pytest.mark.extended
@@ -187,13 +188,13 @@ async def test_anthropic_async() -> None:
         [context, message], model_name=_ANTHROPIC_CLAUDE_MODEL_NAME, temperature=0.2
     )
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
+    assert isinstance(_get_text_content(response), str)
 
 
 def _check_tool_calls(response: BaseMessage, expected_name: str) -> None:
     """Check tool calls are as expected."""
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, list)
+    assert response.content_blocks
     tool_calls = response.tool_calls
     assert len(tool_calls) == 1
     tool_call = tool_calls[0]
@@ -331,8 +332,7 @@ def test_anthropic_multiturn_tool_calling() -> None:
 
     # Verify model responded with final answer
     assert isinstance(response2, AIMessage)
-    assert isinstance(response2.content, str)
-    assert "paris" in response2.content.lower()
+    assert "paris" in _get_text_content(response2).lower()
 
 
 @pytest.mark.extended
@@ -376,7 +376,7 @@ def test_anthropic_tool_error_handling() -> None:
 
     # Verify model acknowledged the error
     assert isinstance(response2, AIMessage)
-    assert isinstance(response2.content, str)
+    assert isinstance(_get_text_content(response2), str)
 
 
 @pytest.mark.extended
@@ -397,7 +397,7 @@ async def test_anthropic_async_invoke_with_betas() -> None:
         betas=["context-1m-2025-08-07"],
     )
     assert isinstance(response, AIMessage)
-    assert isinstance(response.content, str)
+    assert isinstance(_get_text_content(response), str)
 
 
 @pytest.mark.extended

--- a/libs/vertexai/tests/integration_tests/test_vision_models.py
+++ b/libs/vertexai/tests/integration_tests/test_vision_models.py
@@ -11,6 +11,22 @@ from langchain_google_vertexai.vision_models import (
 )
 
 
+def _get_first_image_content_part(
+    message: AIMessage,
+) -> dict[str, dict[str, str] | str]:
+    image_blocks = [
+        block for block in message.content_blocks if block["type"] == "image"
+    ]
+    assert image_blocks
+    image_block = image_blocks[0]
+    return {
+        "type": "image_url",
+        "image_url": {
+            "url": f"data:{image_block['mime_type']};base64,{image_block['base64']}"
+        },
+    }
+
+
 @pytest.mark.skip(
     reason=(
         "Image captioning is deprecated: "
@@ -143,7 +159,7 @@ def test_vertex_ai_image_generation_and_edition() -> None:
     response = generator.invoke(messages)
     assert isinstance(response, AIMessage)
 
-    generated_image = response.content[0]
+    generated_image = _get_first_image_content_part(response)
 
     model = VertexAIImageGeneratorChat()
 


### PR DESCRIPTION
VertexAI integration coverage now validates model responses through normalized `content_blocks` instead of asserting against raw message `.content` shapes. This reduces brittleness around provider-specific output formats, including live Gemini image generation responses that can return an image without a companion text block.