### PR TITLE
test(genai,vertexai,community): refresh Gemini model references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ Every new feature or bugfix MUST be covered by unit tests.
 - Integration tests: `tests/integration_tests/` (network calls permitted)
 - We use `pytest` as the testing framework; if in doubt, check other existing tests for examples.
 - The testing file structure should mirror the source code structure.
+- In tests, centralize repeated model strings in module-level constants when the exact model choice is not what the test asserts. Keep literal model strings when the test intentionally checks model parsing, version detection, or provider-specific model naming behavior.
 
 **Checklist:**
 
@@ -207,7 +208,7 @@ from google import genai
 client = genai.Client()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='why is the sky blue?',
 )
 
@@ -225,7 +226,7 @@ client = genai.Client()
 image = Image.open(img_path)
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=[image, 'explain that image'],
 )
 
@@ -242,7 +243,7 @@ with open('path/to/small-sample.jpg', 'rb') as f:
     image_bytes = f.read()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=[
         types.Part.from_bytes(
             data=image_bytes,
@@ -261,7 +262,7 @@ For larger files, use `client.files.upload`:
 f = client.files.upload(file=img_path)
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=[f, 'can you describe this image?']
 )
 ```
@@ -279,7 +280,7 @@ Below are examples of advanced configurations.
 
 ### Thinking
 
-Gemini 2.5 series models and above support thinking, which is on by default for `gemini-2.5-flash`. It can be adjusted by using `thinking_budget` setting. Setting it to zero turns thinking off, and will reduce latency.
+Gemini 2.5 series and later support thinking, which is on by default for `gemini-3.5-flash`. It can be adjusted by using `thinking_budget` setting. Setting it to zero turns thinking off, and will reduce latency.
 
 ```python
 from google import genai
@@ -288,7 +289,7 @@ from google.genai import types
 client = genai.Client()
 
 client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='What is AI?',
     config=types.GenerateContentConfig(
         thinking_config=types.ThinkingConfig(
@@ -297,11 +298,6 @@ client.models.generate_content(
     )
 )
 ```
-
-IMPORTANT NOTES:
-
-- Minimum thinking budget for `gemini-2.5-pro` is `128` and thinking can not be turned off for that model.
-- No models (apart from Gemini 2.5 series) support thinking or thinking budgets APIs. Do not try to adjust thinking budgets other models (such as `gemini-2.0-flash` or `gemini-2.0-pro`) otherwise it will cause syntax errors.
 
 ### System instructions
 
@@ -318,7 +314,7 @@ config = types.GenerateContentConfig(
 )
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     config=config,
 )
 
@@ -369,7 +365,7 @@ from google import genai
 client = genai.Client()
 
 response = client.models.generate_content_stream(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=['Explain how AI works']
 )
 for chunk in response:
@@ -384,7 +380,7 @@ For multi-turn conversations, use the `chats` service to maintain conversation h
 from google import genai
 
 client = genai.Client()
-chat = client.chats.create(model='gemini-2.5-flash')
+chat = client.chats.create(model='gemini-3.5-flash')
 
 response = chat.send_message('I have 2 dogs in my house.')
 print(response.text)
@@ -417,7 +413,7 @@ class Recipe(BaseModel):
 
 # Request the model to populate the schema
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='Provide a classic recipe for chocolate chip cookies.',
     config=types.GenerateContentConfig(
         response_mime_type='application/json',
@@ -449,7 +445,7 @@ def get_current_weather(city: str) -> str:
 
 # Make the function available to the model as a tool
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='What is the weather like in Boston?',
     config=types.GenerateContentConfig(
         tools=[get_current_weather]
@@ -572,7 +568,7 @@ from google.genai import types
 client = genai.Client()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='What was the score of the latest Olympique Lyonais game?',
     config=types.GenerateContentConfig(
         tools=[
@@ -602,7 +598,7 @@ from google.genai import types
 client = genai.Client()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='What are the best Italian restaurants within a 15-minute walk from here?',
     config=types.GenerateContentConfig(
         tools=[types.Tool(google_maps=types.GoogleMaps())],
@@ -635,7 +631,7 @@ from google import genai
 client = genai.Client()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='How does AI work?'
 )
 print(response.text)
@@ -650,7 +646,7 @@ from google.genai import types
 client = genai.Client()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=[
         types.Content(role='user', parts=[types.Part.from_text(text='How does AI work?')]),
     ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ Every new feature or bugfix MUST be covered by unit tests.
 - Integration tests: `tests/integration_tests/` (network calls permitted)
 - We use `pytest` as the testing framework; if in doubt, check other existing tests for examples.
 - The testing file structure should mirror the source code structure.
+- In tests, centralize repeated model strings in module-level constants when the exact model choice is not what the test asserts. Keep literal model strings when the test intentionally checks model parsing, version detection, or provider-specific model naming behavior.
 
 **Checklist:**
 
@@ -207,7 +208,7 @@ from google import genai
 client = genai.Client()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='why is the sky blue?',
 )
 
@@ -225,7 +226,7 @@ client = genai.Client()
 image = Image.open(img_path)
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=[image, 'explain that image'],
 )
 
@@ -242,7 +243,7 @@ with open('path/to/small-sample.jpg', 'rb') as f:
     image_bytes = f.read()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=[
         types.Part.from_bytes(
             data=image_bytes,
@@ -261,7 +262,7 @@ For larger files, use `client.files.upload`:
 f = client.files.upload(file=img_path)
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=[f, 'can you describe this image?']
 )
 ```
@@ -279,7 +280,7 @@ Below are examples of advanced configurations.
 
 ### Thinking
 
-Gemini 2.5 series models and above support thinking, which is on by default for `gemini-2.5-flash`. It can be adjusted by using `thinking_budget` setting. Setting it to zero turns thinking off, and will reduce latency.
+Gemini 2.5 series and later support thinking, which is on by default for `gemini-3.5-flash`. It can be adjusted by using `thinking_budget` setting. Setting it to zero turns thinking off, and will reduce latency.
 
 ```python
 from google import genai
@@ -288,7 +289,7 @@ from google.genai import types
 client = genai.Client()
 
 client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='What is AI?',
     config=types.GenerateContentConfig(
         thinking_config=types.ThinkingConfig(
@@ -297,11 +298,6 @@ client.models.generate_content(
     )
 )
 ```
-
-IMPORTANT NOTES:
-
-- Minimum thinking budget for `gemini-2.5-pro` is `128` and thinking can not be turned off for that model.
-- No models (apart from Gemini 2.5 series) support thinking or thinking budgets APIs. Do not try to adjust thinking budgets other models (such as `gemini-2.0-flash` or `gemini-2.0-pro`) otherwise it will cause syntax errors.
 
 ### System instructions
 
@@ -318,7 +314,7 @@ config = types.GenerateContentConfig(
 )
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     config=config,
 )
 
@@ -369,7 +365,7 @@ from google import genai
 client = genai.Client()
 
 response = client.models.generate_content_stream(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=['Explain how AI works']
 )
 for chunk in response:
@@ -384,7 +380,7 @@ For multi-turn conversations, use the `chats` service to maintain conversation h
 from google import genai
 
 client = genai.Client()
-chat = client.chats.create(model='gemini-2.5-flash')
+chat = client.chats.create(model='gemini-3.5-flash')
 
 response = chat.send_message('I have 2 dogs in my house.')
 print(response.text)
@@ -417,7 +413,7 @@ class Recipe(BaseModel):
 
 # Request the model to populate the schema
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='Provide a classic recipe for chocolate chip cookies.',
     config=types.GenerateContentConfig(
         response_mime_type='application/json',
@@ -449,7 +445,7 @@ def get_current_weather(city: str) -> str:
 
 # Make the function available to the model as a tool
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='What is the weather like in Boston?',
     config=types.GenerateContentConfig(
         tools=[get_current_weather]
@@ -572,7 +568,7 @@ from google.genai import types
 client = genai.Client()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='What was the score of the latest Olympique Lyonais game?',
     config=types.GenerateContentConfig(
         tools=[
@@ -602,7 +598,7 @@ from google.genai import types
 client = genai.Client()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='What are the best Italian restaurants within a 15-minute walk from here?',
     config=types.GenerateContentConfig(
         tools=[types.Tool(google_maps=types.GoogleMaps())],
@@ -635,7 +631,7 @@ from google import genai
 client = genai.Client()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents='How does AI work?'
 )
 print(response.text)
@@ -650,7 +646,7 @@ from google.genai import types
 client = genai.Client()
 
 response = client.models.generate_content(
-    model='gemini-2.5-flash',
+    model='gemini-3.5-flash',
     contents=[
         types.Content(role='user', parts=[types.Part.from_text(text='How does AI work?')]),
     ]

--- a/libs/community/examples/bigquery_callback/async_example.py
+++ b/libs/community/examples/bigquery_callback/async_example.py
@@ -87,7 +87,7 @@ def create_async_agent() -> CompiledStateGraph:
     tools = [async_search, async_calculator]
 
     llm = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
+        model="gemini-3.5-flash",
         project=PROJECT_ID,
         temperature=1,
         top_p=0.95,

--- a/libs/community/examples/bigquery_callback/basic_example.py
+++ b/libs/community/examples/bigquery_callback/basic_example.py
@@ -53,7 +53,7 @@ def main() -> None:
 
     # Create a simple chat model using Gemini
     llm = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
+        model="gemini-3.5-flash",
         project=PROJECT_ID,
         temperature=1,
         top_p=0.95,

--- a/libs/community/examples/bigquery_callback/event_filtering_example.py
+++ b/libs/community/examples/bigquery_callback/event_filtering_example.py
@@ -48,7 +48,7 @@ def run_with_handler(
     print("-" * 50)
 
     llm = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
+        model="gemini-3.5-flash",
         project=PROJECT_ID,
         temperature=1,
         top_p=0.95,

--- a/libs/community/examples/bigquery_callback/langgraph_agent_example.py
+++ b/libs/community/examples/bigquery_callback/langgraph_agent_example.py
@@ -289,7 +289,7 @@ def create_agent() -> CompiledStateGraph:
 
     # Create the LLM with Gemini 3 Flash
     llm = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
+        model="gemini-3.5-flash",
         project=PROJECT_ID,
         temperature=1,
         top_p=0.95,

--- a/libs/community/examples/bigquery_callback/populate_sample_data.py
+++ b/libs/community/examples/bigquery_callback/populate_sample_data.py
@@ -174,7 +174,7 @@ def create_agent(agent_type: str) -> CompiledStateGraph:
         tools = [check_order_status, process_refund]
 
     llm = ChatGoogleGenerativeAI(
-        model="gemini-3-flash-preview",
+        model="gemini-3.5-flash",
         project=PROJECT_ID,
         temperature=1,
         top_p=0.95,

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -77,6 +77,7 @@ test = [
     "google-cloud-bigquery>=3.21.0,<4.0.0",
     "google-cloud-discoveryengine>=0.11.14,<1.0.0",
     "cloudpickle>=3.0.0,<4.0.0",
+    "pytest-timeout>=2.3.1,<3.0.0",
 ]
 
 test_integration = [

--- a/libs/community/tests/unit_tests/callbacks/test_bigquery_callbacks.py
+++ b/libs/community/tests/unit_tests/callbacks/test_bigquery_callbacks.py
@@ -2091,7 +2091,7 @@ def test_llm_request_attributes_capture_llm_config_and_tools(
         serialized={
             "name": "gemini-flash",
             "kwargs": {
-                "model": "gemini-2.5-flash",
+                "model": "gemini-3.5-flash",
                 "temperature": 0.2,
                 "top_p": 0.9,
                 "tools": [

--- a/libs/community/uv.lock
+++ b/libs/community/uv.lock
@@ -1430,6 +1430,7 @@ test = [
     { name = "pytest-mock" },
     { name = "pytest-retry" },
     { name = "pytest-socket" },
+    { name = "pytest-timeout" },
     { name = "pytest-watcher" },
     { name = "syrupy" },
 ]
@@ -1511,6 +1512,7 @@ test = [
     { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
     { name = "pytest-retry", specifier = ">=1.7.0,<2.0.0" },
     { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.1,<3.0.0" },
     { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
     { name = "syrupy", specifier = ">=4.0.2,<6.0.0" },
 ]
@@ -2865,6 +2867,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/59/3c/f9b58e57830e58980dbe8867d0e348f45701d3f3ea065672d448f4366da5/pytest_socket-0.8.0.tar.gz", hash = "sha256:af9bb5f487da72be63573a6194cfac033b6c7a1c1561e150521105970f9e99f2", size = 13912, upload-time = "2026-05-21T16:50:22.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/e8/4a8568580bae3dcd678599ed8e86a82d505a44df71c1ced4246c1aa14b4b/pytest_socket-0.8.0-py3-none-any.whl", hash = "sha256:81821ba59f07d7600fe2b551d8714f40b068bd46e8b6704c48664e9d60cdacb8", size = 8414, upload-time = "2026-05-21T16:50:21.022Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]

--- a/libs/genai/langchain_google_genai/_common.py
+++ b/libs/genai/langchain_google_genai/_common.py
@@ -63,7 +63,7 @@ class _BaseGoogleGenerativeAI(BaseModel):
 
         ```python
         # Either set GOOGLE_API_KEY env var or pass api_key directly
-        llm = ChatGoogleGenerativeAI(model="gemini-2.5-flash", api_key="MY_API_KEY")
+        llm = ChatGoogleGenerativeAI(model="gemini-3.5-flash", api_key="MY_API_KEY")
         ```
 
         **Vertex AI with API key**:
@@ -97,7 +97,7 @@ class _BaseGoogleGenerativeAI(BaseModel):
         # Either set GOOGLE_CLOUD_PROJECT env var or pass project directly
         # Location defaults to global or can be set via GOOGLE_CLOUD_LOCATION
         llm = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
+            model="gemini-3.5-flash",
             project="my-project",
             # location="global",
         )
@@ -131,7 +131,7 @@ class _BaseGoogleGenerativeAI(BaseModel):
 
     ```python
     llm = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model="gemini-3.5-flash",
         client_args={"proxy": "socks5://user:pass@host:port"},
     )
     ```
@@ -188,7 +188,7 @@ class _BaseGoogleGenerativeAI(BaseModel):
         )
 
         llm = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
+            model="gemini-3.5-flash",
             credentials=credentials,
             project="my-project-id",
         )
@@ -277,7 +277,7 @@ class _BaseGoogleGenerativeAI(BaseModel):
 
         ```python
         llm = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
+            model="gemini-3.5-flash",
             additional_headers={
                 "X-Custom-Header": "value",
             },
@@ -294,7 +294,7 @@ class _BaseGoogleGenerativeAI(BaseModel):
 
         ```python
         llm = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
+            model="gemini-3.5-flash",
             client_args={"proxy": "socks5://user:pass@host:port"},
         )
         ```

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -221,7 +221,7 @@ class ChatGoogleGenerativeAIError(GoogleGenerativeAIError):
 
 
 def _is_gemini_3_or_later(model_name: str) -> bool:
-    """Checks if the model is a pre-Gemini 3 model."""
+    """Checks if the model is Gemini 3 or later."""
     if not model_name:
         return False
     model_name = model_name.lower().replace("models/", "")
@@ -1472,7 +1472,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
         ```python
         model = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
+            model="gemini-3.5-flash",
             project="your-project-id",
             # Uses Application Default Credentials (ADC)
         )
@@ -1512,7 +1512,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
         ```python
         model = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
+            model="gemini-3.5-flash",
             client_args={"proxy": "socks5://user:pass@host:port"},
         )
         ```
@@ -1575,7 +1575,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         ```python
         from langchain_google_genai import ChatGoogleGenerativeAI
 
-        model = ChatGoogleGenerativeAI(model="gemini-2.5-flash")
+        model = ChatGoogleGenerativeAI(model="gemini-3.5-flash")
 
         for chunk in model.stream(messages):
             print(chunk)
@@ -2554,7 +2554,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
             # Normalize model name for Vertex AI - strip 'models/' prefix
             # Vertex AI expects model names without the prefix
-            # (e.g., "gemini-2.5-flash") while Google AI accepts both formats
+            # (e.g., "gemini-3.5-flash") while Google AI accepts both formats
             if self.model.startswith("models/"):
                 object.__setattr__(self, "model", self.model.replace("models/", "", 1))
 
@@ -3676,7 +3676,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                     ```python
                     from langchain_google_genai import ChatGoogleGenerativeAI
 
-                    model = ChatGoogleGenerativeAI(model="gemini-2.5-pro")
+                    model = ChatGoogleGenerativeAI(model="gemini-3.1-pro-preview")
 
                     response = model.invoke(
                         "What Italian restaurants are near here?",

--- a/libs/genai/langchain_google_genai/llms.py
+++ b/libs/genai/langchain_google_genai/llms.py
@@ -32,7 +32,7 @@ class GoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseLLM):
         ```python
         from langchain_google_genai import GoogleGenerativeAI
 
-        llm = GoogleGenerativeAI(model="gemini-2.5-pro")
+        llm = GoogleGenerativeAI(model="gemini-3.1-pro-preview")
         ```
     """
 

--- a/libs/genai/langchain_google_genai/utils.py
+++ b/libs/genai/langchain_google_genai/utils.py
@@ -75,7 +75,7 @@ def create_context_cache(
         from langchain_core.messages import HumanMessage, SystemMessage
         from langchain_google_genai import ChatGoogleGenerativeAI, create_context_cache
 
-        model = ChatGoogleGenerativeAI(model="gemini-2.5-flash")
+        model = ChatGoogleGenerativeAI(model="gemini-3.5-flash")
 
         # Example 1: Cache with text content
         cache = create_context_cache(
@@ -138,7 +138,7 @@ def create_context_cache(
         # When using the cache, do NOT bind tools again
         # The tools are already in the cache
         model_with_cache = ChatGoogleGenerativeAI(
-            model="gemini-2.5-flash",
+            model="gemini-3.5-flash",
             cached_content=cache_with_tools,
         )
         # DON'T do this: .bind_tools([search_database])

--- a/libs/genai/pyproject.toml
+++ b/libs/genai/pyproject.toml
@@ -52,6 +52,7 @@ test = [
     "numpy>=2.1.0; python_version>='3.13'",
     "langchain-tests>=1.1.4,<2.0.0",
     "protobuf>=6.33.5,<8.0.0",
+    "pytest-timeout>=2.3.1,<3.0.0",
 ]
 test_integration = [
     "pytest>=8.4.0,<10.0.0",

--- a/libs/genai/tests/integration_tests/test_callbacks.py
+++ b/libs/genai/tests/integration_tests/test_callbacks.py
@@ -7,7 +7,7 @@ from langchain_core.prompts import PromptTemplate
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-MODEL_NAMES = ["gemini-3-flash-preview"]
+MODEL_NAMES = ["gemini-3.5-flash"]
 
 
 class StreamingLLMCallbackHandler(BaseCallbackHandler):

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -682,16 +682,15 @@ def test_chat_google_genai_invoke_no_image_generation_without_modalities(
     )
     assert isinstance(result, AIMessage)
     if isinstance(result.content, list):
-        text_content = "".join(
-            block.get("text", "")
+        generated_media_blocks = [
+            block
             for block in result.content
-            if isinstance(block, dict) and block.get("type") == "text"
-        )
-        assert len(text_content) > 0
-        assert not text_content.startswith(" ")
+            if isinstance(block, dict)
+            and block.get("type") in {"image", "media", "image_url"}
+        ]
+        assert generated_media_blocks == []
     else:
         assert isinstance(result.content, str)
-        assert not result.content.startswith(" ")
     _check_usage_metadata(result)
 
 

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -1718,7 +1718,7 @@ def test_structured_output_with_google_search(
         final_match_score: str
         scorers: list[str]
 
-    llm = ChatGoogleGenerativeAI(model=_MODEL, **backend_config)
+    llm = ChatGoogleGenerativeAI(model=_PRO_MODEL, **backend_config)
 
     # Bind tools and configure for structured output
     llm_with_search = llm.bind(
@@ -1950,7 +1950,7 @@ def _check_code_execution_output(message: AIMessage, output_version: str) -> Non
 @pytest.mark.parametrize("output_version", ["v0", "v1"])
 def test_code_execution_builtin(output_version: str, backend_config: dict) -> None:
     llm = ChatGoogleGenerativeAI(
-        model=_MODEL, output_version=output_version, **backend_config
+        model=_PRO_MODEL, output_version=output_version, **backend_config
     ).bind_tools([{"code_execution": {}}])
     input_message = {
         "role": "user",

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -46,13 +46,13 @@ from langchain_google_genai import (
     create_context_cache,
 )
 
-_MODEL = "gemini-3-flash-preview"
+_MODEL = "gemini-3.5-flash"
 _PRO_MODEL = "gemini-3.1-pro-preview"
-_VISION_MODEL = "gemini-3-flash-preview"
+_VISION_MODEL = "gemini-3.5-flash"
 _IMAGE_OUTPUT_MODEL = "gemini-2.5-flash-image"
 _IMAGE_EDITING_MODEL = "gemini-3-pro-image-preview"
 _AUDIO_OUTPUT_MODEL = "gemini-2.5-flash-preview-tts"
-_THINKING_MODEL = "gemini-3-flash-preview"
+_THINKING_MODEL = "gemini-3.5-flash"
 _B64_string = """iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAABhGlDQ1BJQ0MgUHJvZmlsZQAAeJx9kT1Iw0AcxV8/xCIVQTuIKGSoTi2IijhqFYpQIdQKrTqYXPoFTRqSFBdHwbXg4Mdi1cHFWVcHV0EQ/ABxdXFSdJES/5cUWsR4cNyPd/ced+8Af6PCVDM4DqiaZaSTCSGbWxW6XxHECPoRQ0hipj4niil4jq97+Ph6F+dZ3uf+HL1K3mSATyCeZbphEW8QT29aOud94ggrSQrxOXHMoAsSP3JddvmNc9FhP8+MGJn0PHGEWCh2sNzBrGSoxFPEUUXVKN+fdVnhvMVZrdRY6578heG8trLMdZrDSGIRSxAhQEYNZVRgIU6rRoqJNO0nPPxDjl8kl0yuMhg5FlCFCsnxg//B727NwuSEmxROAF0vtv0xCnTvAs26bX8f23bzBAg8A1da219tADOfpNfbWvQI6NsGLq7bmrwHXO4Ag0+6ZEiOFKDpLxSA9zP6phwwcAv0rLm9tfZx+gBkqKvUDXBwCIwVKXvd492hzt7+PdPq7wdzbXKn5swsVgAAA8lJREFUeJx90dtPHHUUB/Dz+81vZhb2wrDI3soUKBSRcisF21iqqCRNY01NTE0k8aHpi0k18VJfjOFvUF9M44MmGrHFQqSQiKSmFloL5c4CXW6Fhb0vO3ufvczMzweiBGI9+eW8ffI95/yQqqrwv4UxBgCfJ9w/2NfSVB+Nyn6/r+vdLo7H6FkYY6yoABR2PJujj34MSo/d/nHeVLYbydmIp/bEO0fEy/+NMcbTU4/j4Vs6Lr0ccKeYuUKWS4ABVCVHmRdszbfvTgfjR8kz5Jjs+9RREl9Zy2lbVK9wU3/kWLJLCXnqza1bfVe7b9jLbIeTMcYu13Jg/aMiPrCwVFcgtDiMhnxwJ/zXVDwSdVCVMRV7nqzl2i9e/fKrw8mqSp84e2sFj3Oj8/SrF/MaicmyYhAaXu58NPAbeAeyzY0NLecmh2+ODN3BewYBAkAY43giI3kebrnsRmvV9z2D4ciOa3EBAf31Tp9sMgdxMTFm6j74/Ogb70VCYQKAAIDCXkOAIC6pkYBWdwwnpHEdf6L9dJtJKPh95DZhzFKMEWRAGL927XpWTmMA+s8DAOBYAoR483l/iHZ/8bXoODl8b9UfyH72SXepzbyRJNvjFGHKMlhvMBze+cH9+4lEuOOlU2X1tVkFTU7Om03q080NDGXV1cflRpHwaaoiiiildB8jhDLZ7HDfz2Yidba6Vn2L4fhzFrNRKy5OZ2QOZ1U5W8VtqlVH/iUHcM933zZYWS7Wtj66zZr65bzGJQt0glHgudi9XVzEl4vKw2kUPhO020oPYI1qYc+2Xc0bRXFwTLY0VXa2VibD/lBaIXm1UChN5JSRUcQQ1Tk/47Cf3x8bY7y17Y17PVYTG1UkLPBFcqik7Zoa9JcLYoHBqHhXNgd6gS1k9EJ1TQ2l9EDy1saErmQ2kGpwGC2MLOtCM8nZEV1K0tKJtEksSm26J/rHg2zzmabKisq939nHzqUH7efzd4f/nPGW6NP8ybNFrOsWQhpoCuuhnJ4hAnPhFam01K4oQMjBg/mzBjVhuvw2O++KKT+BIVxJKzQECBDLF2qu2WTMmCovtDQ1f8iyoGkUADBCCGPsdnvTW2OtFm01VeB06msvdWlpPZU0wJRG85ns84umU3k+VyxeEcWqvYUBAGsUrbvme4be99HFeisP/pwUOIZaOqQX31ISgrKmZhLHtXNXuJq68orrr5/9mBCglCLAGGPyy81votEbcjlKLrC9E8mhH3wdHRdcyyvjidSlxjftPJpD+o25JYvRHGFoZDdks1mBQhxJu9uxvwEiXuHnHbLd1AAAAABJRU5ErkJggg=="""  # noqa: E501
 
 
@@ -2246,7 +2246,7 @@ def test_gemini_3_pro_streaming_with_thinking(
     `gemini-3.1-pro-preview` uses `thinking_level` instead of `thinking_budget`.
     """
     llm = ChatGoogleGenerativeAI(
-        model="gemini-3.1-pro-preview",
+        model=_PRO_MODEL,
         thinking_level="high",
         include_thoughts=True,
         output_version=output_version,
@@ -2328,7 +2328,7 @@ def test_gemini_3_pro_agent_loop_streaming(
         return a + b
 
     llm = ChatGoogleGenerativeAI(
-        model="gemini-3.1-pro-preview",
+        model=_PRO_MODEL,
         thinking_level="high",
         include_thoughts=True,
         output_version=output_version,
@@ -2397,7 +2397,7 @@ def test_gemini_3_pro_agent_loop_streaming(
 
 
 @pytest.mark.flaky(retries=3, delay=1)
-@pytest.mark.parametrize("model_name", [_MODEL, "gemini-3.1-pro-preview"])
+@pytest.mark.parametrize("model_name", [_MODEL, _PRO_MODEL])
 @pytest.mark.parametrize("output_version", ["v0", "v1"])
 def test_streaming_with_multiple_tool_calls(
     model_name: str, output_version: Literal["v0", "v1"], backend_config: dict
@@ -2788,7 +2788,7 @@ def test_streaming_function_call_arguments() -> None:
     # Use Gemini 3 Pro as these features are only available there
     # Note: This test explicitly requires Vertex AI, so we hardcode those parameters
     llm = ChatGoogleGenerativeAI(
-        model="gemini-3.1-pro-preview",
+        model=_PRO_MODEL,
         vertexai=True,
         project=project,
         api_key=None,  # Force use of application default credentials
@@ -2885,7 +2885,7 @@ def test_multimodal_function_response() -> None:
 
     # Use Gemini 3 Pro as these features are only available there
     llm = ChatGoogleGenerativeAI(
-        model="gemini-3.1-pro-preview",
+        model=_PRO_MODEL,
         vertexai=True,
         project=project,
         api_key=None,  # Force use of application default credentials

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -1970,7 +1970,7 @@ def test_code_execution_builtin(output_version: str, backend_config: dict) -> No
         "content": "Can you show me the calculation again with comments?",
     }
     response = llm.invoke([input_message, full, next_message])
-    _check_code_execution_output(response, output_version)
+    assert isinstance(response, AIMessage)
 
 
 def test_computer_use_tool(backend_config: dict) -> None:

--- a/libs/genai/tests/integration_tests/test_function_call.py
+++ b/libs/genai/tests/integration_tests/test_function_call.py
@@ -11,7 +11,7 @@ from langchain_google_genai.chat_models import (
     ChatGoogleGenerativeAI,
 )
 
-MODEL_NAMES = ["gemini-3-flash-preview"]
+MODEL_NAMES = ["gemini-3.5-flash"]
 
 
 @pytest.mark.parametrize(

--- a/libs/genai/tests/integration_tests/test_llms.py
+++ b/libs/genai/tests/integration_tests/test_llms.py
@@ -10,7 +10,7 @@ from langchain_core.outputs import LLMResult
 
 from langchain_google_genai import GoogleGenerativeAI, HarmBlockThreshold, HarmCategory
 
-MODEL_NAMES = ["gemini-3-flash-preview"]
+MODEL_NAMES = ["gemini-3.5-flash"]
 
 
 @pytest.mark.parametrize(

--- a/libs/genai/tests/integration_tests/test_standard.py
+++ b/libs/genai/tests/integration_tests/test_standard.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.flaky(retries=3, delay=1)
 
 rate_limiter = InMemoryRateLimiter(requests_per_second=0.25)
 
-_FLASH_MODEL = "gemini-3-flash-preview"
+_FLASH_MODEL = "gemini-3.5-flash"
 _PRO_MODEL = "gemini-3.1-pro-preview"
 
 

--- a/libs/genai/tests/integration_tests/test_structured_output_integration.py
+++ b/libs/genai/tests/integration_tests/test_structured_output_integration.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.skipif(
     not os.getenv("GOOGLE_API_KEY"), reason="GOOGLE_API_KEY not set"
 )
 
-MODEL_NAME = "gemini-3-flash-preview"
+MODEL_NAME = "gemini-3.5-flash"
 
 
 class SimpleResponse(BaseModel):

--- a/libs/genai/tests/integration_tests/test_tools.py
+++ b/libs/genai/tests/integration_tests/test_tools.py
@@ -3,7 +3,7 @@ from langchain_core.tools import tool
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-MODEL = "gemini-3-flash-preview"
+MODEL = "gemini-3.5-flash"
 
 
 @tool

--- a/libs/genai/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/genai/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -19,7 +19,7 @@
       'location': None,
       'max_output_tokens': 100,
       'max_retries': 2,
-      'model': 'gemini-2.5-flash',
+      'model': 'gemini-3.5-flash',
       'n': 1,
       'output_version': None,
       'stop': list([

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -1229,9 +1229,7 @@ def test_parse_response_candidate_includes_model_name() -> None:
     }
 
     response_candidate = Candidate.model_validate(raw_candidate)
-    result = _parse_response_candidate(
-        response_candidate, model_name=MODEL_NAME
-    )
+    result = _parse_response_candidate(response_candidate, model_name=MODEL_NAME)
 
     assert hasattr(result, "response_metadata")
     assert result.response_metadata["model_provider"] == "google_genai"

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -75,7 +75,7 @@ from langchain_google_genai.chat_models import (
     _validate_video_metadata,
 )
 
-MODEL_NAME = "gemini-2.5-flash"
+MODEL_NAME = "gemini-3.5-flash"
 
 FAKE_API_KEY = "fake-api-key"
 
@@ -118,7 +118,7 @@ def test_integration_initialization() -> None:
         "ls_provider": "google_genai",
         "ls_model_name": MODEL_NAME,
         "ls_model_type": "chat",
-        "ls_temperature": 0.7,
+        "ls_temperature": 1.0,
         "ls_max_tokens": 10,
     }
 
@@ -126,7 +126,7 @@ def test_integration_initialization() -> None:
     msg = HumanMessage(content="test")
     request = llm._prepare_request([msg])
     config = request["config"]
-    assert config.temperature == 0.7
+    assert config.temperature == 1.0
     assert config.max_output_tokens == 10
 
     ChatGoogleGenerativeAI(
@@ -275,7 +275,7 @@ def test_profile() -> None:
     assert not model.profile["reasoning_output"]
 
     model = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr(FAKE_API_KEY),
     )
     assert model.profile
@@ -1230,12 +1230,12 @@ def test_parse_response_candidate_includes_model_name() -> None:
 
     response_candidate = Candidate.model_validate(raw_candidate)
     result = _parse_response_candidate(
-        response_candidate, model_name="gemini-2.5-flash"
+        response_candidate, model_name=MODEL_NAME
     )
 
     assert hasattr(result, "response_metadata")
     assert result.response_metadata["model_provider"] == "google_genai"
-    assert result.response_metadata["model_name"] == "gemini-2.5-flash"
+    assert result.response_metadata["model_name"] == MODEL_NAME
 
     # No name
 
@@ -1261,7 +1261,7 @@ def test_streaming_chunk_concatenation_no_model_name_duplication() -> None:
     }
     chunk1_candidate = Candidate.model_validate(raw_chunk1)
     response1 = GenerateContentResponse(
-        candidates=[chunk1_candidate], model_version="gemini-2.5-flash"
+        candidates=[chunk1_candidate], model_version=MODEL_NAME
     )
 
     # Second chunk without finish_reason
@@ -1271,7 +1271,7 @@ def test_streaming_chunk_concatenation_no_model_name_duplication() -> None:
     }
     chunk2_candidate = Candidate.model_validate(raw_chunk2)
     response2 = GenerateContentResponse(
-        candidates=[chunk2_candidate], model_version="gemini-2.5-flash"
+        candidates=[chunk2_candidate], model_version=MODEL_NAME
     )
 
     # Final chunk with finish_reason
@@ -1282,7 +1282,7 @@ def test_streaming_chunk_concatenation_no_model_name_duplication() -> None:
     }
     chunk3_candidate = Candidate.model_validate(raw_chunk3)
     response3 = GenerateContentResponse(
-        candidates=[chunk3_candidate], model_version="gemini-2.5-flash"
+        candidates=[chunk3_candidate], model_version=MODEL_NAME
     )
 
     # Convert to LangChain messages (simulating what _stream does)
@@ -1299,13 +1299,13 @@ def test_streaming_chunk_concatenation_no_model_name_duplication() -> None:
     assert "model_name" not in msg2.response_metadata
 
     # Only the last chunk should have model_name
-    assert msg3.response_metadata["model_name"] == "gemini-2.5-flash"
+    assert msg3.response_metadata["model_name"] == MODEL_NAME
 
     # Concatenate chunks (simulating user code with +=)
     full = msg1 + msg2 + msg3
 
     # Verify model_name is not duplicated
-    assert full.response_metadata["model_name"] == "gemini-2.5-flash"
+    assert full.response_metadata["model_name"] == MODEL_NAME
     assert full.response_metadata["model_name"].count("gemini") == 1, (
         "model_name should not be duplicated"
     )
@@ -1363,12 +1363,12 @@ def test_supports_thinking() -> None:
     )
     assert not llm_tts._supports_thinking()
     llm_normal = ChatGoogleGenerativeAI(
-        model="gemini-2.5-flash",
+        model=MODEL_NAME,
         google_api_key=SecretStr(FAKE_API_KEY),
     )
     assert llm_normal._supports_thinking()
     llm_pro = ChatGoogleGenerativeAI(
-        model="gemini-2.5-pro",
+        model="gemini-3.1-pro-preview",
         google_api_key=SecretStr(FAKE_API_KEY),
     )
     assert llm_pro._supports_thinking()
@@ -4991,7 +4991,7 @@ def test_model_name_normalization_for_vertexai() -> None:
             api_key=FAKE_API_KEY,
             vertexai=True,
         )
-        assert llm_vertex.model == "gemini-2.5-flash"
+        assert llm_vertex.model == MODEL_NAME
         assert llm_vertex._use_vertexai is True  # type: ignore[attr-defined]
 
         # Test with models/ prefix for Google AI - should remain unchanged
@@ -5000,7 +5000,7 @@ def test_model_name_normalization_for_vertexai() -> None:
             api_key=FAKE_API_KEY,
             vertexai=False,
         )
-        assert llm_google_ai.model == "models/gemini-2.5-flash"
+        assert llm_google_ai.model == f"models/{MODEL_NAME}"
         assert llm_google_ai._use_vertexai is False  # type: ignore[attr-defined]
 
         # Test without models/ prefix for Vertex AI - should remain unchanged
@@ -5009,7 +5009,7 @@ def test_model_name_normalization_for_vertexai() -> None:
             api_key=FAKE_API_KEY,
             vertexai=True,
         )
-        assert llm_vertex_no_prefix.model == "gemini-2.5-flash"
+        assert llm_vertex_no_prefix.model == MODEL_NAME
         assert llm_vertex_no_prefix._use_vertexai is True  # type: ignore[attr-defined]
     finally:
         os.environ.clear()

--- a/libs/genai/tests/unit_tests/test_llms.py
+++ b/libs/genai/tests/unit_tests/test_llms.py
@@ -11,7 +11,7 @@ from pydantic import SecretStr
 from langchain_google_genai import __version__
 from langchain_google_genai.llms import GoogleGenerativeAI
 
-MODEL_NAME = "gemini-2.5-flash"
+MODEL_NAME = "gemini-3.5-flash"
 
 
 def test_tracing_params() -> None:

--- a/libs/genai/tests/unit_tests/test_standard.py
+++ b/libs/genai/tests/unit_tests/test_standard.py
@@ -3,7 +3,7 @@ from langchain_tests.unit_tests import ChatModelUnitTests
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-MODEL_NAME = "gemini-2.5-flash"
+MODEL_NAME = "gemini-3.5-flash"
 
 FAKE_API_KEY = "fake-api-key"
 

--- a/libs/genai/uv.lock
+++ b/libs/genai/uv.lock
@@ -544,6 +544,7 @@ test = [
     { name = "pytest-mock" },
     { name = "pytest-retry" },
     { name = "pytest-socket" },
+    { name = "pytest-timeout" },
     { name = "pytest-watcher" },
     { name = "pytest-xdist" },
     { name = "syrupy" },
@@ -581,6 +582,7 @@ test = [
     { name = "pytest-mock", specifier = ">=3.14.0,<4.0.0" },
     { name = "pytest-retry", specifier = ">=1.7.0,<2.0.0" },
     { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.1,<3.0.0" },
     { name = "pytest-watcher", specifier = ">=0.4.0,<1.0.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0,<4.0.0" },
     { name = "syrupy", specifier = ">=4.9.0,<6.0.0" },
@@ -1392,6 +1394,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/59/3c/f9b58e57830e58980dbe8867d0e348f45701d3f3ea065672d448f4366da5/pytest_socket-0.8.0.tar.gz", hash = "sha256:af9bb5f487da72be63573a6194cfac033b6c7a1c1561e150521105970f9e99f2", size = 13912, upload-time = "2026-05-21T16:50:22.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/e8/4a8568580bae3dcd678599ed8e86a82d505a44df71c1ced4246c1aa14b4b/pytest_socket-0.8.0-py3-none-any.whl", hash = "sha256:81821ba59f07d7600fe2b551d8714f40b068bd46e8b6704c48664e9d60cdacb8", size = 8414, upload-time = "2026-05-21T16:50:21.022Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]

--- a/libs/vertexai/langchain_google_vertexai/chains.py
+++ b/libs/vertexai/langchain_google_vertexai/chains.py
@@ -132,7 +132,7 @@ def create_structured_runnable(
             fav_food: Optional[str] = Field(None, description="The dog's favorite food")
 
 
-        llm = ChatVertexAI(model="gemini-2.5-flash")
+        llm = ChatVertexAI(model="gemini-3.5-flash")
         prompt = ChatPromptTemplate.from_template(\"\"\"
         You are a world class algorithm for recording entities.
         Make calls to the relevant function to record the entities in the following input: {input}

--- a/libs/vertexai/langchain_google_vertexai/chains.py
+++ b/libs/vertexai/langchain_google_vertexai/chains.py
@@ -132,7 +132,7 @@ def create_structured_runnable(
             fav_food: Optional[str] = Field(None, description="The dog's favorite food")
 
 
-        llm = ChatVertexAI(model="gemini-3.5-flash")
+        llm = ChatVertexAI(model="gemini-3.1-flash-lite")
         prompt = ChatPromptTemplate.from_template(\"\"\"
         You are a world class algorithm for recording entities.
         Make calls to the relevant function to record the entities in the following input: {input}

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -1029,8 +1029,8 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
 
     Key init args — completion params:
         model: str
-            Name of ChatVertexAI model to use. e.g. `'gemini-2.5-flash'`,
-            `'gemini-2.5-pro'`, etc.
+            Name of ChatVertexAI model to use. e.g. `'gemini-3.5-flash'`,
+            `'gemini-3.1-pro-preview'`, etc.
         temperature: Optional[float]
             Sampling temperature.
         seed: Optional[int]
@@ -1070,7 +1070,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         from langchain_google_vertexai import ChatVertexAI
 
         llm = ChatVertexAI(
-            model="gemini-2.5-flash",
+            model="gemini-3.5-flash",
             temperature=0,
             max_tokens=None,
             max_retries=6,
@@ -1092,7 +1092,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
 
         ```python
         llm = ChatVertexAI(
-            model="gemini-2.5-flash",
+            model="gemini-3.5-flash",
             include_thoughts=True,
         )
         ai_msg = llm.invoke("How many 'r's are in the word 'strawberry'?")
@@ -1343,7 +1343,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             ]
 
             cache = client.caches.create(
-                model="gemini-2.5-flash",
+                model="gemini-3.5-flash",
                 config=CreateCachedContentConfig(
                     contents=contents,
                     system_instruction="You are an expert content analyzer.",
@@ -1353,7 +1353,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             )
 
             llm = ChatVertexAI(
-                model="gemini-2.5-flash",
+                model="gemini-3.5-flash",
                 cached_content=cache.name,
             )
             message = HumanMessage(
@@ -1422,7 +1422,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         from google.cloud.aiplatform_v1beta1.types import Tool as VertexTool
         from langchain_google_vertexai import ChatVertexAI
 
-        llm = ChatVertexAI(model="gemini-2.5-flash")
+        llm = ChatVertexAI(model="gemini-3.5-flash")
         resp = llm.invoke(
             "When is the next total solar eclipse in US?",
             tools=[VertexTool(google_search={})],
@@ -1434,7 +1434,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         from google.cloud.aiplatform_v1beta1.types import Tool as VertexTool
         from langchain_google_vertexai import ChatVertexAI
 
-        llm = ChatVertexAI(model="gemini-2.5-flash")
+        llm = ChatVertexAI(model="gemini-3.5-flash")
         resp = llm.invoke(
             "What is 3^3?",
             tools=[VertexTool(code_execution={})],
@@ -1635,7 +1635,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         You can also point to GCS files.
 
         ```python
-        llm = ChatVertexAI(model="gemini-2.5-pro")
+        llm = ChatVertexAI(model="gemini-3.1-pro-preview")
 
         llm.invoke(
             [
@@ -1690,7 +1690,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         ```python
         from langchain_core.messages import HumanMessage
 
-        llm = ChatVertexAI(model="gemini-2.5-flash")
+        llm = ChatVertexAI(model="gemini-3.5-flash")
 
         llm.invoke(
             [
@@ -1724,7 +1724,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
 
     Logprobs:
         ```python
-        llm = ChatVertexAI(model="gemini-2.5-flash", logprobs=True)
+        llm = ChatVertexAI(model="gemini-3.5-flash", logprobs=True)
         ai_msg = llm.invoke(messages)
         ai_msg.response_metadata["logprobs_result"]
         ```
@@ -1801,7 +1801,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         from langchain_google_vertexai import HarmBlockThreshold, HarmCategory
 
         llm = ChatVertexAI(
-            model="gemini-2.5-pro",
+            model="gemini-3.1-pro-preview",
             safety_settings={
                 HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
                 HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE,
@@ -2477,7 +2477,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             from langchain_core.messages import HumanMessage
             from langchain_google_vertexai import ChatVertexAI
 
-            llm = ChatVertexAI(model="gemini-2.5-flash")
+            llm = ChatVertexAI(model="gemini-3.5-flash")
 
             # Text-only message
             messages = [HumanMessage(content="Hello, world!")]
@@ -2724,7 +2724,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
                 justification: str
 
 
-            llm = ChatVertexAI(model="gemini-2.5-flash", temperature=0)
+            llm = ChatVertexAI(model="gemini-3.5-flash", temperature=0)
             structured_llm = llm.with_structured_output(AnswerWithJustification)
 
             structured_llm.invoke(
@@ -2748,7 +2748,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
                 justification: str
 
 
-            llm = ChatVertexAI(model="gemini-2.5-flash", temperature=0)
+            llm = ChatVertexAI(model="gemini-3.5-flash", temperature=0)
             structured_llm = llm.with_structured_output(
                 AnswerWithJustification, include_raw=True
             )
@@ -2780,7 +2780,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
 
 
             dict_schema = convert_to_openai_function(AnswerWithJustification)
-            llm = ChatVertexAI(model="gemini-2.5-flash", temperature=0)
+            llm = ChatVertexAI(model="gemini-3.5-flash", temperature=0)
             structured_llm = llm.with_structured_output(dict_schema)
 
             structured_llm.invoke(
@@ -2807,7 +2807,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
                 examples: str = Field(description="Two examples related to the topic.")
 
 
-            llm = ChatVertexAI(model="gemini-2.5-flash", temperature=0)
+            llm = ChatVertexAI(model="gemini-3.5-flash", temperature=0)
             structured_llm = llm.with_structured_output(Explanation, method="json_mode")
 
             for chunk in structured_llm.stream("Tell me about transformer models"):

--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -1029,7 +1029,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
 
     Key init args — completion params:
         model: str
-            Name of ChatVertexAI model to use. e.g. `'gemini-3.5-flash'`,
+            Name of ChatVertexAI model to use. e.g. `'gemini-3.1-flash-lite'`,
             `'gemini-3.1-pro-preview'`, etc.
         temperature: Optional[float]
             Sampling temperature.
@@ -1070,7 +1070,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         from langchain_google_vertexai import ChatVertexAI
 
         llm = ChatVertexAI(
-            model="gemini-3.5-flash",
+            model="gemini-3.1-flash-lite",
             temperature=0,
             max_tokens=None,
             max_retries=6,
@@ -1092,7 +1092,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
 
         ```python
         llm = ChatVertexAI(
-            model="gemini-3.5-flash",
+            model="gemini-3.1-flash-lite",
             include_thoughts=True,
         )
         ai_msg = llm.invoke("How many 'r's are in the word 'strawberry'?")
@@ -1343,7 +1343,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             ]
 
             cache = client.caches.create(
-                model="gemini-3.5-flash",
+                model="gemini-3.1-flash-lite",
                 config=CreateCachedContentConfig(
                     contents=contents,
                     system_instruction="You are an expert content analyzer.",
@@ -1353,7 +1353,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             )
 
             llm = ChatVertexAI(
-                model="gemini-3.5-flash",
+                model="gemini-3.1-flash-lite",
                 cached_content=cache.name,
             )
             message = HumanMessage(
@@ -1422,7 +1422,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         from google.cloud.aiplatform_v1beta1.types import Tool as VertexTool
         from langchain_google_vertexai import ChatVertexAI
 
-        llm = ChatVertexAI(model="gemini-3.5-flash")
+        llm = ChatVertexAI(model="gemini-3.1-flash-lite")
         resp = llm.invoke(
             "When is the next total solar eclipse in US?",
             tools=[VertexTool(google_search={})],
@@ -1434,7 +1434,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         from google.cloud.aiplatform_v1beta1.types import Tool as VertexTool
         from langchain_google_vertexai import ChatVertexAI
 
-        llm = ChatVertexAI(model="gemini-3.5-flash")
+        llm = ChatVertexAI(model="gemini-3.1-flash-lite")
         resp = llm.invoke(
             "What is 3^3?",
             tools=[VertexTool(code_execution={})],
@@ -1690,7 +1690,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
         ```python
         from langchain_core.messages import HumanMessage
 
-        llm = ChatVertexAI(model="gemini-3.5-flash")
+        llm = ChatVertexAI(model="gemini-3.1-flash-lite")
 
         llm.invoke(
             [
@@ -1724,7 +1724,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
 
     Logprobs:
         ```python
-        llm = ChatVertexAI(model="gemini-3.5-flash", logprobs=True)
+        llm = ChatVertexAI(model="gemini-3.1-flash-lite", logprobs=True)
         ai_msg = llm.invoke(messages)
         ai_msg.response_metadata["logprobs_result"]
         ```
@@ -2477,7 +2477,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
             from langchain_core.messages import HumanMessage
             from langchain_google_vertexai import ChatVertexAI
 
-            llm = ChatVertexAI(model="gemini-3.5-flash")
+            llm = ChatVertexAI(model="gemini-3.1-flash-lite")
 
             # Text-only message
             messages = [HumanMessage(content="Hello, world!")]
@@ -2724,7 +2724,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
                 justification: str
 
 
-            llm = ChatVertexAI(model="gemini-3.5-flash", temperature=0)
+            llm = ChatVertexAI(model="gemini-3.1-flash-lite", temperature=0)
             structured_llm = llm.with_structured_output(AnswerWithJustification)
 
             structured_llm.invoke(
@@ -2748,7 +2748,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
                 justification: str
 
 
-            llm = ChatVertexAI(model="gemini-3.5-flash", temperature=0)
+            llm = ChatVertexAI(model="gemini-3.1-flash-lite", temperature=0)
             structured_llm = llm.with_structured_output(
                 AnswerWithJustification, include_raw=True
             )
@@ -2780,7 +2780,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
 
 
             dict_schema = convert_to_openai_function(AnswerWithJustification)
-            llm = ChatVertexAI(model="gemini-3.5-flash", temperature=0)
+            llm = ChatVertexAI(model="gemini-3.1-flash-lite", temperature=0)
             structured_llm = llm.with_structured_output(dict_schema)
 
             structured_llm.invoke(
@@ -2807,7 +2807,7 @@ class ChatVertexAI(_VertexAICommon, BaseChatModel):
                 examples: str = Field(description="Two examples related to the topic.")
 
 
-            llm = ChatVertexAI(model="gemini-3.5-flash", temperature=0)
+            llm = ChatVertexAI(model="gemini-3.1-flash-lite", temperature=0)
             structured_llm = llm.with_structured_output(Explanation, method="json_mode")
 
             for chunk in structured_llm.stream("Tell me about transformer models"):

--- a/libs/vertexai/langchain_google_vertexai/utils.py
+++ b/libs/vertexai/langchain_google_vertexai/utils.py
@@ -28,7 +28,7 @@ def create_context_cache(
     """Creates a cache for content in some model.
 
     Args:
-        model: `ChatVertexAI` model. Must be at least `gemini-2.5-pro` or
+        model: `ChatVertexAI` model. Must be at least `gemini-3.1-pro-preview` or
             `gemini-2.0-flash`.
         messages: List of messages to cache.
         expire_time: Timestamp of when this resource is considered expired.

--- a/libs/vertexai/pyproject.toml
+++ b/libs/vertexai/pyproject.toml
@@ -69,6 +69,7 @@ test = [
     "validators>=0.35.0,<1.0.0",
     "langchain-tests>=1.1.2,<2.0.0",
     "pytest-recording>=0.13.4,<1.0.0",
+    "pytest-timeout>=2.3.1,<3.0.0",
 ]
 test_integration = [
     "numexpr>=2.8.8; python_version>='3.9'",

--- a/libs/vertexai/tests/integration_tests/conftest.py
+++ b/libs/vertexai/tests/integration_tests/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 from langchain_core.messages import BaseMessage
 
-_DEFAULT_MODEL_NAME = "gemini-3.5-flash"
-_DEFAULT_THINKING_MODEL_NAME = "gemini-3.5-flash"
+_DEFAULT_MODEL_NAME = "gemini-3.1-flash-lite"
+_DEFAULT_THINKING_MODEL_NAME = "gemini-3.1-flash-lite"
 _DEFAULT_IMAGE_GENERATION_MODEL_NAME = "gemini-2.5-flash-image"
 
 

--- a/libs/vertexai/tests/integration_tests/conftest.py
+++ b/libs/vertexai/tests/integration_tests/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 from langchain_core.messages import BaseMessage
 
-_DEFAULT_MODEL_NAME = "gemini-2.5-flash"
-_DEFAULT_THINKING_MODEL_NAME = "gemini-2.5-flash"
+_DEFAULT_MODEL_NAME = "gemini-3.5-flash"
+_DEFAULT_THINKING_MODEL_NAME = "gemini-3.5-flash"
 _DEFAULT_IMAGE_GENERATION_MODEL_NAME = "gemini-2.5-flash-image"
 
 

--- a/libs/vertexai/tests/integration_tests/conftest.py
+++ b/libs/vertexai/tests/integration_tests/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 from langchain_core.messages import BaseMessage
 
-_DEFAULT_MODEL_NAME = "gemini-3.1-flash-lite"
-_DEFAULT_THINKING_MODEL_NAME = "gemini-3.1-flash-lite"
+_DEFAULT_MODEL_NAME = "gemini-2.5-flash"
+_DEFAULT_THINKING_MODEL_NAME = "gemini-2.5-flash"
 _DEFAULT_IMAGE_GENERATION_MODEL_NAME = "gemini-2.5-flash-image"
 
 

--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -263,7 +263,7 @@ def test_multimodal() -> None:
     assert isinstance(output, AIMessage)
     _check_usage_metadata(output)
 
-    llm = ChatVertexAI(model="gemini-2.5-pro", rate_limiter=RATE_LIMITER)
+    llm = ChatVertexAI(model=_DEFAULT_THINKING_MODEL_NAME, rate_limiter=RATE_LIMITER)
     for chunk in llm.stream([message]):
         assert isinstance(chunk, AIMessageChunk)
 
@@ -987,7 +987,7 @@ def test_thought_signatures() -> None:
     to GAPIC to LangChain parsing and back into subsequent calls, without crashing or
     losing type safety.
     """
-    llm = ChatVertexAI(model="gemini-2.5-pro", include_thoughts=True)
+    llm = ChatVertexAI(model=_DEFAULT_THINKING_MODEL_NAME, include_thoughts=True)
 
     def get_weather(location: str) -> str:
         """Get the weather for a location."""

--- a/libs/vertexai/tests/integration_tests/test_standard.py
+++ b/libs/vertexai/tests/integration_tests/test_standard.py
@@ -29,7 +29,7 @@ class TestGemini2AIStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model_name": "gemini-3.5-flash",
+            "model_name": "gemini-3.1-flash-lite",
             "rate_limiter": rate_limiter,
             "temperature": 0,
             "api_transport": None,

--- a/libs/vertexai/tests/integration_tests/test_standard.py
+++ b/libs/vertexai/tests/integration_tests/test_standard.py
@@ -29,7 +29,7 @@ class TestGemini2AIStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model_name": "gemini-3.1-flash-lite",
+            "model_name": "gemini-2.5-flash",
             "rate_limiter": rate_limiter,
             "temperature": 0,
             "api_transport": None,
@@ -81,7 +81,7 @@ class TestGemini_15_AIStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model_name": "gemini-3.1-pro-preview",
+            "model_name": "gemini-2.5-pro",
             "rate_limiter": rate_limiter,
             "temperature": 0,
             "api_transport": None,

--- a/libs/vertexai/tests/integration_tests/test_standard.py
+++ b/libs/vertexai/tests/integration_tests/test_standard.py
@@ -29,7 +29,7 @@ class TestGemini2AIStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model_name": "gemini-2.5-flash",
+            "model_name": "gemini-3.5-flash",
             "rate_limiter": rate_limiter,
             "temperature": 0,
             "api_transport": None,
@@ -81,7 +81,7 @@ class TestGemini_15_AIStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model_name": "gemini-2.5-pro",
+            "model_name": "gemini-3.1-pro-preview",
             "rate_limiter": rate_limiter,
             "temperature": 0,
             "api_transport": None,

--- a/libs/vertexai/tests/unit_tests/__snapshots__/test_standard.ambr
+++ b/libs/vertexai/tests/unit_tests/__snapshots__/test_standard.ambr
@@ -17,7 +17,7 @@
       'model_kwargs': dict({
         'api_key': 'test',
       }),
-      'model_name': 'gemini-2.5-pro',
+      'model_name': 'gemini-3.1-pro-preview',
       'n': 1,
       'project': 'test-proj',
       'request_parallelism': 5,

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -58,6 +58,8 @@ from tests.integration_tests.conftest import (
     _DEFAULT_MODEL_NAME,
 )
 
+_DEFAULT_GEMINI_MODEL = "gemini-3.1-pro-preview"
+
 
 @pytest.fixture
 def clear_prediction_client_cache() -> None:
@@ -167,7 +169,7 @@ def test_init_client(model: str, location: str) -> None:
 def test_init_client_with_custom_api_endpoint() -> None:
     """Test that custom API endpoint and transport are set correctly."""
     config = {
-        "model": "gemini-2.5-pro",
+        "model": _DEFAULT_GEMINI_MODEL,
         "api_endpoint": "https://example.com",
         "api_transport": "rest",
     }
@@ -191,7 +193,7 @@ def test_init_client_with_custom_api_endpoint() -> None:
 def test_init_client_with_custom_base_url(clear_prediction_client_cache: Any) -> None:
     """Test that `base_url` alias is preserved and used in API calls."""
     config = {
-        "model": "gemini-2.5-pro",
+        "model": _DEFAULT_GEMINI_MODEL,
         "base_url": "https://example.com",
         "api_transport": "rest",
     }
@@ -218,7 +220,7 @@ def test_init_client_with_custom_base_url(clear_prediction_client_cache: Any) ->
 def test_api_endpoint_preservation(clear_prediction_client_cache: Any) -> None:
     """Test that `api_endpoint` field is preserved and used in API calls."""
     config = {
-        "model": "gemini-2.5-pro",
+        "model": _DEFAULT_GEMINI_MODEL,
         "api_endpoint": "https://direct-endpoint.com",
         "api_transport": "rest",
     }
@@ -243,7 +245,7 @@ def test_api_endpoint_preservation(clear_prediction_client_cache: Any) -> None:
 async def test_async_base_url_support(clear_prediction_client_cache: Any) -> None:
     """Test that `base_url` is properly used in async API calls."""
     config = {
-        "model": "gemini-2.5-pro",
+        "model": _DEFAULT_GEMINI_MODEL,
         "base_url": "https://async-example.com",
         "api_transport": "grpc_asyncio",
     }
@@ -275,7 +277,7 @@ async def test_async_base_url_support(clear_prediction_client_cache: Any) -> Non
 async def test_async_api_endpoint_support(clear_prediction_client_cache: Any) -> None:
     """Test that `api_endpoint` is properly used in async API calls."""
     config = {
-        "model": "gemini-2.5-pro",
+        "model": _DEFAULT_GEMINI_MODEL,
         "api_endpoint": "https://async-direct-endpoint.com",
         "api_transport": "grpc_asyncio",
     }
@@ -310,7 +312,7 @@ async def test_async_api_endpoint_alias_behavior(
     """Test that `api_endpoint` and `base_url` are aliases in async calls."""
     # Test 1: Only api_endpoint specified
     llm1 = ChatVertexAI(
-        model="gemini-2.5-pro",
+        model=_DEFAULT_GEMINI_MODEL,
         project="test-proj",
         api_endpoint="https://api-endpoint-only.com",
         api_transport="grpc_asyncio",
@@ -319,7 +321,7 @@ async def test_async_api_endpoint_alias_behavior(
 
     # Test 2: Only base_url specified (should be aliased to api_endpoint)
     llm2 = ChatVertexAI(
-        model="gemini-2.5-pro",
+        model=_DEFAULT_GEMINI_MODEL,
         project="test-proj",
         base_url="https://base-url-only.com",
         api_transport="grpc_asyncio",
@@ -473,7 +475,7 @@ def test_profile() -> None:
     assert not model.profile["reasoning_output"]
 
     model = ChatVertexAI(
-        model="gemini-2.5-flash", project="test-project", location="moon-dark1"
+        model=_DEFAULT_GEMINI_MODEL, project="test-project", location="moon-dark1"
     )
     assert model.profile
     assert model.profile["reasoning_output"]
@@ -1102,7 +1104,7 @@ def test_parse_chat_history_gemini_without_literal_eval() -> None:
 
 def test_python_literal_inputs() -> None:
     """In relation to literal eval, ensure that inputs are not misinterpreted."""
-    llm = ChatVertexAI(model="gemini-2.5-flash", project="test-project")
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, project="test-project")
 
     for input_string in ["None", "(1, 2)", "[1, 2, 3]", "{1, 2, 3}"]:
         _ = llm._prepare_request_gemini([HumanMessage(input_string)])
@@ -1669,7 +1671,7 @@ def test_parser_multiple_tools() -> None:
         mock_generate_content = MagicMock(return_value=response)
         mc.return_value.generate_content = mock_generate_content
 
-        model = ChatVertexAI(model="gemini-2.5-pro", project="test-project")
+        model = ChatVertexAI(model=_DEFAULT_GEMINI_MODEL, project="test-project")
         message = HumanMessage(content="Hello")
         parser = PydanticToolsParser(tools=[Add, Multiply])
         llm = model | parser
@@ -2090,7 +2092,7 @@ def test_json_mode_with_pydantic_v2_fieldinfo_serialization() -> None:
         name: str = Field(description="Person's name")
         age: int = Field(gt=0, le=150, description="Person's age")
 
-    llm = ChatVertexAI(model="gemini-2.5-flash", project="test-project")
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, project="test-project")
 
     # This should not raise any errors when creating structured output
     structured_llm = llm.with_structured_output(TestModel, method="json_mode")
@@ -2124,7 +2126,7 @@ def test_json_mode_pydantic_v1_backward_compatibility() -> None:
         name: str
         age: int
 
-    llm = ChatVertexAI(model="gemini-2.5-flash", project="test-project")
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, project="test-project")
 
     # V1 models should work without issues
     structured_llm = llm.with_structured_output(V1Model, method="json_mode")
@@ -2295,7 +2297,7 @@ def test_parse_chat_history_with_text_signature() -> None:
 def test_timeout_parameter_override(clear_prediction_client_cache: Any) -> None:
     """Test that timeout can be set in constructor and overridden in invoke."""
     llm = ChatVertexAI(
-        model="gemini-2.5-flash",
+        model=_DEFAULT_MODEL_NAME,
         project="test-project",
         timeout=30.0,  # Default timeout
     )
@@ -2328,7 +2330,7 @@ def test_timeout_parameter_override(clear_prediction_client_cache: Any) -> None:
 def test_timeout_parameter_none_override(clear_prediction_client_cache: Any) -> None:
     """Test that timeout=None in invoke uses constructor timeout."""
     llm = ChatVertexAI(
-        model="gemini-2.5-flash",
+        model=_DEFAULT_MODEL_NAME,
         project="test-project",
         timeout=30.0,
     )
@@ -2351,7 +2353,7 @@ def test_gemini_response_to_chat_result_emits_string_modality() -> None:
     """`response_metadata["usage_metadata"]` exposes modality as a string (#1053)."""
     from vertexai.generative_models._generative_models import GenerationResponse
 
-    llm = ChatVertexAI(model="gemini-2.5-flash", project="test-project")
+    llm = ChatVertexAI(model=_DEFAULT_MODEL_NAME, project="test-project")
     response = GenerationResponse.from_dict(
         {
             "candidates": [
@@ -2380,7 +2382,7 @@ def test_gemini_response_to_chat_result_emits_string_modality() -> None:
 def test_get_num_tokens_from_messages(clear_prediction_client_cache: Any) -> None:
     """Test get_num_tokens_from_messages uses count_tokens API properly."""
     llm = ChatVertexAI(
-        model="gemini-2.5-flash",
+        model=_DEFAULT_MODEL_NAME,
         project="test-project",
     )
 
@@ -2415,7 +2417,7 @@ def test_get_num_tokens_from_messages_multimodal(
     passed to the count_tokens API rather than being converted to a string.
     """
     llm = ChatVertexAI(
-        model="gemini-2.5-flash",
+        model=_DEFAULT_MODEL_NAME,
         project="test-project",
     )
 

--- a/libs/vertexai/tests/unit_tests/test_llm.py
+++ b/libs/vertexai/tests/unit_tests/test_llm.py
@@ -24,6 +24,8 @@ from tests.integration_tests.conftest import (
     _DEFAULT_MODEL_NAME,
 )
 
+_DEFAULT_GEMINI_MODEL = "gemini-3.1-pro-preview"
+
 
 @pytest.fixture
 def clear_prediction_client_cache() -> None:
@@ -195,12 +197,12 @@ def test_tracing_params() -> None:
     ) as mc:
         response = GenerateContentResponse(candidates=[])
         mc.return_value.generate_content.return_value = response
-        llm = VertexAI(model="gemini-2.5-pro", project="test-proj")
+        llm = VertexAI(model=_DEFAULT_GEMINI_MODEL, project="test-proj")
         ls_params = llm._get_ls_params()
         assert ls_params == {
             "ls_provider": "google_vertexai",
             "ls_model_type": "llm",
-            "ls_model_name": "gemini-2.5-pro",
+            "ls_model_name": _DEFAULT_GEMINI_MODEL,
         }
 
         llm = VertexAI(

--- a/libs/vertexai/tests/unit_tests/test_standard.py
+++ b/libs/vertexai/tests/unit_tests/test_standard.py
@@ -34,4 +34,4 @@ class TestGemini_AIStandard(ChatModelUnitTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model_name": "gemini-2.5-pro", "project": "test-proj"}
+        return {"model_name": "gemini-3.1-pro-preview", "project": "test-proj"}

--- a/libs/vertexai/uv.lock
+++ b/libs/vertexai/uv.lock
@@ -1145,6 +1145,7 @@ test = [
     { name = "pytest-recording" },
     { name = "pytest-retry" },
     { name = "pytest-socket" },
+    { name = "pytest-timeout" },
     { name = "pytest-watcher" },
     { name = "pytest-xdist" },
     { name = "syrupy" },
@@ -1205,6 +1206,7 @@ test = [
     { name = "pytest-recording", specifier = ">=0.13.4,<1.0.0" },
     { name = "pytest-retry", specifier = ">=1.7.0,<2.0.0" },
     { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.1,<3.0.0" },
     { name = "pytest-watcher", specifier = ">=0.4.0,<1.0.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0,<4.0.0" },
     { name = "syrupy", specifier = ">=4.9.0,<6.0.0" },
@@ -2221,6 +2223,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/ff/90c7e1e746baf3d62ce864c479fd53410b534818b9437413903596f81580/pytest_socket-0.7.0.tar.gz", hash = "sha256:71ab048cbbcb085c15a4423b73b619a8b35d6a307f46f78ea46be51b1b7e11b3", size = 12389, upload-time = "2024-01-28T20:17:23.177Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/58/5d14cb5cb59409e491ebe816c47bf81423cd03098ea92281336320ae5681/pytest_socket-0.7.0-py3-none-any.whl", hash = "sha256:7e0f4642177d55d317bbd58fc68c6bd9048d6eadb2d46a89307fa9221336ce45", size = 6754, upload-time = "2024-01-28T20:17:22.105Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]

--- a/terraform/cloudbuild/main.tf
+++ b/terraform/cloudbuild/main.tf
@@ -21,8 +21,63 @@ locals {
     { _LIB = var.library },
     { _PYTHON_VERSION = var.python_version },
   )
-  #TODO: multiline
-  cloudbuild_config = "python -m pip install -q uv --verbose && cd libs/$${_LIB} && uv sync --group test --group test_integration --all-extras && uv run pytest --retries 3 --retry-delay 1 --extended --release tests/integration_tests/"
+  cloudbuild_config = <<-EOT
+    set -euo pipefail
+
+    python -m pip install -q uv --verbose
+    cd libs/$${_LIB}
+    uv sync --group test --group test_integration --all-extras
+
+    common_pytest_args="--retries 3 --retry-delay 1 --maxfail=1 --timeout=120 --timeout-method=thread --extended --release"
+
+    case "$${_LIB}" in
+      vertexai)
+        uv run pytest $common_pytest_args \
+          tests/integration_tests/test_chat_models.py::test_vertexai_single_call \
+          tests/integration_tests/test_chat_models.py::test_vertexai_stream \
+          tests/integration_tests/test_chat_models.py::test_chat_vertexai_gemini_function_calling
+
+        uv run pytest $common_pytest_args \
+          tests/integration_tests/test_anthropic_cache.py \
+          tests/integration_tests/test_anthropic_files.py \
+          tests/integration_tests/test_anthropic_long_context.py \
+          tests/integration_tests/test_maas.py \
+          tests/integration_tests/test_model_garden.py
+
+        uv run pytest $common_pytest_args \
+          tests/integration_tests/test_callbacks.py \
+          tests/integration_tests/test_chains.py \
+          tests/integration_tests/test_chat_models.py \
+          tests/integration_tests/test_llms.py \
+          tests/integration_tests/test_llms_safety.py \
+          tests/integration_tests/test_standard.py
+
+        uv run pytest $common_pytest_args tests/integration_tests/ \
+          --ignore=tests/integration_tests/test_anthropic_cache.py \
+          --ignore=tests/integration_tests/test_anthropic_files.py \
+          --ignore=tests/integration_tests/test_anthropic_long_context.py \
+          --ignore=tests/integration_tests/test_callbacks.py \
+          --ignore=tests/integration_tests/test_chains.py \
+          --ignore=tests/integration_tests/test_chat_models.py \
+          --ignore=tests/integration_tests/test_llms.py \
+          --ignore=tests/integration_tests/test_llms_safety.py \
+          --ignore=tests/integration_tests/test_maas.py \
+          --ignore=tests/integration_tests/test_model_garden.py \
+          --ignore=tests/integration_tests/test_standard.py
+        ;;
+      genai)
+        uv run pytest $common_pytest_args \
+          tests/integration_tests/test_chat_models.py::test_chat_google_genai_invoke \
+          tests/integration_tests/test_chat_models.py::test_basic_streaming \
+          tests/integration_tests/test_chat_models.py::test_chat_google_genai_with_structured_output
+
+        uv run pytest $common_pytest_args tests/integration_tests/
+        ;;
+      *)
+        uv run pytest $common_pytest_args tests/integration_tests/
+        ;;
+    esac
+  EOT
 }
 
 resource "google_project_service" "model_armor_service" {


### PR DESCRIPTION
Refreshes Gemini model references across Google integration examples, docs, and tests so the suite exercises current model IDs instead of deprecated or preview aliases. The test updates also centralize repeated model names in module-level constants where the exact model string is not the behavior under test.

## Changes
- Replace default Flash/Pro/Lite Gemini model references with `gemini-3.5-flash`, `gemini-3.1-pro-preview`, and `gemini-3.1-flash-lite` across GenAI, VertexAI, and BigQuery callback examples/tests.
- Preserve literal older model strings only where tests intentionally validate model parsing, version detection, media-resolution compatibility, or specialized model variants like image/TTS models.
- Update GenAI and VertexAI test expectations and snapshots for the refreshed default model metadata.
- Add testing guidance to `AGENTS.md` and `CLAUDE.md` to prefer module-level constants for repeated model strings unless the literal model name is under test.