### PR TITLE
fix(vertexai): replace removed bison integration test models

### DIFF
--- a/libs/vertexai/tests/integration_tests/test_chat_models.py
+++ b/libs/vertexai/tests/integration_tests/test_chat_models.py
@@ -148,12 +148,9 @@ def test_vertexai_single_call(model_name: str | None, endpoint_version: str) -> 
 @pytest.mark.release
 @pytest.mark.xfail(reason="vertex api doesn't respect n/candidate_count")
 def test_candidates() -> None:
-    """Test making a single invoke call with `n>1`.
-
-    # TODO: what is chat-bison@001? is it marked for deprecation?
-    """
+    """Test making a single invoke call with `n>1`."""
     model = ChatVertexAI(
-        model="chat-bison@001", temperature=0.3, n=2, rate_limiter=RATE_LIMITER
+        model=_DEFAULT_MODEL_NAME, temperature=0.3, n=2, rate_limiter=RATE_LIMITER
     )
     message = HumanMessage(content="Hello")
     response = model.generate(messages=[[message]])

--- a/libs/vertexai/tests/integration_tests/test_llms.py
+++ b/libs/vertexai/tests/integration_tests/test_llms.py
@@ -44,7 +44,7 @@ def test_vertex_generate() -> None:
 @pytest.mark.release
 @pytest.mark.xfail(reason="VertexAI doesn't always respect number of candidates")
 def test_vertex_generate_multiple_candidates() -> None:
-    llm = VertexAI(temperature=0.3, n=2, model="text-bison@001")
+    llm = VertexAI(temperature=0.3, n=2, model=_DEFAULT_MODEL_NAME)
     output = llm.generate(["Say foo:"])
     assert isinstance(output, LLMResult)
     assert len(output.generations) == 1


### PR DESCRIPTION
Updates the Vertex AI integration tests so they no longer construct removed PaLM 2 `bison@001` publisher models. The affected candidate-count tests now use the shared integration-test default model, which keeps them aligned with the rest of the suite and avoids scheduled failures from Vertex `NotFound` errors.

Careful review: these tests are still marked `xfail` because Vertex does not consistently honor multiple candidates; this change only updates the model they request.