### PR TITLE
fix(genai): include audio usage token details

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -77,7 +77,13 @@ from langchain_core.messages import (
     is_data_content_block,
 )
 from langchain_core.messages import content as types
-from langchain_core.messages.ai import UsageMetadata, add_usage, subtract_usage
+from langchain_core.messages.ai import (
+    InputTokenDetails,
+    OutputTokenDetails,
+    UsageMetadata,
+    add_usage,
+    subtract_usage,
+)
 from langchain_core.messages.tool import invalid_tool_call, tool_call, tool_call_chunk
 from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.base import OutputParserLike
@@ -1260,6 +1266,22 @@ def _parse_response_candidate(
     )
 
 
+def _get_token_count_for_modality(
+    token_counts: Sequence[Any] | None, modality: str
+) -> int:
+    if not token_counts:
+        return 0
+
+    count = 0
+    for token_count in token_counts:
+        token_modality = getattr(token_count, "modality", None)
+        token_modality_value = getattr(token_modality, "value", token_modality)
+        if token_modality_value == modality:
+            count += cast("int", getattr(token_count, "token_count", 0) or 0)
+
+    return count
+
+
 def _response_to_result(
     response: GenerateContentResponse,
     stream: bool = False,
@@ -1284,21 +1306,45 @@ def _response_to_result(
         ) + thought_tokens
         total_tokens = response.usage_metadata.total_token_count or 0
         cache_read_tokens = response.usage_metadata.cached_content_token_count or 0
-        if input_tokens + output_tokens + cache_read_tokens + total_tokens > 0:
+        audio_input_tokens = _get_token_count_for_modality(
+            response.usage_metadata.prompt_tokens_details, "AUDIO"
+        )
+        audio_output_tokens = _get_token_count_for_modality(
+            response.usage_metadata.candidates_tokens_details, "AUDIO"
+        )
+        if (
+            input_tokens
+            + output_tokens
+            + cache_read_tokens
+            + total_tokens
+            + audio_input_tokens
+            + audio_output_tokens
+            > 0
+        ):
+            input_token_details = InputTokenDetails(cache_read=cache_read_tokens)
+            if audio_input_tokens > 0:
+                input_token_details["audio"] = audio_input_tokens
+
+            output_token_details = OutputTokenDetails()
             if thought_tokens > 0:
+                output_token_details["reasoning"] = thought_tokens
+            if audio_output_tokens > 0:
+                output_token_details["audio"] = audio_output_tokens
+
+            if output_token_details:
                 cumulative_usage = UsageMetadata(
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     total_tokens=total_tokens,
-                    input_token_details={"cache_read": cache_read_tokens},
-                    output_token_details={"reasoning": thought_tokens},
+                    input_token_details=input_token_details,
+                    output_token_details=output_token_details,
                 )
             else:
                 cumulative_usage = UsageMetadata(
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     total_tokens=total_tokens,
-                    input_token_details={"cache_read": cache_read_tokens},
+                    input_token_details=input_token_details,
                 )
             # previous usage metadata needs to be subtracted because gemini api returns
             # already-accumulated token counts with each chunk

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -23,6 +23,7 @@ from google.genai.types import (
     HttpOptions,
     HttpRetryOptions,
     Language,
+    ModalityTokenCount,
     Part,
     ThinkingLevel,
 )
@@ -2578,6 +2579,36 @@ def test_chat_google_genai_invoke_with_audio_mocked() -> None:
     assert audio_block["type"] == "audio"
     assert "base64" in audio_block
     assert audio_block["base64"] == base64.b64encode(wav_bytes).decode()
+
+
+def test_response_to_result_includes_audio_usage_metadata() -> None:
+    """Test audio token details are exposed in LangChain usage metadata."""
+    mock_response = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                content=Content(parts=[Part(text="ok")]),
+                finish_reason="STOP",
+            )
+        ],
+        usage_metadata=GenerateContentResponseUsageMetadata(
+            prompt_token_count=10,
+            candidates_token_count=20,
+            total_token_count=30,
+            cached_content_token_count=0,
+            prompt_tokens_details=[ModalityTokenCount(modality="AUDIO", token_count=4)],
+            candidates_tokens_details=[
+                ModalityTokenCount(modality="AUDIO", token_count=16)
+            ],
+        ),
+    )
+
+    result = _response_to_result(mock_response)
+    message = result.generations[0].message
+
+    assert isinstance(message, AIMessage)
+    assert message.usage_metadata is not None
+    assert message.usage_metadata["input_token_details"]["audio"] == 4
+    assert message.usage_metadata["output_token_details"]["audio"] == 16
 
 
 def test_auto_audio_modality_for_tts_models() -> None:


### PR DESCRIPTION
## Description

Fixes #1821.

This maps audio token counts from Google GenAI usage metadata into LangChain usage metadata. The response converter already reads aggregate token counts, but it ignored `prompt_tokens_details` and `candidates_tokens_details`, so TTS/audio responses lost their `audio` token breakdown.

## Relevant issues

Fixes #1821

## Type

🐛 Bug Fix

## Changes(optional)

- Add a small helper to sum token counts for a requested response modality.
- Include AUDIO counts in `input_token_details.audio` and `output_token_details.audio` when present.
- Add a regression test covering audio token details from a mocked `GenerateContentResponse`.

## Testing(optional)

- `uv run pytest tests/unit_tests/test_chat_models.py::test_response_to_result_includes_audio_usage_metadata`
- `uv run pytest tests/unit_tests/test_chat_models.py -k audio`
- `make test` from `libs/genai`
- `make lint` from `libs/genai`

## Note(optional)

I used Codex to help inspect the issue, implement the targeted change, and run the local validation commands. I reviewed the resulting diff before opening this PR.
