### PR TITLE
fix(community): resolve document_ids MIME types via files().get (#1867)

### DIFF
--- a/libs/community/langchain_google_community/drive.py
+++ b/libs/community/langchain_google_community/drive.py
@@ -542,24 +542,17 @@ class GoogleDriveLoader(BaseLoader, BaseModel):
         creds = self._load_credentials()
         service = build("drive", "v3", credentials=creds)
 
-        q = " or ".join(f"id = '{doc_id}'" for doc_id in self.document_ids)
-        results = (
-            service.files()
-            .list(
-                q=q,
-                fields="files(id, mimeType)",
-                includeItemsFromAllDrives=True,
-                supportsAllDrives=True,
-            )
-            .execute()
-        )
-        mime_types: Dict[str, str] = {
-            f["id"]: f["mimeType"] for f in results.get("files", [])
-        }
-
         documents: List[Document] = []
         for doc_id in self.document_ids:
-            mime_type = mime_types.get(doc_id)
+            # Resolve the MIME type with files().get. The Drive API `q` parameter has no
+            # `id` field, so a files().list(q="id = '...'") lookup is rejected with HTTP
+            # 400; files().get is the correct way to fetch a file by its id.
+            file = (
+                service.files()
+                .get(fileId=doc_id, fields="mimeType", supportsAllDrives=True)
+                .execute()
+            )
+            mime_type = file.get("mimeType")
             if mime_type == "application/vnd.google-apps.spreadsheet":
                 documents.extend(self._load_sheet_from_id(doc_id))
             elif mime_type == "application/pdf" or self.file_loader_cls is not None:

--- a/libs/community/tests/unit_tests/test_drive.py
+++ b/libs/community/tests/unit_tests/test_drive.py
@@ -43,10 +43,11 @@ def test_drive_invalid_scope() -> None:
 
 
 def _make_mock_service(mime_type: str, file_id: str) -> MagicMock:
-    """Return a mock Drive service whose files().list() returns one file entry."""
+    """Return a mock Drive service whose files().get() returns one file's mimeType."""
     mock_service = MagicMock()
-    mock_service.files().list().execute.return_value = {
-        "files": [{"id": file_id, "mimeType": mime_type}]
+    mock_service.files().get().execute.return_value = {
+        "id": file_id,
+        "mimeType": mime_type,
     }
     return mock_service
 
@@ -117,3 +118,28 @@ def test_load_documents_from_ids_dispatches_pdfs() -> None:
     mock_sheet.assert_not_called()
     mock_doc.assert_not_called()
     assert result == [pdf_doc]
+
+
+def test_load_documents_from_ids_resolves_mime_type_with_files_get() -> None:
+    """MIME types must be resolved with files().get, not a files().list query.
+
+    The Drive API `q` parameter has no `id` field, so a `files().list(q="id = '...'")`
+    lookup is rejected with HTTP 400 against the real API (a mocked service hides this).
+    Resolving each id with files().get keeps the call valid.
+    """
+    doc = Document(page_content="hello", metadata={})
+    mock_service = _make_mock_service(
+        "application/vnd.google-apps.document", "doc_id_456"
+    )
+    loader = GoogleDriveLoader(document_ids=["doc_id_456"])
+    with (
+        patch.object(loader, "_load_credentials"),
+        patch("googleapiclient.discovery.build", return_value=mock_service),
+        patch.object(loader, "_load_document_from_id", return_value=doc),
+    ):
+        loader._load_documents_from_ids()
+
+    mock_service.files().get.assert_any_call(
+        fileId="doc_id_456", fields="mimeType", supportsAllDrives=True
+    )
+    mock_service.files().list.assert_not_called()


### PR DESCRIPTION
## Description
`GoogleDriveLoader.load()` fails with HTTP 400 for any `document_ids`. `_load_documents_from_ids` resolves MIME types with `files().list(q="id = '...'")`, but the Drive API `q` parameter has no `id` field, so the request is rejected with "Invalid Value". Loading by `document_ids` is broken against the real API on every release since #1644 (4.0.0, 5.0.0, and `main`). 3.x is not affected. Mocked unit tests did not catch it because the Drive service is stubbed.

## Fix
Resolve each id with `files().get(fileId=..., fields="mimeType")` — the correct way to fetch a file by id. The per-type dispatch added in #1644 (Sheets → `_load_sheet_from_id`, PDF → `_load_file_from_id`, else → `_load_document_from_id`) is unchanged.

## Tests
- Updated the mock service to stub `files().get()` (the call the loader now makes).
- Added a regression test asserting MIME resolution uses `files().get(fileId=...)` and never `files().list`.
- All unit tests pass; `ruff` and `mypy` are clean.

## Note
This makes one `files().get` call per id instead of a single `files().list`. That is required, since `files().list` cannot query by id, and `document_ids` lists are typically small.

Fixes #1867
