### PR TITLE
fix(genai): support constructor thinking config

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -96,7 +96,14 @@ from langchain_core.utils.function_calling import (
 )
 from langchain_core.utils.pydantic import is_basemodel_subclass
 from langchain_core.utils.utils import _build_model_kwargs
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 from pydantic.v1 import BaseModel as BaseModelV1
 from typing_extensions import Self, is_typeddict
 
@@ -2400,6 +2407,21 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         this defaults to `'high'`.
     """
 
+    thinking_config: dict[str, Any] | ThinkingConfig | None = Field(
+        default=None,
+    )
+    """Raw Google GenAI thinking configuration.
+
+    Accepts the same fields as `google.genai.types.ThinkingConfig`, including
+    `thinking_level`, `thinking_budget`, and `include_thoughts`.
+
+    !!! note "Precedence"
+
+        If `thinking_config` is provided together with flat thinking arguments,
+        the flat arguments take precedence for matching fields. After merging,
+        `thinking_level` takes precedence over `thinking_budget` for Gemini 3+ models.
+    """
+
     cached_content: str | None = None
     """The name of the cached content used as context to serve the prediction.
 
@@ -2453,6 +2475,15 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     @classmethod
     def is_lc_serializable(cls) -> bool:
         return True
+
+    @field_validator("thinking_config", mode="before")
+    @classmethod
+    def _serialize_thinking_config(
+        cls, value: ThinkingConfig | dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        if isinstance(value, ThinkingConfig):
+            return value.model_dump(exclude_none=True)
+        return value
 
     @model_validator(mode="before")
     @classmethod
@@ -2675,6 +2706,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             "thinking_budget": self.thinking_budget,
             "include_thoughts": self.include_thoughts,
             "thinking_level": self.thinking_level,
+            "thinking_config": self.thinking_config,
             "image_config": self.image_config,
         }
 
@@ -2796,12 +2828,14 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
     def _build_thinking_config(self, **kwargs: Any) -> ThinkingConfig | None:
         """Build thinking configuration if supported by the model."""
+        raw_thinking_config = kwargs.get("thinking_config", self.thinking_config)
         thinking_level = kwargs.get("thinking_level", self.thinking_level)
         thinking_budget = kwargs.get("thinking_budget", self.thinking_budget)
         include_thoughts = kwargs.get("include_thoughts", self.include_thoughts)
 
         has_thinking_params = (
-            thinking_level is not None
+            raw_thinking_config is not None
+            or thinking_level is not None
             or thinking_budget is not None
             or include_thoughts is not None
         )
@@ -2809,23 +2843,30 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             return None
 
         config: dict[str, Any] = {}
-
-        # thinking_level takes precedence over thinking_budget for Gemini 3+ models
-        if thinking_level is not None:
-            if thinking_budget is not None:
-                warnings.warn(
-                    "Both 'thinking_level' and 'thinking_budget' were provided. "
-                    "'thinking_level' takes precedence for Gemini 3+ models; "
-                    "'thinking_budget' will be ignored.",
-                    UserWarning,
-                    stacklevel=2,
+        if raw_thinking_config is not None:
+            config.update(
+                ThinkingConfig.model_validate(raw_thinking_config).model_dump(
+                    exclude_none=True
                 )
-            config["thinking_level"] = thinking_level
-        elif thinking_budget is not None:
-            config["thinking_budget"] = thinking_budget
+            )
 
+        if thinking_level is not None:
+            config["thinking_level"] = thinking_level
+        if thinking_budget is not None:
+            config["thinking_budget"] = thinking_budget
         if include_thoughts is not None:
             config["include_thoughts"] = include_thoughts
+
+        # thinking_level takes precedence over thinking_budget for Gemini 3+ models
+        if "thinking_level" in config and "thinking_budget" in config:
+            warnings.warn(
+                "Both 'thinking_level' and 'thinking_budget' were set after merging "
+                "thinking configuration values. 'thinking_level' takes precedence "
+                "for Gemini 3+ models; 'thinking_budget' will be ignored.",
+                UserWarning,
+                stacklevel=2,
+            )
+            config.pop("thinking_budget")
 
         return ThinkingConfig(**config)
 

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -24,6 +24,7 @@ from google.genai.types import (
     HttpRetryOptions,
     Language,
     Part,
+    ThinkingConfig,
     ThinkingLevel,
 )
 from google.genai.types import (
@@ -1325,6 +1326,36 @@ def test_serialize() -> None:
     assert llm == llm_loaded
 
 
+def test_serialize_with_thinking_config() -> None:
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key="test-key",
+        thinking_config={"include_thoughts": True, "thinkingBudget": 2048},
+    )
+    serialized = dumps(llm)
+    assert "not_implemented" not in serialized
+
+    llm_loaded = loads(
+        serialized,
+        secrets_map={"GOOGLE_API_KEY": "test-key"},
+        valid_namespaces=["langchain_google_genai"],
+        allowed_objects="all",
+    )
+    llm.client = None
+    llm_loaded.client = None
+    assert llm == llm_loaded
+
+
+def test_thinking_config_object_is_stored_as_serializable_dict() -> None:
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key="test-key",
+        thinking_config=ThinkingConfig(include_thoughts=True, thinking_budget=2048),
+    )
+
+    assert llm.thinking_config == {"include_thoughts": True, "thinking_budget": 2048}
+
+
 @pytest.mark.parametrize(
     "tool_message",
     [
@@ -2281,6 +2312,44 @@ def test_thinking_config_merging_with_generation_config() -> None:
         assert result.usage_metadata["input_tokens"] == 20
         assert result.usage_metadata["output_tokens"] == 15
         assert result.usage_metadata["total_tokens"] == 35
+
+
+def test_constructor_thinking_config_is_propagated() -> None:
+    """Test that constructor-level `thinking_config` is sent in request config."""
+    mock_response = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                content=Content(parts=[Part(text="There are 2 O's in Google.")]),
+                finish_reason="STOP",
+            )
+        ],
+        usage_metadata=GenerateContentResponseUsageMetadata(
+            prompt_token_count=20,
+            candidates_token_count=15,
+            total_token_count=35,
+            cached_content_token_count=0,
+        ),
+    )
+
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        thinking_config={"include_thoughts": True, "thinkingBudget": 2048},
+    )
+    assert llm.client is not None
+    assert llm.model_kwargs == {}
+
+    with patch.object(
+        llm.client.models, "generate_content", return_value=mock_response
+    ) as mock_client_method:
+        llm.invoke("How many O's are in Google?")
+
+        mock_client_method.assert_called_once()
+        config = mock_client_method.call_args.kwargs.get("config")
+        assert config is not None
+        assert config.thinking_config is not None
+        assert config.thinking_config.include_thoughts is True
+        assert config.thinking_config.thinking_budget == 2048
 
 
 def test_modalities_override_in_generation_config() -> None:
@@ -4532,6 +4601,83 @@ def test_thinking_budget_alone_still_works() -> None:
     assert config.thinking_config.thinking_budget == 64
     # Pydantic models define all fields; check value is None rather than hasattr
     assert config.thinking_config.thinking_level is None
+
+
+def test_thinking_config_flat_args_take_precedence() -> None:
+    """Test flat thinking args override matching raw `thinking_config` keys."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        thinking_config={"thinking_budget": 2048, "include_thoughts": False},
+        thinking_budget=64,
+        include_thoughts=True,
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg])
+    config = request["config"]
+    assert config.thinking_config is not None
+    assert config.thinking_config.thinking_budget == 64
+    assert config.thinking_config.include_thoughts is True
+
+
+def test_thinking_config_cross_source_level_budget_warning() -> None:
+    """Test merged `thinking_level` and `thinking_budget` emit a warning."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        thinking_config={"thinkingLevel": "low"},
+        thinking_budget=128,
+    )
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        request = llm._prepare_request([HumanMessage(content="test")])
+
+    assert len(warning_list) == 1
+    assert issubclass(warning_list[0].category, UserWarning)
+    assert "thinking_level' takes precedence" in str(warning_list[0].message)
+    config = request["config"]
+    assert config.thinking_config is not None
+    assert config.thinking_config.thinking_level == ThinkingLevel.LOW
+    assert config.thinking_config.thinking_budget is None
+
+
+def test_thinking_config_single_source_level_budget_warning() -> None:
+    """Test raw `thinking_config` warns when it includes level and budget."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        thinking_config={"thinkingLevel": "high", "thinkingBudget": 128},
+    )
+
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+        request = llm._prepare_request([HumanMessage(content="test")])
+
+    assert len(warning_list) == 1
+    assert issubclass(warning_list[0].category, UserWarning)
+    assert "thinking_level' takes precedence" in str(warning_list[0].message)
+    config = request["config"]
+    assert config.thinking_config is not None
+    assert config.thinking_config.thinking_level == ThinkingLevel.HIGH
+    assert config.thinking_config.thinking_budget is None
+
+
+def test_thinking_config_object_is_propagated() -> None:
+    """Test `ThinkingConfig` constructor input is propagated to request config."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        thinking_config=ThinkingConfig(include_thoughts=True, thinking_budget=512),
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg])
+    config = request["config"]
+    assert config.thinking_config is not None
+    assert config.thinking_config.include_thoughts is True
+    assert config.thinking_config.thinking_budget == 512
 
 
 def test_kwargs_override_max_output_tokens() -> None:


### PR DESCRIPTION
Fixes #1497.
Supersedes #1521.

---

`ChatGoogleGenerativeAI` now accepts raw Google `thinking_config` at construction time and carries it into the generated request config. This fixes the case where `thinking_config={...}` was swept into `model_kwargs` and never used, while preserving LangChain serialization by storing config values as plain dicts until request preparation.

## Changes

- Adds `thinking_config` as a constructor field and normalizes raw dict / `ThinkingConfig` inputs through `ThinkingConfig` when building request params.
- Preserves LangChain serialization round trips by storing SDK `ThinkingConfig` objects as serializable dict values.
- Defines merge precedence for raw config plus flat thinking kwargs, including the Gemini 3 `thinking_level`-over-`thinking_budget` rule and warning.
- Covers constructor propagation, serialization, precedence, warning collisions, and SDK object input with unit tests.