### PR TITLE
fix(genai): propagate generation config fields

### DIFF
--- a/libs/genai/langchain_google_genai/_common.py
+++ b/libs/genai/langchain_google_genai/_common.py
@@ -340,6 +340,18 @@ class _BaseGoogleGenerativeAI(BaseModel):
 
     """
 
+    frequency_penalty: float | None = None
+    """Penalize tokens that repeatedly appear in the generated text.
+
+    Must be within `[-2.0, 2.0]`.
+    """
+
+    presence_penalty: float | None = None
+    """Penalize tokens that already appear in the generated text.
+
+    Must be within `[-2.0, 2.0]`.
+    """
+
     top_p: float | None = None
     """Decode using nucleus sampling.
 
@@ -367,7 +379,7 @@ class _BaseGoogleGenerativeAI(BaseModel):
     the `thinking_budget` parameter.
     """
 
-    n: int = 1
+    n: int = Field(default=1, alias="candidate_count")
     """Number of chat completions to generate for each prompt.
 
     Note that the API may not return the full `n` completions if duplicates are
@@ -594,6 +606,8 @@ class _BaseGoogleGenerativeAI(BaseModel):
         return {
             "model": self.model,
             "temperature": self.temperature,
+            "frequency_penalty": self.frequency_penalty,
+            "presence_penalty": self.presence_penalty,
             "top_p": self.top_p,
             "top_k": self.top_k,
             "max_output_tokens": self.max_output_tokens,

--- a/libs/genai/langchain_google_genai/_common.py
+++ b/libs/genai/langchain_google_genai/_common.py
@@ -341,15 +341,21 @@ class _BaseGoogleGenerativeAI(BaseModel):
     """
 
     frequency_penalty: float | None = None
-    """Penalize tokens that repeatedly appear in the generated text.
+    """Penalize tokens proportionally to how often they have already appeared.
 
-    Must be within `[-2.0, 2.0]`.
+    Scales with the count of prior appearances, so it discourages verbatim
+    repetition more strongly than `presence_penalty`.
+
+    Must be within `[-2.0, 2.0)`.
     """
 
     presence_penalty: float | None = None
-    """Penalize tokens that already appear in the generated text.
+    """Penalize tokens that have already appeared at all in the generated text.
 
-    Must be within `[-2.0, 2.0]`.
+    Applied once a token has appeared, regardless of how many times, so it
+    encourages introducing new topics rather than reducing repetition.
+
+    Must be within `[-2.0, 2.0)`.
     """
 
     top_p: float | None = None

--- a/libs/genai/langchain_google_genai/_common.py
+++ b/libs/genai/langchain_google_genai/_common.py
@@ -346,7 +346,7 @@ class _BaseGoogleGenerativeAI(BaseModel):
     Scales with the count of prior appearances, so it discourages verbatim
     repetition more strongly than `presence_penalty`.
 
-    Must be within `[-2.0, 2.0)`.
+    Must be within `[-2.0, 2.0]`.
     """
 
     presence_penalty: float | None = None
@@ -355,7 +355,7 @@ class _BaseGoogleGenerativeAI(BaseModel):
     Applied once a token has appeared, regardless of how many times, so it
     encourages introducing new topics rather than reducing repetition.
 
-    Must be within `[-2.0, 2.0)`.
+    Must be within `[-2.0, 2.0]`.
     """
 
     top_p: float | None = None

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2528,6 +2528,20 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             msg = "top_k must be positive"
             raise ValueError(msg)
 
+        if (
+            self.frequency_penalty is not None
+            and not -2.0 <= self.frequency_penalty < 2.0
+        ):
+            msg = "frequency_penalty must be in the range [-2.0, 2.0)"
+            raise ValueError(msg)
+
+        if (
+            self.presence_penalty is not None
+            and not -2.0 <= self.presence_penalty < 2.0
+        ):
+            msg = "presence_penalty must be in the range [-2.0, 2.0)"
+            raise ValueError(msg)
+
         additional_headers = self.additional_headers or {}
         self.default_metadata = tuple(additional_headers.items())
 
@@ -2790,7 +2804,9 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         config: dict[str, Any] = {
             "candidate_count": kwargs.get("candidate_count", self.n),
             "temperature": kwargs.get("temperature", self.temperature),
-            "stop_sequences": stop if stop is not None else self.stop,
+            "stop_sequences": (
+                stop if stop is not None else kwargs.get("stop_sequences", self.stop)
+            ),
             "max_output_tokens": kwargs.get(
                 "max_output_tokens", self.max_output_tokens
             ),

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2530,16 +2530,16 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
         if (
             self.frequency_penalty is not None
-            and not -2.0 <= self.frequency_penalty < 2.0
+            and not -2.0 <= self.frequency_penalty <= 2.0
         ):
-            msg = "frequency_penalty must be in the range [-2.0, 2.0)"
+            msg = "frequency_penalty must be in the range [-2.0, 2.0]"
             raise ValueError(msg)
 
         if (
             self.presence_penalty is not None
-            and not -2.0 <= self.presence_penalty < 2.0
+            and not -2.0 <= self.presence_penalty <= 2.0
         ):
-            msg = "presence_penalty must be in the range [-2.0, 2.0)"
+            msg = "presence_penalty must be in the range [-2.0, 2.0]"
             raise ValueError(msg)
 
         additional_headers = self.additional_headers or {}

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2343,7 +2343,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     error.
     """
 
-    stop: list[str] | None = None
+    stop: list[str] | None = Field(default=None, alias="stop_sequences")
     """Stop sequences for the model."""
 
     response_mime_type: str | None = None
@@ -2696,6 +2696,8 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         return {
             "model": self.model,
             "temperature": self.temperature,
+            "frequency_penalty": self.frequency_penalty,
+            "presence_penalty": self.presence_penalty,
             "top_p": self.top_p,
             "top_k": self.top_k,
             "max_output_tokens": self.max_output_tokens,
@@ -2786,14 +2788,18 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     ) -> dict[str, Any]:
         """Build the base generation configuration from instance attributes."""
         config: dict[str, Any] = {
-            "candidate_count": self.n,
+            "candidate_count": kwargs.get("candidate_count", self.n),
             "temperature": kwargs.get("temperature", self.temperature),
-            "stop_sequences": stop,
+            "stop_sequences": stop if stop is not None else self.stop,
             "max_output_tokens": kwargs.get(
                 "max_output_tokens", self.max_output_tokens
             ),
             "top_k": kwargs.get("top_k", self.top_k),
             "top_p": kwargs.get("top_p", self.top_p),
+            "frequency_penalty": kwargs.get(
+                "frequency_penalty", self.frequency_penalty
+            ),
+            "presence_penalty": kwargs.get("presence_penalty", self.presence_penalty),
             "response_modalities": kwargs.get(
                 "response_modalities", self.response_modalities
             ),

--- a/libs/genai/langchain_google_genai/llms.py
+++ b/libs/genai/langchain_google_genai/llms.py
@@ -83,6 +83,8 @@ class GoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseLLM):
             project=self.project,
             location=self.location,
             temperature=self.temperature,
+            frequency_penalty=self.frequency_penalty,
+            presence_penalty=self.presence_penalty,
             top_p=self.top_p,
             top_k=self.top_k,
             max_tokens=self.max_output_tokens,

--- a/libs/genai/langchain_google_genai/llms.py
+++ b/libs/genai/langchain_google_genai/llms.py
@@ -87,6 +87,7 @@ class GoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseLLM):
             presence_penalty=self.presence_penalty,
             top_p=self.top_p,
             top_k=self.top_k,
+            n=self.n,
             max_tokens=self.max_output_tokens,
             max_retries=self.max_retries,
             timeout=self.timeout,

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4848,15 +4848,28 @@ def test_n_and_candidate_count_alias_resolves_to_alias() -> None:
 
 
 @pytest.mark.parametrize("field", ["frequency_penalty", "presence_penalty"])
-@pytest.mark.parametrize("value", [-2.5, 2.0, 5.0])
+@pytest.mark.parametrize("value", [-2.5, 2.1, 5.0])
 def test_penalty_out_of_range_raises(field: str, value: float) -> None:
-    """Test penalties outside `[-2.0, 2.0)` are rejected at construction."""
+    """Test penalties outside `[-2.0, 2.0]` are rejected at construction."""
     with pytest.raises(ValueError, match=f"{field} must be in the range"):
         ChatGoogleGenerativeAI(
             model=MODEL_NAME,
             google_api_key=SecretStr(FAKE_API_KEY),
             **{field: value},
         )
+
+
+@pytest.mark.parametrize("field", ["frequency_penalty", "presence_penalty"])
+@pytest.mark.parametrize("value", [-2.0, 2.0])
+def test_penalty_range_bounds_are_allowed(field: str, value: float) -> None:
+    """Test penalties at the documented bounds are accepted."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        **{field: value},
+    )
+
+    assert getattr(llm, field) == value
 
 
 def test_penalties_in_identifying_params() -> None:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -31,6 +31,7 @@ from google.genai.types import (
     Outcome as CodeExecutionResultOutcome,
 )
 from google.protobuf.struct_pb2 import Struct
+from langchain_core._api import LangChainBetaWarning
 from langchain_core.exceptions import ContextOverflowError
 from langchain_core.load import dumps, loads
 from langchain_core.messages import (
@@ -1313,12 +1314,16 @@ def test_streaming_chunk_concatenation_no_model_name_duplication() -> None:
 def test_serialize() -> None:
     llm = ChatGoogleGenerativeAI(model=MODEL_NAME, google_api_key="test-key")
     serialized = dumps(llm)
-    llm_loaded = loads(
-        serialized,
-        secrets_map={"GOOGLE_API_KEY": "test-key"},
-        valid_namespaces=["langchain_google_genai"],
-        allowed_objects="all",
-    )
+    with pytest.warns(
+        LangChainBetaWarning,
+        match="The function `loads` is in beta",
+    ):
+        llm_loaded = loads(
+            serialized,
+            secrets_map={"GOOGLE_API_KEY": "test-key"},
+            valid_namespaces=["langchain_google_genai"],
+            allowed_objects="all",
+        )
     # Pydantic 2 equality will fail on complex attributes like clients with
     # different IDs
     llm.client = None
@@ -1335,12 +1340,14 @@ def test_serialize_with_thinking_config() -> None:
     serialized = dumps(llm)
     assert "not_implemented" not in serialized
 
-    llm_loaded = loads(
-        serialized,
-        secrets_map={"GOOGLE_API_KEY": "test-key"},
-        valid_namespaces=["langchain_google_genai"],
-        allowed_objects="all",
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", LangChainBetaWarning)
+        llm_loaded = loads(
+            serialized,
+            secrets_map={"GOOGLE_API_KEY": "test-key"},
+            valid_namespaces=["langchain_google_genai"],
+            allowed_objects="all",
+        )
     llm.client = None
     llm_loaded.client = None
     assert llm == llm_loaded
@@ -4705,6 +4712,95 @@ def test_kwargs_override_stop() -> None:
     request = llm._prepare_request([msg], stop=["me"])
     config = request["config"]
     assert config.stop_sequences == ["me"]
+
+
+def test_generation_config_constructor_fields_are_propagated() -> None:
+    """Test Google generation config field aliases are propagated."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        presence_penalty=0.1,
+        frequency_penalty=0.2,
+        candidate_count=2,
+        stop_sequences=["stop"],
+    )
+
+    assert llm.model_kwargs == {}
+    assert llm.n == 2
+    assert llm.stop == ["stop"]
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg])
+    config = request["config"]
+    assert config.presence_penalty == 0.1
+    assert config.frequency_penalty == 0.2
+    assert config.candidate_count == 2
+    assert config.stop_sequences == ["stop"]
+
+
+def test_generation_config_constructor_defaults_are_preserved() -> None:
+    """Test unset generation config fields keep default request semantics."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg])
+    config = request["config"]
+    assert config.presence_penalty is None
+    assert config.frequency_penalty is None
+
+
+def test_n_constructor_field_sets_candidate_count() -> None:
+    """Test LangChain `n` field still sets Google `candidate_count`."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        n=2,
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg])
+    config = request["config"]
+    assert config.candidate_count == 2
+
+
+def test_kwargs_override_generation_config_constructor_fields() -> None:
+    """Test per-call kwargs override model-level generation config fields."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        presence_penalty=0.1,
+        frequency_penalty=0.2,
+        candidate_count=2,
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request(
+        [msg],
+        candidate_count=3,
+        presence_penalty=0.0,
+        frequency_penalty=0.5,
+    )
+    config = request["config"]
+    assert config.presence_penalty == 0.0
+    assert config.frequency_penalty == 0.5
+    assert config.candidate_count == 3
+
+
+def test_constructor_stop_is_propagated() -> None:
+    """Test model-level `stop` is propagated when no per-call stop is passed."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        stop=["stop"],
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg])
+    config = request["config"]
+    assert config.stop_sequences == ["stop"]
 
 
 def test_kwargs_override_thinking_budget() -> None:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -1314,10 +1314,8 @@ def test_streaming_chunk_concatenation_no_model_name_duplication() -> None:
 def test_serialize() -> None:
     llm = ChatGoogleGenerativeAI(model=MODEL_NAME, google_api_key="test-key")
     serialized = dumps(llm)
-    with pytest.warns(
-        LangChainBetaWarning,
-        match="The function `loads` is in beta",
-    ):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", LangChainBetaWarning)
         llm_loaded = loads(
             serialized,
             secrets_map={"GOOGLE_API_KEY": "test-key"},
@@ -4714,6 +4712,20 @@ def test_kwargs_override_stop() -> None:
     assert config.stop_sequences == ["me"]
 
 
+def test_kwargs_stop_sequences_overrides_constructor_stop() -> None:
+    """Test that per-call `stop_sequences` overrides constructor `stop`."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        stop=["you"],
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg], stop_sequences=["me"])
+    config = request["config"]
+    assert config.stop_sequences == ["me"]
+
+
 def test_generation_config_constructor_fields_are_propagated() -> None:
     """Test Google generation config field aliases are propagated."""
     llm = ChatGoogleGenerativeAI(
@@ -4801,6 +4813,89 @@ def test_constructor_stop_is_propagated() -> None:
     request = llm._prepare_request([msg])
     config = request["config"]
     assert config.stop_sequences == ["stop"]
+
+
+def test_per_call_empty_stop_overrides_constructor_stop() -> None:
+    """Test a per-call empty `stop` list clears the model-level `stop`."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        stop=["stop"],
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg], stop=[])
+    config = request["config"]
+    # An empty list is a valid "clear the stops" signal and must not fall back
+    # to the model-level `stop`.
+    assert config.stop_sequences == []
+
+
+def test_n_and_candidate_count_alias_resolves_to_alias() -> None:
+    """Test passing both `n` and its `candidate_count` alias: alias wins.
+
+    Pins the standard Pydantic `populate_by_name=True` resolution order so a
+    future change to alias handling is caught.
+    """
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        n=2,
+        candidate_count=5,
+    )
+
+    assert llm.n == 5
+
+
+@pytest.mark.parametrize("field", ["frequency_penalty", "presence_penalty"])
+@pytest.mark.parametrize("value", [-2.5, 2.0, 5.0])
+def test_penalty_out_of_range_raises(field: str, value: float) -> None:
+    """Test penalties outside `[-2.0, 2.0)` are rejected at construction."""
+    with pytest.raises(ValueError, match=f"{field} must be in the range"):
+        ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            google_api_key=SecretStr(FAKE_API_KEY),
+            **{field: value},
+        )
+
+
+def test_penalties_in_identifying_params() -> None:
+    """Test penalties are included in identifying parameters for tracing."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        frequency_penalty=0.2,
+        presence_penalty=0.1,
+    )
+    params = llm._identifying_params
+    assert params["frequency_penalty"] == 0.2
+    assert params["presence_penalty"] == 0.1
+
+
+def test_serialize_round_trips_generation_config_aliases() -> None:
+    """Test alias-set generation config fields survive serialization."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key="test-key",
+        candidate_count=2,
+        stop_sequences=["stop"],
+        frequency_penalty=0.2,
+        presence_penalty=0.1,
+    )
+    serialized = dumps(llm)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", LangChainBetaWarning)
+        llm_loaded = loads(
+            serialized,
+            secrets_map={"GOOGLE_API_KEY": "test-key"},
+            valid_namespaces=["langchain_google_genai"],
+            allowed_objects="all",
+        )
+    llm.client = None
+    llm_loaded.client = None
+    assert llm == llm_loaded
+    assert llm_loaded.n == 2
+    assert llm_loaded.stop == ["stop"]
 
 
 def test_kwargs_override_thinking_budget() -> None:

--- a/libs/genai/tests/unit_tests/test_llms.py
+++ b/libs/genai/tests/unit_tests/test_llms.py
@@ -60,6 +60,19 @@ def test_tracing_params() -> None:
         assert "Did you mean: 'safety_settings'?" in call_args
 
 
+def test_penalties_are_passed_to_internal_chat_model() -> None:
+    """Test penalties propagate to the internal chat model client."""
+    llm = GoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key="foo",
+        frequency_penalty=0.2,
+        presence_penalty=0.1,
+    )
+
+    assert llm.client.frequency_penalty == 0.2
+    assert llm.client.presence_penalty == 0.1
+
+
 def test_base_url_support() -> None:
     """Test that `base_url` is properly passed through to `ChatGoogleGenerativeAI`."""
     mock_client_instance = Mock()

--- a/libs/genai/tests/unit_tests/test_llms.py
+++ b/libs/genai/tests/unit_tests/test_llms.py
@@ -60,17 +60,26 @@ def test_tracing_params() -> None:
         assert "Did you mean: 'safety_settings'?" in call_args
 
 
-def test_penalties_are_passed_to_internal_chat_model() -> None:
-    """Test penalties propagate to the internal chat model client."""
+def test_generation_config_fields_are_passed_to_internal_chat_model() -> None:
+    """Test generation config fields propagate to the internal chat model client."""
     llm = GoogleGenerativeAI(
         model=MODEL_NAME,
         google_api_key="foo",
         frequency_penalty=0.2,
         presence_penalty=0.1,
+        candidate_count=2,
     )
 
+    assert llm.n == 2
     assert llm.client.frequency_penalty == 0.2
     assert llm.client.presence_penalty == 0.1
+    assert llm.client.n == 2
+
+    request = llm.client._prepare_request([])
+    config = request["config"]
+    assert config.frequency_penalty == 0.2
+    assert config.presence_penalty == 0.1
+    assert config.candidate_count == 2
 
 
 def test_base_url_support() -> None:


### PR DESCRIPTION
`ChatGoogleGenerativeAI` now treats the remaining Google generation config constructor options from the Slack report as real model fields instead of unexpected kwargs. Model-level `stop` now reaches `stop_sequences`, `candidate_count` is accepted as an alias for `n`, and penalty settings are carried into request config while preserving per-call override behavior.

Fixes #1586.
Supersedes #1588.
Supersedes #1818.

## Changes

- Adds `presence_penalty` and `frequency_penalty` to the shared Google GenAI model config and forwards them through both chat and legacy LLM paths.
- Accepts Google-style aliases for `candidate_count` and `stop_sequences` while preserving existing LangChain fields `n` and `stop`.
- Falls back to model-level `stop` when no per-call stop override is supplied.
- Keeps per-call kwargs authoritative for generation config values, including falsy overrides like `presence_penalty=0.0`.
- Covers constructor propagation, default `None` semantics, alias behavior, per-call overrides, and legacy `GoogleGenerativeAI` penalty pass-through with unit tests.