### PR TITLE
fix(genai): propagate model-level `media_resolution` to the request

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2820,6 +2820,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 "response_modalities", self.response_modalities
             ),
             "seed": kwargs.get("seed", self.seed),
+            "media_resolution": kwargs.get("media_resolution", self.media_resolution),
         }
 
         # Convert response modalities

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -23,6 +23,7 @@ from google.genai.types import (
     HttpOptions,
     HttpRetryOptions,
     Language,
+    MediaResolution,
     Part,
     ThinkingConfig,
     ThinkingLevel,
@@ -4526,6 +4527,41 @@ def test_per_part_media_resolution_warning_gemini_25_data_block() -> None:
             "Setting per-part media resolution requests to Gemini 2.5 models and older "
             "is not supported" in str(w[0].message)
         )
+
+
+def test_model_level_media_resolution_propagated_to_request() -> None:
+    """A `media_resolution` set on the model is propagated to the request config."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        media_resolution=MediaResolution.MEDIA_RESOLUTION_LOW,
+    )
+    request = llm._prepare_request([HumanMessage(content="test")])
+    assert request["config"].media_resolution == MediaResolution.MEDIA_RESOLUTION_LOW
+
+
+def test_call_level_media_resolution_overrides_model_level() -> None:
+    """A per-call `media_resolution` overrides the model-level value in the request."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        media_resolution=MediaResolution.MEDIA_RESOLUTION_LOW,
+    )
+    request = llm._prepare_request(
+        [HumanMessage(content="test")],
+        media_resolution=MediaResolution.MEDIA_RESOLUTION_HIGH,
+    )
+    assert request["config"].media_resolution == MediaResolution.MEDIA_RESOLUTION_HIGH
+
+
+def test_media_resolution_absent_when_unset() -> None:
+    """`media_resolution` is omitted from the request config when not configured."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+    request = llm._prepare_request([HumanMessage(content="test")])
+    assert request["config"].media_resolution is None
 
 
 def test_thinking_level_parameter() -> None:


### PR DESCRIPTION
`media_resolution` set on the `ChatGoogleGenerativeAI` constructor is silently dropped from the request. `_build_base_generation_config` builds every other generation parameter from the instance (`temperature`, `seed`, `response_modalities`, …) but never reads `self.media_resolution`, so a model-level value never reaches the API. Only the per-call keyword works today, and only incidentally — it survives as an unconsumed kwarg splatted onto `GenerateContentConfig`.

Model-level support originally shipped in #1259; the later refactor of `_prepare_params` dropped the line that read `self.media_resolution`. The field is still a public constructor parameter and still appears in `_identifying_params`.

The fix adds `media_resolution` to the base config alongside `seed`. When unset it is filtered out by the existing `if v is not None` comprehension, and because it now enters `params.model_fields_set` it is excluded from the leftover-kwarg pass — so the per-call keyword still works and still takes precedence.

**Careful review:** the per-call path — `media_resolution` now flows through `params` rather than `remaining_kwargs`, so it is not double-applied; `test_call_level_media_resolution_overrides_model_level` locks the precedence.

### Release note

`media_resolution` set on the `ChatGoogleGenerativeAI` constructor is now sent to the model instead of being silently ignored. Per-call `media_resolution` continues to work and takes precedence.

### Tests

No-network unit tests in `test_chat_models.py`: the model-level value reaches the request, a per-call value overrides it, and it is omitted when unset.

---

*Disclosure: this change was prepared with the help of an AI agent (Claude Code); the fix, tests, and local verification (`ruff format` / `ruff check` / `mypy` / unit tests) were reviewed before submission.*
