### PR TITLE
release(genai): 4.2.7

### DIFF
--- a/libs/genai/pyproject.toml
+++ b/libs/genai/pyproject.toml
@@ -9,7 +9,7 @@ license = {text = "MIT"}
 readme = "README.md"
 authors = []
 
-version = "4.2.6"
+version = "4.2.7"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.4.7,<2.0.0",

--- a/libs/genai/uv.lock
+++ b/libs/genai/uv.lock
@@ -520,7 +520,7 @@ wheels = [
 
 [[package]]
 name = "langchain-google-genai"
-version = "4.2.6"
+version = "4.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "filetype" },


### PR DESCRIPTION
Bumps `langchain-google-genai` from 4.2.6 to 4.2.7.

Changes since 4.2.6:
- fix(genai): handle empty items dict in array schema conversion (#1587)
- chore(model-profiles): refresh model profile data (#1802)
- chore: bump vcrpy from 8.1.1 to 8.2.1 in /libs/genai (#1857)

Co-authored-by: deepagents-code