### PR TITLE
fix(genai): remove default temperature for gemini models

### DIFF
--- a/libs/genai/langchain_google_genai/_common.py
+++ b/libs/genai/langchain_google_genai/_common.py
@@ -331,6 +331,13 @@ class _BaseGoogleGenerativeAI(BaseModel):
     """Run inference with this temperature.
 
     Must be within `[0.0, 2.0]`.
+
+    !!! note "Automatic override for Gemini 3.0+ models"
+
+        If `temperature` is not explicitly set and the model is Gemini 3.0 or later,
+        it will be automatically set to `None` instead of the default `0.7` per the
+        Google GenAI API best practices, as it can cause infinite loops, degraded
+        reasoning performance, and failure on complex tasks.
     """
 
     frequency_penalty: float | None = None

--- a/libs/genai/langchain_google_genai/_common.py
+++ b/libs/genai/langchain_google_genai/_common.py
@@ -16,6 +16,15 @@ from langchain_google_genai._enums import (
 _TELEMETRY_TAG = "remote_reasoning_engine"
 _TELEMETRY_ENV_VARIABLE_NAME = "GOOGLE_CLOUD_AGENT_ENGINE_ID"
 
+
+def _is_gemini_3_or_later(model_name: str) -> bool:
+    """Checks if the model is Gemini 3 or later."""
+    if not model_name:
+        return False
+    model_name = model_name.lower().replace("models/", "")
+    return "gemini-3" in model_name
+
+
 # Cache package version at module import time to avoid blocking I/O in async contexts
 try:
     LC_GOOGLE_GENAI_VERSION = metadata.version("langchain-google-genai")
@@ -541,6 +550,13 @@ class _BaseGoogleGenerativeAI(BaseModel):
 
     See: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/add-labels-to-api-calls
     """
+
+    @model_validator(mode="after")
+    def _default_temperature_by_model(self) -> Self:
+        """Set fallback default temperature (0.7) for non-Gemini 3 models if unset."""
+        if self.temperature is None and not _is_gemini_3_or_later(self.model or ""):
+            self.temperature = 0.7
+        return self
 
     @model_validator(mode="after")
     def _resolve_project_from_credentials(self) -> Self:

--- a/libs/genai/langchain_google_genai/_common.py
+++ b/libs/genai/langchain_google_genai/_common.py
@@ -326,18 +326,10 @@ class _BaseGoogleGenerativeAI(BaseModel):
     model: str = Field(...)
     """Model name to use."""
 
-    temperature: float = 0.7
+    temperature: float | None = None
     """Run inference with this temperature.
 
     Must be within `[0.0, 2.0]`.
-
-    !!! note "Automatic override for Gemini 3.0+ models"
-
-        If `temperature` is not explicitly set and the model is Gemini 3.0 or later,
-        it will be automatically set to `1.0` instead of the default `0.7` per the
-        Google GenAI API best practices, as it can cause infinite loops, degraded
-        reasoning performance, and failure on complex tasks.
-
     """
 
     frequency_penalty: float | None = None

--- a/libs/genai/langchain_google_genai/_common.py
+++ b/libs/genai/langchain_google_genai/_common.py
@@ -17,14 +17,6 @@ _TELEMETRY_TAG = "remote_reasoning_engine"
 _TELEMETRY_ENV_VARIABLE_NAME = "GOOGLE_CLOUD_AGENT_ENGINE_ID"
 
 
-def _is_gemini_3_or_later(model_name: str) -> bool:
-    """Checks if the model is Gemini 3 or later."""
-    if not model_name:
-        return False
-    model_name = model_name.lower().replace("models/", "")
-    return "gemini-3" in model_name
-
-
 # Cache package version at module import time to avoid blocking I/O in async contexts
 try:
     LC_GOOGLE_GENAI_VERSION = metadata.version("langchain-google-genai")
@@ -335,7 +327,7 @@ class _BaseGoogleGenerativeAI(BaseModel):
     model: str = Field(...)
     """Model name to use."""
 
-    temperature: float | None = None
+    temperature: float | None = 0.7
     """Run inference with this temperature.
 
     Must be within `[0.0, 2.0]`.
@@ -550,13 +542,6 @@ class _BaseGoogleGenerativeAI(BaseModel):
 
     See: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/add-labels-to-api-calls
     """
-
-    @model_validator(mode="after")
-    def _default_temperature_by_model(self) -> Self:
-        """Set fallback default temperature (0.7) for non-Gemini 3 models if unset."""
-        if self.temperature is None and not _is_gemini_3_or_later(self.model or ""):
-            self.temperature = 0.7
-        return self
 
     @model_validator(mode="after")
     def _resolve_project_from_credentials(self) -> Self:

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2505,20 +2505,10 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
-        """Validates params and builds client.
-
-        We override `temperature` to `1.0` for Gemini 3+ models if not explicitly set.
-        This is to prevent infinite loops and degraded performance that can occur with
-        `temperature < 1.0` on these models.
-        """
+        """Validates params and builds client."""
         if self.temperature is not None and not 0 <= self.temperature <= 2.0:
             msg = "temperature must be in the range [0.0, 2.0]"
             raise ValueError(msg)
-
-        if "temperature" not in self.model_fields_set and _is_gemini_3_or_later(
-            self.model
-        ):
-            self.temperature = 1.0
 
         if self.top_p is not None and not 0 <= self.top_p <= 1:
             msg = "top_p must be in the range [0.0, 1.0]"

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -111,6 +111,7 @@ from langchain_google_genai._common import (
     GoogleGenerativeAIError,
     SafetySettingDict,
     _BaseGoogleGenerativeAI,
+    _is_gemini_3_or_later,
     get_user_agent,
 )
 from langchain_google_genai._compat import (
@@ -225,14 +226,6 @@ class ChatGoogleGenerativeAIError(GoogleGenerativeAIError):
     Raised when there are specific issues related to the Google GenAI API usage in the
     `ChatGoogleGenerativeAI` class, such as unsupported message types or roles.
     """
-
-
-def _is_gemini_3_or_later(model_name: str) -> bool:
-    """Checks if the model is Gemini 3 or later."""
-    if not model_name:
-        return False
-    model_name = model_name.lower().replace("models/", "")
-    return "gemini-3" in model_name
 
 
 def _is_gemini_25_model(model_name: str) -> bool:

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -111,7 +111,6 @@ from langchain_google_genai._common import (
     GoogleGenerativeAIError,
     SafetySettingDict,
     _BaseGoogleGenerativeAI,
-    _is_gemini_3_or_later,
     get_user_agent,
 )
 from langchain_google_genai._compat import (
@@ -226,6 +225,14 @@ class ChatGoogleGenerativeAIError(GoogleGenerativeAIError):
     Raised when there are specific issues related to the Google GenAI API usage in the
     `ChatGoogleGenerativeAI` class, such as unsupported message types or roles.
     """
+
+
+def _is_gemini_3_or_later(model_name: str) -> bool:
+    """Checks if the model is Gemini 3 or later."""
+    if not model_name:
+        return False
+    model_name = model_name.lower().replace("models/", "")
+    return "gemini-3" in model_name
 
 
 def _is_gemini_25_model(model_name: str) -> bool:
@@ -2499,6 +2506,11 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
         """Validates params and builds client."""
+        if "temperature" not in self.model_fields_set and _is_gemini_3_or_later(
+            self.model
+        ):
+            self.temperature = None
+
         if self.temperature is not None and not 0 <= self.temperature <= 2.0:
             msg = "temperature must be in the range [0.0, 2.0]"
             raise ValueError(msg)

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -58,6 +58,7 @@ from langchain_google_genai import (
     Modality,
     __version__,
 )
+from langchain_google_genai._common import _is_gemini_3_or_later
 from langchain_google_genai._compat import (
     _convert_from_v1_to_generativelanguage_v1beta,
 )
@@ -68,7 +69,6 @@ from langchain_google_genai.chat_models import (
     _convert_to_parts,
     _convert_tool_message_to_parts,
     _get_ai_message_tool_messages_parts,
-    _is_gemini_3_or_later,
     _is_gemini_25_model,
     _merge_http_options,
     _parse_chat_history,
@@ -1442,6 +1442,24 @@ def test_temperature_range_model_validation() -> None:
 
     with pytest.raises(ValueError):
         ChatGoogleGenerativeAI(model=MODEL_NAME, temperature=-0.5)
+
+
+def test_temperature_default_by_model_version() -> None:
+    """Test that legacy models get 0.7 temperature by default.
+
+    Also ensures Gemini 3 models get None.
+    """
+    llm_gemini_3 = ChatGoogleGenerativeAI(
+        model="gemini-3.5-flash",
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+    assert llm_gemini_3.temperature is None
+
+    llm_gemini_2_5 = ChatGoogleGenerativeAI(
+        model="gemini-2.5-flash",
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+    assert llm_gemini_2_5.temperature == 0.7
 
 
 @patch("langchain_google_genai.chat_models.Client")

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -58,7 +58,6 @@ from langchain_google_genai import (
     Modality,
     __version__,
 )
-from langchain_google_genai._common import _is_gemini_3_or_later
 from langchain_google_genai._compat import (
     _convert_from_v1_to_generativelanguage_v1beta,
 )
@@ -69,6 +68,7 @@ from langchain_google_genai.chat_models import (
     _convert_to_parts,
     _convert_tool_message_to_parts,
     _get_ai_message_tool_messages_parts,
+    _is_gemini_3_or_later,
     _is_gemini_25_model,
     _merge_http_options,
     _parse_chat_history,

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -120,7 +120,7 @@ def test_integration_initialization() -> None:
         "ls_provider": "google_genai",
         "ls_model_name": MODEL_NAME,
         "ls_model_type": "chat",
-        "ls_temperature": 1.0,
+        "ls_temperature": None,
         "ls_max_tokens": 10,
     }
 
@@ -128,7 +128,7 @@ def test_integration_initialization() -> None:
     msg = HumanMessage(content="test")
     request = llm._prepare_request([msg])
     config = request["config"]
-    assert config.temperature == 1.0
+    assert getattr(config, "temperature", None) is None
     assert config.max_output_tokens == 10
 
     ChatGoogleGenerativeAI(

--- a/libs/genai/tests/unit_tests/test_llms.py
+++ b/libs/genai/tests/unit_tests/test_llms.py
@@ -22,6 +22,7 @@ def test_tracing_params() -> None:
         "ls_provider": "google_genai",
         "ls_model_type": "llm",
         "ls_model_name": MODEL_NAME,
+        "ls_temperature": 0.7,
     }
     assert llm.metadata is not None
     assert llm.metadata["lc_versions"]["langchain-google-genai"] == __version__

--- a/libs/genai/tests/unit_tests/test_llms.py
+++ b/libs/genai/tests/unit_tests/test_llms.py
@@ -22,7 +22,6 @@ def test_tracing_params() -> None:
         "ls_provider": "google_genai",
         "ls_model_type": "llm",
         "ls_model_name": MODEL_NAME,
-        "ls_temperature": 0.7,
     }
     assert llm.metadata is not None
     assert llm.metadata["lc_versions"]["langchain-google-genai"] == __version__


### PR DESCRIPTION
Newer models will have a fixed temperature and start throwing errors when temperatures are specified, so we no longer want to specify a default.

All gemini-3 series models use a temperature of 1.0 by default, so that does not need to be specified.