### PR TITLE
fix(genai): don't forward project/location to Client in Vertex AI API-key auth

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2614,14 +2614,27 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 os.environ["GOOGLE_API_KEY"] = google_api_key
                 api_key_env_set = True
 
+            # Vertex AI "Express Mode" (API-key auth, no credentials) is
+            # project-less by design. The google-genai SDK gives an
+            # explicitly-passed `project`/`location` precedence over an API
+            # key that was only set via environment variable, which causes
+            # it to silently discard the API key and fall back to
+            # Application Default Credentials -- raising
+            # `DefaultCredentialsError` even though a valid API key was
+            # supplied (see #1473). Only pass `project`/`location` through
+            # when we're not authenticating purely via API key.
+            using_api_key_only = bool(google_api_key) and not self.credentials
+            client_kwargs: dict[str, Any] = {
+                "vertexai": True,
+                "credentials": self.credentials,
+                "http_options": http_options,
+            }
+            if not using_api_key_only:
+                client_kwargs["project"] = self.project
+                client_kwargs["location"] = self.location
+
             try:
-                self.client = Client(
-                    vertexai=True,
-                    project=self.project,
-                    location=self.location,
-                    credentials=self.credentials,
-                    http_options=http_options,
-                )
+                self.client = Client(**client_kwargs)
             finally:
                 # Clean up the temporary environment variable if we set it
                 if api_key_env_set:

--- a/libs/genai/langchain_google_genai/embeddings.py
+++ b/libs/genai/langchain_google_genai/embeddings.py
@@ -284,14 +284,28 @@ class GoogleGenerativeAIEmbeddings(BaseModel, Embeddings):
                 os.environ["GOOGLE_API_KEY"] = google_api_key
                 api_key_env_set = True
 
+            # Vertex AI "Express Mode" (API-key auth, no credentials) is
+            # project-less by design. The google-genai SDK gives an
+            # explicitly-passed `project`/`location` precedence over an API
+            # key that was only set via environment variable, which causes
+            # it to silently discard the API key and fall back to
+            # Application Default Credentials -- raising
+            # `DefaultCredentialsError` even though a valid API key was
+            # supplied (see #1473 in ChatGoogleGenerativeAI). Only pass
+            # `project`/`location` through when we're not authenticating
+            # purely via API key.
+            using_api_key_only = bool(google_api_key) and not self.credentials
+            client_kwargs: dict[str, Any] = {
+                "vertexai": True,
+                "credentials": self.credentials,
+                "http_options": http_options,
+            }
+            if not using_api_key_only:
+                client_kwargs["project"] = self.project
+                client_kwargs["location"] = self.location
+
             try:
-                self.client = Client(
-                    vertexai=True,
-                    project=self.project,
-                    location=self.location,
-                    credentials=self.credentials,
-                    http_options=http_options,
-                )
+                self.client = Client(**client_kwargs)
             finally:
                 # Clean up the temporary environment variable if we set it
                 if api_key_env_set:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -762,6 +762,53 @@ def test_api_version_forwarded_to_http_options_vertex() -> None:
         assert call_http_options.base_url == "https://gateway.example.com/api/gemini"
 
 
+def test_vertexai_express_mode_omits_project_and_location() -> None:
+    """Regression test for #1473.
+
+    When authenticating to Vertex AI purely via API key (Express Mode, no
+    `credentials`), `project`/`location` must NOT be forwarded to the
+    `Client` constructor. The underlying google-genai SDK gives an
+    explicitly-passed `project`/`location` precedence over an API key that
+    was only set via environment variable, silently discarding the API key
+    and falling back to Application Default Credentials -- which raises
+    `DefaultCredentialsError` at request time even though a valid API key
+    was supplied.
+    """
+    with patch("langchain_google_genai.chat_models.Client") as mock_client:
+        ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            vertexai=True,
+            project="fake-project-id",
+            api_key=FAKE_API_KEY,
+        )
+        call_kwargs = mock_client.call_args_list[0].kwargs
+        assert "project" not in call_kwargs
+        assert "location" not in call_kwargs
+        assert call_kwargs["vertexai"] is True
+        assert call_kwargs["credentials"] is None
+
+
+def test_vertexai_credentials_mode_forwards_project_and_location() -> None:
+    """`project`/`location` are still forwarded when using credentials.
+
+    Ensures the fix for #1473 doesn't regress the ADC/service-account
+    credentials path, which legitimately needs `project`/`location`.
+    """
+    fake_credentials = Mock()
+    with patch("langchain_google_genai.chat_models.Client") as mock_client:
+        ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            vertexai=True,
+            project="fake-project-id",
+            location="us-central1",
+            credentials=fake_credentials,
+        )
+        call_kwargs = mock_client.call_args_list[0].kwargs
+        assert call_kwargs["project"] == "fake-project-id"
+        assert call_kwargs["location"] == "us-central1"
+        assert call_kwargs["credentials"] is fake_credentials
+
+
 def test_async_client_property() -> None:
     """Test that async_client property exposes `client.aio`."""
     chat = ChatGoogleGenerativeAI(

--- a/libs/genai/tests/unit_tests/test_embeddings.py
+++ b/libs/genai/tests/unit_tests/test_embeddings.py
@@ -234,7 +234,35 @@ def test_vertexai_backend() -> None:
     mock_client.assert_called_once()
     call_kwargs = mock_client.call_args.kwargs
     assert call_kwargs["vertexai"] is True
+    # Regression test for #1473: when authenticating purely via API key
+    # (Vertex AI Express Mode, no `credentials`), `project`/`location` must
+    # NOT be forwarded to `Client`. The google-genai SDK gives an
+    # explicitly-passed `project` precedence over an API key that was only
+    # set via environment variable, which silently discards the API key
+    # and falls back to Application Default Credentials at request time.
+    assert "project" not in call_kwargs
+    assert "location" not in call_kwargs
+    assert call_kwargs["credentials"] is None
+
+
+def test_vertexai_backend_with_credentials_forwards_project() -> None:
+    """`project`/`location` are still forwarded when using credentials."""
+    fake_credentials = MagicMock()
+    with patch("langchain_google_genai.embeddings.Client") as mock_client:
+        _ = GoogleGenerativeAIEmbeddings(
+            model=MODEL_NAME,
+            project="test-project",
+            location="us-central1",
+            credentials=fake_credentials,
+            vertexai=True,
+        )
+
+    mock_client.assert_called_once()
+    call_kwargs = mock_client.call_args.kwargs
+    assert call_kwargs["vertexai"] is True
     assert call_kwargs["project"] == "test-project"
+    assert call_kwargs["location"] == "us-central1"
+    assert call_kwargs["credentials"] is fake_credentials
 
 
 def test_vertexai_auto_detection_with_project() -> None:


### PR DESCRIPTION
Fixes #1473

Fixed an issue where Vertex AI authentication using only an `api_key` was failing.

Previously, when `vertexai=True` and no explicit `credentials` were provided, the wrapper was still passing `project` and `location` values to the `google-genai` Client. Since the SDK prioritizes explicitly provided `project`/`location` values over an API key loaded from the environment, the API key was ignored and the SDK attempted to use Application Default Credentials instead, resulting in a `DefaultCredentialsError`.

This update ensures `project` and `location` are only forwarded when explicit credentials are provided. The same fix was also applied to `embeddings.py`, which had the same behavior.

Added regression tests covering both API-key-only authentication and credentials-based authentication flows. Also updated an existing embeddings test that was expecting the previous incorrect behavior.

Verified with:

* All 274 unit tests passing
* `ruff check` passing
* `ruff format --check` passing
