### PR TITLE
fix(vertexai): strip streaming metadata from nested tool_result content

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
@@ -423,7 +423,15 @@ def _clean_content_block(block: Any) -> Any:
     if block.get("type") not in ("tool_use", "image"):
         keys_to_remove.add("id")
 
-    return {k: v for k, v in block.items() if k not in keys_to_remove}
+    cleaned = {k: v for k, v in block.items() if k not in keys_to_remove}
+
+    # tool_result blocks nest their own content blocks, which can also carry
+    # streaming metadata (e.g. `index`). The top-level strip above does not
+    # reach them, so recurse into the nested content (#1256).
+    if block.get("type") == "tool_result" and isinstance(cleaned.get("content"), list):
+        cleaned["content"] = [_clean_content_block(b) for b in cleaned["content"]]
+
+    return cleaned
 
 
 def _clean_content(content: Any) -> Any:

--- a/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
@@ -1226,6 +1226,49 @@ def test_format_messages_tool_message_with_streaming_metadata() -> None:
     }
 
 
+def test_format_messages_preformatted_tool_result_nested_streaming_metadata() -> None:
+    """Streaming metadata is stripped from nested content of pre-formatted tool_results.
+
+    Regression test for https://github.com/langchain-ai/langchain-google/issues/1256
+
+    When a ToolMessage already holds `tool_result` blocks (e.g. rehydrated from a
+    prior turn in a multi-agent graph), `_clean_content_block` stripped streaming
+    metadata from the top level of the `tool_result` block but left its nested
+    `content` blocks untouched. The leaked `index` on the inner text block made
+    the Anthropic API reject the request with
+    `tool_result.content.0.text.index: Extra inputs are not permitted`.
+    """
+    messages = [
+        AIMessage(
+            content="",
+            tool_calls=[
+                create_tool_call(
+                    name="get_weather", args={"city": "Paris"}, id="call_1"
+                )
+            ],
+        ),
+        ToolMessage(
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_1",
+                    "content": [{"type": "text", "text": "Sunny, 22°C", "index": 0}],
+                }
+            ],
+            tool_call_id="call_1",
+        ),
+    ]
+
+    _, formatted = _format_messages_anthropic(messages, project="test-project")
+
+    # The nested text block must not leak the streaming 'index' field.
+    assert formatted[1]["content"][0] == {
+        "type": "tool_result",
+        "tool_use_id": "call_1",
+        "content": [{"type": "text", "text": "Sunny, 22°C"}],  # NO 'index'
+    }
+
+
 def test_format_messages_tool_message_with_error() -> None:
     """Test that error ToolMessages include is_error flag."""
     messages = [


### PR DESCRIPTION
## Why

`ChatAnthropicVertex` (Claude on Vertex) rejects multi-turn tool-calling requests with:

```
anthropic.BadRequestError: 400 - tool_result.content.0.text.index: Extra inputs are not permitted
```

`_clean_content_block` strips streaming metadata (`index`, `partial_json`) from the **top level** of a content block, but a `tool_result` block nests its own `content` list. When a `ToolMessage` already holds pre-formatted `tool_result` blocks — as happens when message history is rehydrated between turns in a multi-agent / LangGraph graph (the reporter hit it "immediately after the first subagent responds") — the inner text blocks keep their streaming `index`, and Anthropic rejects the payload.

This recurses into the nested `content` of `tool_result` blocks so the inner blocks are cleaned too.

Fixes #1256

## Review notes

- Recursion is guarded to `tool_result` blocks whose `content` is a `list`; string tool_result content (plain-text results) passes through unchanged.
- Nested blocks are cleaned via the same `_clean_content_block`, so inner text blocks also (correctly) have `id` stripped — forbidden inside `tool_result` — through the existing `keys_to_remove` logic.
- Behavior is unchanged for every non-`tool_result` block (the prior return value is preserved).

## Tests

Added `test_format_messages_preformatted_tool_result_nested_streaming_metadata`, covering the pre-formatted-`tool_result` path (the existing streaming-metadata test only covered the conversion path). It fails before the change (`index` leaks) and passes after. Full `vertexai` unit suite: 298 passed, 2 skipped.

---

_Disclosure: Drafted with Claude Code. The root-cause analysis, fix, and regression test were generated by an AI agent and reviewed and verified by me before submission._
