### PR TITLE
fix(vertexai): sniff image media type when a URL has no file extension

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
@@ -78,6 +78,29 @@ def _create_usage_metadata(anthropic_usage: BaseModel) -> UsageMetadata:
     )
 
 
+def _sniff_image_media_type(data: bytes) -> str | None:
+    """Best-effort detect an image media type from its leading byte signature.
+
+    Used as a fallback when an image URL has no usable file extension to derive
+    the media type from. Covers the image formats Anthropic accepts.
+
+    Args:
+        data: The raw image bytes.
+
+    Returns:
+        The detected media type, or `None` if the signature is unrecognized.
+    """
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
 def _format_image(image_url: str, project: str | None) -> dict:
     """Formats a message image to a dict for Anthropic API."""
     regex = r"^data:(?P<media_type>(?:image|application)/.+);base64,(?P<data>.+)$"
@@ -92,13 +115,22 @@ def _format_image(image_url: str, project: str | None) -> dict:
         loader = ImageBytesLoader(project=project)
         image_bytes = loader.load_bytes(image_url)
         path = urllib.parse.urlparse(image_url).path
-        raw_mime_type = path.split(".")[-1].lower()
-        doc_type = "application" if raw_mime_type == "pdf" else "image"
-        mime_type = (
-            f"{doc_type}/jpeg"
-            if raw_mime_type == "jpg"
-            else f"{doc_type}/{raw_mime_type}"
-        )
+        filename = path.rsplit("/", 1)[-1]
+        if "." in filename:
+            raw_mime_type = filename.rsplit(".", 1)[-1].lower()
+            doc_type = "application" if raw_mime_type == "pdf" else "image"
+            mime_type = (
+                f"{doc_type}/jpeg"
+                if raw_mime_type == "jpg"
+                else f"{doc_type}/{raw_mime_type}"
+            )
+        else:
+            # URLs without a file extension (e.g. CDN / signed URLs) would
+            # otherwise produce a malformed media type like "image//path".
+            # Fall back to detecting the type from the downloaded bytes.
+            mime_type = (
+                _sniff_image_media_type(image_bytes) or "application/octet-stream"
+            )
         return {
             "type": "base64",
             "media_type": mime_type,

--- a/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
@@ -1582,6 +1582,34 @@ def test_format_image(image_url: str, expected_media_type: str) -> None:
         mock_loader_instance.load_bytes.assert_called_once_with(image_url)
 
 
+@pytest.mark.parametrize(
+    ("magic_bytes", "expected_media_type"),
+    [
+        (b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR", "image/png"),
+        (b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01", "image/jpeg"),
+        (b"GIF89a\x01\x00\x01\x00", "image/gif"),
+        (b"RIFF\x24\x00\x00\x00WEBPVP8 ", "image/webp"),
+    ],
+)
+def test_format_image_url_without_extension_sniffs_media_type(
+    magic_bytes: bytes, expected_media_type: str
+) -> None:
+    """URLs without a file extension must not yield a malformed media type.
+
+    CDN / signed image URLs frequently have no extension; the old code
+    produced media types like ``image//images/abc`` from the URL path.
+    The byte signature is used as a fallback instead.
+    """
+    with patch(
+        "langchain_google_vertexai._anthropic_utils.ImageBytesLoader"
+    ) as MockLoader:
+        MockLoader.return_value.load_bytes.return_value = magic_bytes
+        result = _format_image("https://cdn.example.com/images/abc123", "test-project")
+
+    assert result["type"] == "base64"
+    assert result["media_type"] == expected_media_type
+
+
 def test_format_messages_anthropic_system_not_first() -> None:
     """Test that system messages are accepted when not at position 0.
 


### PR DESCRIPTION
## Why

`_format_image` derives the Anthropic `media_type` from the image URL's **file extension**:

```python
raw_mime_type = path.split(".")[-1].lower()
```

For image URLs **without an extension** — common for CDN endpoints and signed URLs (e.g. `https://cdn.example.com/images/abc123`) — `path.split(".")[-1]` returns the whole path, so the media type becomes a malformed string like `image//images/abc123`, which the Anthropic API rejects. The `gs://` branch already derives the media type from the loader rather than the extension; only the URL branch was affected.

## What

When the URL has no usable file extension, fall back to detecting the media type from the downloaded bytes' signature (JPEG / PNG / GIF / WebP — the formats Anthropic accepts). URLs that already carry an extension are handled exactly as before.

## Tests

Added `test_format_image_url_without_extension_sniffs_media_type` (parametrized over the four signatures), which fails on `main` (`image//images/abc123`) and passes with the fix. The existing `test_format_image` cases (`.png?token=`, `.jpg`, `.pdf`) are unchanged. Full `test_anthropic_utils.py`: **66 passed**; `ruff` and `mypy` clean.

## Areas worth a careful look

- The fallback set is limited to the image formats Anthropic's Vertex endpoint accepts; unknown signatures fall back to `application/octet-stream` rather than a fabricated `image/<garbage>` type.
- Found while working on the URL→base64 image path (#1886), which routes **all** `type: "image"` URL blocks through `_format_image` — so extension-less URLs now reach this code more often.

---

🤖 *AI disclosure:* found by code review and fixed/tested with Claude Code (an AI coding agent). The regression is pinned by the new test; happy to adjust the detected-format set or the fallback if you'd prefer a different approach.
