### PR TITLE
fix(vertexai): guard ToolMessage-first history in _parse_chat_history_gemini

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -662,15 +662,21 @@ def _parse_chat_history_gemini(
             )
             parts = [part]
 
-            prev_content = vertex_messages[-1]
-            prev_content_is_tool_response = prev_content and prev_content.role == "user"
+            # Guard against an empty history (ToolMessage first, or only a
+            # leading SystemMessage): mirror the FunctionMessage branch above
+            # rather than indexing vertex_messages[-1] and raising IndexError.
+            if vertex_messages:
+                prev_content = vertex_messages[-1]
+                prev_content_is_tool_response = (
+                    prev_content and prev_content.role == "user"
+                )
 
-            if prev_content_is_tool_response:
-                prev_parts = list(prev_content.parts)
-                prev_parts.extend(parts)
-                # replacing last message
-                vertex_messages[-1] = Content(role=role, parts=prev_parts)
-                continue
+                if prev_content_is_tool_response:
+                    prev_parts = list(prev_content.parts)
+                    prev_parts.extend(parts)
+                    # replacing last message
+                    vertex_messages[-1] = Content(role=role, parts=prev_parts)
+                    continue
 
             vertex_messages.append(Content(role=role, parts=parts))
         else:

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -784,6 +784,33 @@ def test_parse_history_gemini_function_empty_list() -> None:
     )
 
 
+def test_parse_history_gemini_tool_message_first() -> None:
+    """A ToolMessage with no preceding content must not raise IndexError.
+
+    Mirrors the FunctionMessage branch, which already guards the empty case.
+    """
+    loader = ImageBytesLoader()
+
+    # ToolMessage as the very first message.
+    _, history = _parse_chat_history_gemini(
+        [ToolMessage(content="result", tool_call_id="1", name="get_weather")], loader
+    )
+    assert len(history) == 1
+    assert history[0].role == "user"
+
+    # A leading SystemMessage does not append to history, so a following
+    # ToolMessage still sees an empty vertex_messages.
+    _, history2 = _parse_chat_history_gemini(
+        [
+            SystemMessage(content="sys"),
+            ToolMessage(content="result", tool_call_id="1", name="get_weather"),
+        ],
+        loader,
+    )
+    assert len(history2) == 1
+    assert history2[0].role == "user"
+
+
 def test_parse_history_gemini_function() -> None:
     """Test parsing of chat history with multiple tool calls and responses."""
     system_input = "You're supposed to answer math questions."


### PR DESCRIPTION
## Why

The `ToolMessage` branch of `_parse_chat_history_gemini` reads `vertex_messages[-1]` unconditionally:

```python
prev_content = vertex_messages[-1]
```

So a `ToolMessage` with no preceding content message raises `IndexError: list index out of range`. Two concrete inputs hit it:

- `_parse_chat_history_gemini([ToolMessage(content="result", tool_call_id="1", name="get_weather")], loader)`
- `[SystemMessage("sys"), ToolMessage(...)]` — a `SystemMessage` does not append to `vertex_messages`, so it is still empty when the `ToolMessage` is reached.

The sibling `FunctionMessage` branch already guards this exact case with `if vertex_messages:`.

## What

Wrap the `vertex_messages[-1]` lookup in `if vertex_messages:` and fall through to appending a new `Content`, mirroring the `FunctionMessage` branch. Non-empty histories are unchanged.

## Tests

Added `test_parse_history_gemini_tool_message_first` (ToolMessage first, and after a lone SystemMessage). It fails on `main` (`IndexError` at chat_models.py:665) and passes with the fix. Full `test_chat_models.py`: **113 passed, 1 skipped**; `ruff` and `mypy` clean.

---

🤖 *AI disclosure:* found by an automated code-review pass and fixed/tested with Claude Code (an AI coding agent). The regression is pinned by the new test; the fixed input still yields a proper Gemini API error for a lone function_response, matching the FunctionMessage branch.
