### PR TITLE
fix(genai): don't mutate caller's tool dict in convert_to_genai_function_declarations

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -415,6 +415,9 @@ def _format_to_genai_function_declaration(
             function = convert_to_openai_tool(cast("dict", tool))["function"]
         else:
             function = cast("dict", tool)
+        # Copy so we don't mutate the caller's tool dict when normalizing
+        # `parameters` below (several branches above alias the input dict).
+        function = dict(function)
         function["parameters"] = function.get("parameters") or {}
         # Empty 'properties' field not supported.
         if not function["parameters"].get("properties"):

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -142,6 +142,34 @@ def test_tool_with_anyof_nullable_param() -> None:
     assert a_property.get("nullable") is True, "Expected 'a' to be marked as nullable."
 
 
+def test_convert_to_genai_function_declarations_does_not_mutate_input() -> None:
+    """Converting tool dicts must not mutate the caller's objects."""
+    import copy
+
+    # OpenAI-format tool whose `parameters` lack `properties` (would be wiped).
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "search",
+            "description": "d",
+            "parameters": {
+                "type": "object",
+                "required": ["q"],
+                "additionalProperties": True,
+            },
+        },
+    }
+    before = copy.deepcopy(tool)
+    convert_to_genai_function_declarations([tool])
+    assert tool == before
+
+    # Parameterless {name, description} dict (would get a `parameters` key added).
+    tool2 = {"name": "foo", "description": "bar"}
+    before2 = copy.deepcopy(tool2)
+    convert_to_genai_function_declarations([tool2])
+    assert tool2 == before2
+
+
 def test_tool_with_array_anyof_nullable_param() -> None:
     """Checks an array parameter marked as optional.
 


### PR DESCRIPTION
## Why

`_format_to_genai_function_declaration` binds `function` to the caller's tool dict (or its nested `"function"`) and then normalizes `parameters` **in place**:

```python
function = tool["function"]          # (or `cast("dict", tool)`)
function["parameters"] = function.get("parameters") or {}
if not function["parameters"].get("properties"):
    function["parameters"] = {}
```

So `convert_to_genai_function_declarations([tool])` mutates the caller's object:

- an OpenAI-format tool whose `parameters` lack a `properties` key has its `parameters` **wiped to `{}`** (losing `required`, `additionalProperties`, …);
- a parameterless `{"name", "description"}` dict gets a `parameters` key **added** to it.

Since tool dicts are frequently shared/reused across providers and calls, this silently corrupts the caller's data.

## What

Shallow-copy `function` before normalizing `parameters`. The lines only reassign the top-level `parameters` key, so a shallow copy fully prevents caller mutation while leaving the produced `FunctionDeclaration` byte-identical.

## Tests

Added `test_convert_to_genai_function_declarations_does_not_mutate_input` (OpenAI-format-without-properties and parameterless cases). It fails on `main` (the input dict is mutated) and passes with the fix. Full `test_function_utils.py`: **33 passed**; `ruff` and `mypy` clean.

---

🤖 *AI disclosure:* found by an automated code-review pass and fixed/tested with Claude Code (an AI coding agent). The regression is pinned by the new test.
