### PR TITLE
fix(genai): apply tool_choice in create_context_cache instead of dropping it

### DIFF
--- a/libs/genai/langchain_google_genai/utils.py
+++ b/libs/genai/langchain_google_genai/utils.py
@@ -11,6 +11,7 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel
 
 from langchain_google_genai._function_utils import (
+    _tool_choice_to_tool_config,
     _ToolChoiceType,
     convert_to_genai_function_declarations,
 )
@@ -179,6 +180,22 @@ def create_context_cache(
 
     if tool_list:
         cache_config_kwargs["tools"] = tool_list
+
+    # Apply tool_choice into the cache's tool_config so a forced/among tool
+    # selection is baked into the cached content (it can't be set on later
+    # requests). Mirrors ChatGoogleGenerativeAI's tool_choice handling.
+    if tool_choice:
+        if not tool_list:
+            msg = (
+                f"Received {tool_choice=} but no tools. 'tool_choice' can only "
+                "be specified if 'tools' is specified."
+            )
+            raise ValueError(msg)
+        all_names = model._extract_tool_names(tool_list)
+        if all_names:
+            cache_config_kwargs["tool_config"] = _tool_choice_to_tool_config(
+                tool_choice, all_names
+            )
 
     # Create the cache
     cache = model.client.caches.create(

--- a/libs/genai/tests/unit_tests/test_utils.py
+++ b/libs/genai/tests/unit_tests/test_utils.py
@@ -1,0 +1,48 @@
+"""Unit tests for `langchain_google_genai.utils`."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+
+from langchain_google_genai.utils import create_context_cache
+
+
+def test_create_context_cache_applies_tool_choice() -> None:
+    """`tool_choice` must be wired into the cache's `tool_config` (#1773 area).
+
+    Previously the documented `tool_choice` parameter was accepted and silently
+    dropped, so a forced/among tool selection never reached the cached content.
+    """
+
+    @tool
+    def search(q: str) -> str:
+        """Search for something."""
+        return q
+
+    model = MagicMock()
+    model.model = "gemini-2.5-flash"
+    model._extract_tool_names.return_value = ["search"]
+
+    captured: dict[str, Any] = {}
+
+    def fake_create(*, model: Any, config: Any) -> Any:
+        captured["config"] = config
+        result = MagicMock()
+        result.name = "caches/abc"
+        return result
+
+    model.client.caches.create.side_effect = fake_create
+
+    name = create_context_cache(
+        model,
+        [HumanMessage("hi")],
+        tools=[search],
+        tool_choice="any",
+    )
+
+    assert name == "caches/abc"
+    # tool_choice must be applied to the cache's tool_config, not dropped.
+    assert captured["config"].tool_config is not None
+    assert captured["config"].tool_config.function_calling_config is not None


### PR DESCRIPTION
## Why

`create_context_cache` documents and accepts a `tool_choice` parameter (signature + docstring), but the function body never references it. So:

```python
create_context_cache(model, messages, tools=[search], tool_choice="any")
```

silently produces a cache with **no** tool-calling constraint — the documented `tool_choice` is dropped with no error. Since `tool_config` can't be set on requests that use a cache, the forced/among-tools selection is lost entirely.

## What

Wire `tool_choice` into the cache's `tool_config`, reusing the same helpers `ChatGoogleGenerativeAI` already uses (`_extract_tool_names` + `_tool_choice_to_tool_config`), including the "`tool_choice` requires `tools`" validation. `CreateCachedContentConfig` supports `tool_config`, so the forced selection is baked into the cached content.

## Tests

Added `tests/unit_tests/test_utils.py::test_create_context_cache_applies_tool_choice`: calls `create_context_cache(..., tools=[t], tool_choice="any")` and asserts the created cache config carries a `tool_config`. It fails on `main` (`tool_config is None` — dropped) and passes with the fix. `ruff` and `mypy` clean.

Note: this bakes the tool-choice mode into the reusable cache; if you'd instead prefer to drop the (currently no-op) parameter, happy to switch to that.

---

🤖 *AI disclosure:* found by an automated code-review pass and fixed/tested with Claude Code (an AI coding agent).
