### PR TITLE
fix(vertexai): avoid SerializeToJsonError for non-finite tool-call args

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/chat_models.py
+++ b/libs/vertexai/langchain_google_vertexai/chat_models.py
@@ -24,6 +24,7 @@ from collections.abc import Callable, Mapping, Sequence
 from collections.abc import AsyncIterator, Iterator
 
 import proto  # type: ignore[import-untyped]
+from proto.marshal.collections import MapComposite, RepeatedComposite  # type: ignore[import-untyped]
 
 from langchain_core._api import deprecated
 from langchain_core.callbacks import (
@@ -760,6 +761,30 @@ def _collapse_text_content(content: list[Any]) -> str | list[Any]:
     return content
 
 
+def _unwrap_proto_composite(value: Any) -> Any:
+    """Recursively convert proto-plus composite values to plain Python types.
+
+    `proto.Message.to_dict` round-trips values through
+    `google.protobuf.json_format`, which raises `SerializeToJsonError` for
+    non-finite floats (`inf`, `-inf`, `nan`) since they aren't valid strict
+    JSON. Walking the composite objects directly avoids that round-trip
+    entirely, so non-finite values pass through unchanged.
+
+    Args:
+        value: A proto-plus value, e.g. a `MapComposite`, `RepeatedComposite`,
+            or primitive, such as the ones found in `FunctionCall.args`.
+
+    Returns:
+        The value with any `MapComposite`/`RepeatedComposite` converted to a
+        plain `dict`/`list`, recursively.
+    """
+    if isinstance(value, MapComposite):
+        return {k: _unwrap_proto_composite(v) for k, v in value.items()}
+    if isinstance(value, RepeatedComposite):
+        return [_unwrap_proto_composite(v) for v in value]
+    return value
+
+
 @overload
 def _parse_response_candidate(
     response_candidate: Candidate | VertexCandidate,
@@ -812,7 +837,7 @@ def _parse_response_candidate(
             # but in general the full set of function calls is stored in tool_calls.
             function_call = {"name": part.function_call.name}
             # dump to match other function calling llm for now
-            function_call_args_dict = proto.Message.to_dict(part.function_call)["args"]
+            function_call_args_dict = _unwrap_proto_composite(part.function_call.args)
             function_call["arguments"] = json.dumps(
                 {k: function_call_args_dict[k] for k in function_call_args_dict}
             )

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+import math
 import sys
 import warnings
 from dataclasses import dataclass
@@ -1604,6 +1605,56 @@ def test_validate_video_metadata_tolerates_unparseable_values(
                 },
             ),
         ),
+        (
+            Candidate(
+                content=Content(
+                    role="model",
+                    parts=[
+                        Part(
+                            function_call=FunctionCall(
+                                name="search",
+                                args={"query": "everything", "limit": float("inf")},
+                            ),
+                        )
+                    ],
+                )
+            ),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    create_tool_call(
+                        name="search",
+                        args={"query": "everything", "limit": float("inf")},
+                        id="00000000-0000-0000-0000-00000000000",
+                    ),
+                ],
+            ),
+        ),
+        (
+            Candidate(
+                content=Content(
+                    role="model",
+                    parts=[
+                        Part(
+                            function_call=FunctionCall(
+                                name="search",
+                                args={"query": "everything", "limit": float("-inf")},
+                            ),
+                        )
+                    ],
+                )
+            ),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    create_tool_call(
+                        name="search",
+                        args={"query": "everything", "limit": float("-inf")},
+                        id="00000000-0000-0000-0000-00000000000",
+                    ),
+                ],
+            ),
+        ),
     ],
 )
 def test_parse_response_candidate(raw_candidate, expected) -> None:
@@ -1626,6 +1677,32 @@ def test_parse_response_candidate(raw_candidate, expected) -> None:
                 res_kw = result.additional_kwargs[key]
                 exp_kw = value
                 assert res_kw == exp_kw
+
+
+def test_parse_response_candidate_nan_arg() -> None:
+    """A NaN tool-call arg should parse instead of raising SerializeToJsonError.
+
+    NaN isn't equal to itself, so this needs `math.isnan` instead of the
+    equality-based comparisons in `test_parse_response_candidate`.
+    """
+    candidate = Candidate(
+        content=Content(
+            role="model",
+            parts=[
+                Part(
+                    function_call=FunctionCall(
+                        name="search",
+                        args={"query": "everything", "limit": float("nan")},
+                    ),
+                )
+            ],
+        )
+    )
+    result = _parse_response_candidate(candidate)
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0]["name"] == "search"
+    assert result.tool_calls[0]["args"]["query"] == "everything"
+    assert math.isnan(result.tool_calls[0]["args"]["limit"])
 
 
 def test_parser_multiple_tools() -> None:


### PR DESCRIPTION
## Description

`ChatVertexAI.invoke()`/`.astream()` crashes with `google.protobuf.json_format.SerializeToJsonError` whenever Gemini returns a non-finite float (`Infinity`, `-Infinity`, or `NaN`) as a tool-call argument — e.g. when the model interprets "no limit" as `Infinity` for a numeric parameter.

**Root cause:** `_parse_response_candidate` builds tool-call args via `proto.Message.to_dict(part.function_call)["args"]`, which round-trips the args `Struct` through `google.protobuf.json_format.MessageToDict`. That serializer rejects non-finite floats outright since they aren't valid strict JSON, raising an uncaught exception.

**Fix:** Walk `part.function_call.args` (a proto-plus `MapComposite`) directly instead, recursively converting `MapComposite`/`RepeatedComposite` to plain `dict`/`list` without ever invoking the JSON serializer. This mirrors how the sibling `langchain-google-genai` package already handles function-call args (`dict(part.function_call.args)`), which never had this bug because it doesn't do the protobuf-JSON round-trip either.

## Testing

- Added 3 regression cases to `test_parse_response_candidate` / a new `test_parse_response_candidate_nan_arg` (`Infinity`, `-Infinity`, `NaN`) in `libs/vertexai/tests/unit_tests/test_chat_models.py`.
- Verified locally: `make test` (300 passed, 2 skipped), `make lint` (ruff + mypy clean).

## Areas for careful review

- The new `_unwrap_proto_composite` helper bypasses `proto.Message.to_dict()`'s int/float normalization for this one field — finite values are unaffected (e.g. `1.0 == 1`), but reviewers should double check no downstream code depends on the exact `to_dict()` output shape beyond what's covered by existing tests.

Fixes #1874