### PR TITLE
fix(genai): guard against None parameters in dict tool conversion

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -411,7 +411,11 @@ def _format_to_genai_function_declaration(
             all(k in tool for k in ("name", "description")) and "parameters" not in tool
         ):
             function = cast("dict", tool)
-        elif "parameters" in tool and tool["parameters"].get("properties"):
+        elif (
+            "parameters" in tool
+            and tool["parameters"] is not None
+            and tool["parameters"].get("properties")
+        ):
             function = convert_to_openai_tool(cast("dict", tool))["function"]
         else:
             function = cast("dict", tool)

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -1501,6 +1501,41 @@ def test_optional_dict_schema_validation() -> None:
     )
 
 
+def test_format_to_genai_function_declaration_none_parameters() -> None:
+    """A `None` `parameters` value must not raise `AttributeError`.
+
+    Regression test for a dict tool whose `parameters` key is present but set
+    to `None` (e.g. produced by `bind_tools`'s fallback path for a titleless
+    dict schema), which previously crashed on `tool["parameters"].get(...)`.
+    """
+    tool = {"name": "MISSING_NAME", "parameters": None}
+    genai_func = _format_to_genai_function_declaration(tool)
+    assert genai_func.name == "MISSING_NAME"
+
+
+def test_convert_to_genai_function_declarations_none_parameters() -> None:
+    """End-to-end regression test for issue #1807.
+
+    `convert_to_genai_function_declarations` is called a second time on the
+    stored `{"function_declarations": [...]}` tools during request
+    preparation. If a declaration in that list has `parameters: None` (as
+    produced by `bind_tools`'s fallback path for a titleless dict schema),
+    this previously raised `AttributeError` instead of a `ValueError` or a
+    usable (if incomplete) declaration.
+    """
+    tools = [
+        {
+            "function_declarations": [
+                {"name": "MISSING_NAME", "parameters": None},
+            ]
+        }
+    ]
+    result = convert_to_genai_function_declarations(tools)
+    assert len(result) == 1
+    assert result[0].function_declarations is not None
+    assert result[0].function_declarations[0].name == "MISSING_NAME"
+
+
 def test_tool_field_enum_array() -> None:
     class ToolInfo(BaseModel):
         kind: list[Literal["foo", "bar"]]


### PR DESCRIPTION
## Description

`with_structured_output(schema, method="function_calling")` raises `AttributeError: 'NoneType' object has no attribute 'get'` when `schema` is a dict without a top-level `"title"` key.

**Root cause:** Two problems compound:
1. `bind_tools`'s fallback (triggered when `convert_to_openai_tool` rejects a titleless dict) produces a `FunctionDeclaration(name="MISSING_NAME", parameters=None)` via `_format_to_genai_function_declaration`'s `else` branch.
2. When `_prepare_request` later re-parses the stored `{"function_declarations": [...]}` tools, `_format_to_genai_function_declaration` hits `tool["parameters"].get("properties")` — but `"parameters"` is present with value `None`, so `.get()` crashes.

**Fix:** Add a `None` check before calling `.get("properties")` on `tool["parameters"]`.

## Scope note

Problem 1 (the `bind_tools` fallback silently producing a `MISSING_NAME`/`parameters=None` declaration for titleless dict schemas, instead of raising a clearer error or handling the schema properly) is a separate, deeper issue. This PR only fixes the crash (Problem 2) — happy to follow up on Problem 1 separately if maintainers want it addressed.

## Testing

- Added `test_format_to_genai_function_declaration_none_parameters` (direct unit test) and `test_convert_to_genai_function_declarations_none_parameters` (end-to-end, mirrors the actual `_prepare_request` code path) to `libs/genai/tests/unit_tests/test_function_utils.py`.
- Verified locally: `make test` (336 passed), `make lint` (ruff + mypy clean).

Fixes #1807