### PR TITLE
test(genai): retry flaky structured output streaming tests

### DIFF
--- a/libs/genai/tests/integration_tests/test_structured_output_integration.py
+++ b/libs/genai/tests/integration_tests/test_structured_output_integration.py
@@ -6,9 +6,12 @@ from pydantic import BaseModel
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-pytestmark = pytest.mark.skipif(
-    not os.getenv("GOOGLE_API_KEY"), reason="GOOGLE_API_KEY not set"
-)
+pytestmark = [
+    pytest.mark.skipif(
+        not os.getenv("GOOGLE_API_KEY"), reason="GOOGLE_API_KEY not set"
+    ),
+    pytest.mark.flaky(retries=3, delay=1),
+]
 
 MODEL_NAME = "gemini-3.5-flash"
 


### PR DESCRIPTION
`test_async_streaming_with_json_schema[google_ai]` failed with `assert 9999...9 == 99`. I reproduced the streaming/merge/parse path locally and confirmed the library correctly yields `count=99` for well-formed delta streams — the runaway integer is nondeterministic Gemini degeneration (the model emitted a long run of `9`s for the unbounded `int` field), not a code bug. This test module was the only one in the genai integration suite without a `flaky` retry marker, so I added the module-wide `@pytest.mark.flaky(retries=3, delay=1)` used everywhere else (e.g. `test_standard.py`, `test_chat_models.py`) to retry transient model degeneration.

Made by [Open SWE](https://openswe.vercel.app/agents/75d54989-6853-4f2d-a378-c75c2ab3f637)