### PR TITLE
feat(genai): add `reasoning_effort` as a standard chat model parameter

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2422,6 +2422,26 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         `thinking_level` takes precedence over `thinking_budget` for Gemini 3+ models.
     """
 
+    reasoning_effort: Literal["none", "low", "medium", "high"] | None = Field(
+        default=None,
+    )
+    """Cross-provider reasoning effort setting for Gemini 3+ models.
+
+    Provides a standard `reasoning_effort` parameter consistent with other chat
+    model integrations (e.g. `ChatOpenAI`, `ChatAnthropic`).
+
+    Supported values:
+        * `'none'`: Disables thinking.
+        * `'low'`: Minimizes latency and cost.
+        * `'medium'`: Balances latency/cost with reasoning depth.
+        * `'high'`: Maximizes reasoning depth.
+
+    `reasoning_effort` is translated to Gemini's native thinking settings. Native
+    fields (`thinking_level`, `thinking_budget`, `thinking_config`) take precedence
+    if explicitly set. `'xhigh'`/`'max'` are intentionally unsupported since Gemini
+    has no equivalent.
+"""
+
     cached_content: str | None = None
     """The name of the cached content used as context to serve the prediction.
 
@@ -2849,14 +2869,15 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         thinking_level = kwargs.get("thinking_level", self.thinking_level)
         thinking_budget = kwargs.get("thinking_budget", self.thinking_budget)
         include_thoughts = kwargs.get("include_thoughts", self.include_thoughts)
+        reasoning_effort = kwargs.get("reasoning_effort", self.reasoning_effort)
 
-        has_thinking_params = (
+        has_native_thinking_params = (
             raw_thinking_config is not None
             or thinking_level is not None
             or thinking_budget is not None
             or include_thoughts is not None
         )
-        if not has_thinking_params:
+        if not has_native_thinking_params and reasoning_effort is None:
             return None
 
         config: dict[str, Any] = {}
@@ -2873,6 +2894,15 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             config["thinking_budget"] = thinking_budget
         if include_thoughts is not None:
             config["include_thoughts"] = include_thoughts
+
+        # `reasoning_effort` is a cross-provider convenience field. Native thinking
+        # params (checked above) take precedence if explicitly set. This is not gated
+        # on `_supports_thinking()`, matching the existing `thinking_*` behavior.
+        if reasoning_effort is not None and not has_native_thinking_params:
+            if reasoning_effort == "none":
+                config["thinking_budget"] = 0
+            else:
+                config["thinking_level"] = reasoning_effort
 
         # thinking_level takes precedence over thinking_budget for Gemini 3+ models
         if "thinking_level" in config and "thinking_budget" in config:
@@ -3044,6 +3074,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             "thinking_budget",
             "thinking_level",
             "include_thoughts",
+            "reasoning_effort",
             "response_schema",
             "response_json_schema",
             "response_mime_type",

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2388,8 +2388,9 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     for more details on supported JSON Schema features.
     """
 
-    thinking_level: Literal["minimal", "low", "medium", "high"] | None = Field(
+    reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = Field(
         default=None,
+        alias="thinking_level",
     )
     """Indicates the thinking level.
 
@@ -2402,16 +2403,18 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     !!! note "Replaces `thinking_budget`"
 
         `thinking_budget` is deprecated for Gemini 3+ models. If both parameters are
-        provided, `thinking_level` takes precedence.
+        provided, this field takes precedence.
 
         If left unspecified, the model's default thinking level is used. For Gemini 3+,
         this defaults to `'high'`.
 
-    !!! note "Cross-provider alias"
+    !!! note "`thinking_level` alias"
 
-        Also accepts `reasoning_effort` as a constructor or call-time keyword for
-        consistency with other chat model integrations. Both names set the same
-        value; use `thinking_level` to read it back.
+        `thinking_level` -- Gemini's own native name for this setting -- is also
+        accepted as an alias for this field, at both construction and call time.
+        If both `thinking_level` and `reasoning_effort` are set, `thinking_level`
+        wins (Pydantic's alias-resolution precedence). Use `reasoning_effort` or
+        `thinking_level` interchangeably to read the value back.
     """
 
     thinking_config: dict[str, Any] | ThinkingConfig | None = Field(
@@ -2441,15 +2444,6 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
     def __init__(self, **kwargs: Any) -> None:
         """Needed for arg validation."""
-        # `reasoning_effort` is a cross-provider-compatible alias for
-        # `thinking_level` (see that field's docstring). Resolved here, ahead of
-        # `model_fields`-based validation below and the `build_extra` validator
-        # (which only recognizes `Field(alias=...)`, not this manual alias), so
-        # neither ever sees the `reasoning_effort` key.
-        if "reasoning_effort" in kwargs:
-            reasoning_effort = kwargs.pop("reasoning_effort")
-            kwargs.setdefault("thinking_level", reasoning_effort)
-
         # Get all valid field names, including aliases
         valid_fields = set()
         for field_name, field_info in self.__class__.model_fields.items():
@@ -2477,6 +2471,11 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     @property
     def _llm_type(self) -> str:
         return "chat-google-generative-ai"
+
+    @property
+    def thinking_level(self) -> Literal["minimal", "low", "medium", "high"] | None:
+        """Alias for `reasoning_effort` (Gemini's native name for this setting)."""
+        return self.reasoning_effort
 
     @property
     def _supports_code_execution(self) -> bool:
@@ -2732,7 +2731,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             "media_resolution": self.media_resolution,
             "thinking_budget": self.thinking_budget,
             "include_thoughts": self.include_thoughts,
-            "thinking_level": self.thinking_level,
+            "thinking_level": self.reasoning_effort,
             "thinking_config": self.thinking_config,
             "image_config": self.image_config,
         }
@@ -2862,11 +2861,13 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     def _build_thinking_config(self, **kwargs: Any) -> ThinkingConfig | None:
         """Build thinking configuration if supported by the model."""
         raw_thinking_config = kwargs.get("thinking_config", self.thinking_config)
-        # `reasoning_effort` is a cross-provider alias for `thinking_level`.
-        # Resolve it before validation so `reasoning_effort` never reaches
-        # `build_extra` or field validation.
+        # `thinking_level` is Gemini's native alias for `reasoning_effort`
+        # (`Field(alias="thinking_level")`). Pydantic aliases don't apply to
+        # call-time kwargs, so it's resolved here too. `thinking_level` wins if
+        # both are set, matching the construction-time alias-resolution
+        # precedence.
         thinking_level = kwargs.get(
-            "thinking_level", kwargs.get("reasoning_effort", self.thinking_level)
+            "thinking_level", kwargs.get("reasoning_effort", self.reasoning_effort)
         )
         thinking_budget = kwargs.get("thinking_budget", self.thinking_budget)
         include_thoughts = kwargs.get("include_thoughts", self.include_thoughts)

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2394,6 +2394,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     """Indicates the thinking level.
 
     Supported values:
+        * `'minimal'`: Lowest available reasoning depth.
         * `'low'`: Minimizes latency and cost.
         * `'medium'`: Balances latency/cost with reasoning depth.
         * `'high'`: Maximizes reasoning depth.
@@ -2405,6 +2406,12 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
         If left unspecified, the model's default thinking level is used. For Gemini 3+,
         this defaults to `'high'`.
+
+    !!! note "Cross-provider alias"
+
+        Also accepts `reasoning_effort` as a constructor or call-time keyword for
+        consistency with other chat model integrations. Both names set the same
+        value; use `thinking_level` to read it back.
     """
 
     thinking_config: dict[str, Any] | ThinkingConfig | None = Field(
@@ -2422,26 +2429,6 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         `thinking_level` takes precedence over `thinking_budget` for Gemini 3+ models.
     """
 
-    reasoning_effort: Literal["none", "low", "medium", "high"] | None = Field(
-        default=None,
-    )
-    """Cross-provider reasoning effort setting for Gemini 3+ models.
-
-    Provides a standard `reasoning_effort` parameter consistent with other chat
-    model integrations (e.g. `ChatOpenAI`, `ChatAnthropic`).
-
-    Supported values:
-        * `'none'`: Disables thinking.
-        * `'low'`: Minimizes latency and cost.
-        * `'medium'`: Balances latency/cost with reasoning depth.
-        * `'high'`: Maximizes reasoning depth.
-
-    `reasoning_effort` is translated to Gemini's native thinking settings. Native
-    fields (`thinking_level`, `thinking_budget`, `thinking_config`) take precedence
-    if explicitly set. `'xhigh'`/`'max'` are intentionally unsupported since Gemini
-    has no equivalent.
-"""
-
     cached_content: str | None = None
     """The name of the cached content used as context to serve the prediction.
 
@@ -2454,6 +2441,15 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
     def __init__(self, **kwargs: Any) -> None:
         """Needed for arg validation."""
+        # `reasoning_effort` is a cross-provider-compatible alias for
+        # `thinking_level` (see that field's docstring). Resolved here, ahead of
+        # `model_fields`-based validation below and the `build_extra` validator
+        # (which only recognizes `Field(alias=...)`, not this manual alias), so
+        # neither ever sees the `reasoning_effort` key.
+        if "reasoning_effort" in kwargs:
+            reasoning_effort = kwargs.pop("reasoning_effort")
+            kwargs.setdefault("thinking_level", reasoning_effort)
+
         # Get all valid field names, including aliases
         valid_fields = set()
         for field_name, field_info in self.__class__.model_fields.items():
@@ -2866,18 +2862,22 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     def _build_thinking_config(self, **kwargs: Any) -> ThinkingConfig | None:
         """Build thinking configuration if supported by the model."""
         raw_thinking_config = kwargs.get("thinking_config", self.thinking_config)
-        thinking_level = kwargs.get("thinking_level", self.thinking_level)
+        # `reasoning_effort` is a cross-provider alias for `thinking_level`.
+        # Resolve it before validation so `reasoning_effort` never reaches
+        # `build_extra` or field validation.
+        thinking_level = kwargs.get(
+            "thinking_level", kwargs.get("reasoning_effort", self.thinking_level)
+        )
         thinking_budget = kwargs.get("thinking_budget", self.thinking_budget)
         include_thoughts = kwargs.get("include_thoughts", self.include_thoughts)
-        reasoning_effort = kwargs.get("reasoning_effort", self.reasoning_effort)
 
-        has_native_thinking_params = (
+        has_thinking_params = (
             raw_thinking_config is not None
             or thinking_level is not None
             or thinking_budget is not None
             or include_thoughts is not None
         )
-        if not has_native_thinking_params and reasoning_effort is None:
+        if not has_thinking_params:
             return None
 
         config: dict[str, Any] = {}
@@ -2894,15 +2894,6 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             config["thinking_budget"] = thinking_budget
         if include_thoughts is not None:
             config["include_thoughts"] = include_thoughts
-
-        # `reasoning_effort` is a cross-provider convenience field. Native thinking
-        # params (checked above) take precedence if explicitly set. This is not gated
-        # on `_supports_thinking()`, matching the existing `thinking_*` behavior.
-        if reasoning_effort is not None and not has_native_thinking_params:
-            if reasoning_effort == "none":
-                config["thinking_budget"] = 0
-            else:
-                config["thinking_level"] = reasoning_effort
 
         # thinking_level takes precedence over thinking_budget for Gemini 3+ models
         if "thinking_level" in config and "thinking_budget" in config:

--- a/libs/genai/langchain_google_genai/data/_profiles.py
+++ b/libs/genai/langchain_google_genai/data/_profiles.py
@@ -240,7 +240,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
@@ -271,7 +271,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
@@ -304,7 +304,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
@@ -335,7 +335,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
@@ -367,7 +367,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
@@ -400,7 +400,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
@@ -432,7 +432,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
@@ -464,7 +464,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",
@@ -496,7 +496,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "none",
+            "minimal",
             "low",
             "medium",
             "high",

--- a/libs/genai/langchain_google_genai/data/_profiles.py
+++ b/libs/genai/langchain_google_genai/data/_profiles.py
@@ -239,6 +239,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
+        "reasoning_effort_levels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+        ],
+        "reasoning_effort_default": "high",
     },
     "gemini-3-pro-image-preview": {
         "name": "Nano Banana Pro",
@@ -263,6 +270,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
+        "reasoning_effort_levels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+        ],
+        "reasoning_effort_default": "high",
     },
     "gemini-3-pro-preview": {
         "name": "Gemini 3 Pro Preview",
@@ -289,6 +303,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
+        "reasoning_effort_levels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+        ],
+        "reasoning_effort_default": "high",
     },
     "gemini-3.1-flash-image-preview": {
         "name": "Nano Banana 2",
@@ -313,6 +334,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
+        "reasoning_effort_levels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+        ],
+        "reasoning_effort_default": "high",
     },
     "gemini-3.1-flash-lite": {
         "name": "Gemini 3.1 Flash Lite",
@@ -338,6 +366,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
+        "reasoning_effort_levels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+        ],
+        "reasoning_effort_default": "high",
     },
     "gemini-3.1-flash-lite-preview": {
         "name": "Gemini 3.1 Flash Lite Preview",
@@ -364,6 +399,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
+        "reasoning_effort_levels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+        ],
+        "reasoning_effort_default": "high",
     },
     "gemini-3.1-pro-preview": {
         "name": "Gemini 3.1 Pro Preview",
@@ -389,6 +431,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
+        "reasoning_effort_levels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+        ],
+        "reasoning_effort_default": "high",
     },
     "gemini-3.1-pro-preview-customtools": {
         "name": "Gemini 3.1 Pro Preview Custom Tools",
@@ -414,6 +463,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
+        "reasoning_effort_levels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+        ],
+        "reasoning_effort_default": "high",
     },
     "gemini-3.5-flash": {
         "name": "Gemini 3.5 Flash",
@@ -439,6 +495,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
+        "reasoning_effort_levels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+        ],
+        "reasoning_effort_default": "high",
     },
     "gemini-embedding-001": {
         "name": "Gemini Embedding 001",

--- a/libs/genai/langchain_google_genai/data/profile_augmentations.toml
+++ b/libs/genai/langchain_google_genai/data/profile_augmentations.toml
@@ -7,37 +7,37 @@ image_tool_message = true
 tool_choice = true
 
 [overrides."gemini-3-flash-preview"]
-reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 reasoning_effort_default = "high"
 
 [overrides."gemini-3-pro-image-preview"]
-reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 reasoning_effort_default = "high"
 
 [overrides."gemini-3-pro-preview"]
-reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 reasoning_effort_default = "high"
 
 [overrides."gemini-3.1-flash-image-preview"]
-reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 reasoning_effort_default = "high"
 
 [overrides."gemini-3.1-flash-lite"]
-reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 reasoning_effort_default = "high"
 
 [overrides."gemini-3.1-flash-lite-preview"]
-reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 reasoning_effort_default = "high"
 
 [overrides."gemini-3.1-pro-preview"]
-reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 reasoning_effort_default = "high"
 
 [overrides."gemini-3.1-pro-preview-customtools"]
-reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 reasoning_effort_default = "high"
 
 [overrides."gemini-3.5-flash"]
-reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 reasoning_effort_default = "high"

--- a/libs/genai/langchain_google_genai/data/profile_augmentations.toml
+++ b/libs/genai/langchain_google_genai/data/profile_augmentations.toml
@@ -5,3 +5,39 @@ image_url_inputs = true
 pdf_inputs = true
 image_tool_message = true
 tool_choice = true
+
+[overrides."gemini-3-flash-preview"]
+reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_default = "high"
+
+[overrides."gemini-3-pro-image-preview"]
+reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_default = "high"
+
+[overrides."gemini-3-pro-preview"]
+reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_default = "high"
+
+[overrides."gemini-3.1-flash-image-preview"]
+reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_default = "high"
+
+[overrides."gemini-3.1-flash-lite"]
+reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_default = "high"
+
+[overrides."gemini-3.1-flash-lite-preview"]
+reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_default = "high"
+
+[overrides."gemini-3.1-pro-preview"]
+reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_default = "high"
+
+[overrides."gemini-3.1-pro-preview-customtools"]
+reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_default = "high"
+
+[overrides."gemini-3.5-flash"]
+reasoning_effort_levels = ["none", "low", "medium", "high"]
+reasoning_effort_default = "high"

--- a/libs/genai/pyproject.toml
+++ b/libs/genai/pyproject.toml
@@ -61,6 +61,13 @@ test_integration = [
 [tool.uv]
 constraint-dependencies = ["urllib3>=2.6.3"]
 
+[tool.uv.sources]
+# Temporary: pin to the langchain PR branch that adds reasoning_effort_levels/
+# reasoning_effort_default to ModelProfile (langchain-ai/langchain#38887), since
+# that hasn't released yet. Switch to a real langchain-core version pin once it
+# does.
+langchain-core = { git = "https://github.com/langchain-ai/langchain", branch = "nm/reasoning-effort", subdirectory = "libs/core" }
+
 [tool.ruff]
 fix = true
 

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -370,15 +370,10 @@ def test_chat_google_genai_invoke_reasoning_effort(
     )
 
     assert isinstance(result, AIMessage)
-    if isinstance(result.content, list):
-        text_content = "".join(
-            block.get("text", "")
-            for block in result.content
-            if isinstance(block, dict) and block.get("type") == "text"
-        )
-        assert len(text_content) > 0
-    else:
-        assert isinstance(result.content, str)
+    content_blocks = result.content_blocks
+    text_blocks = [block for block in content_blocks if block.get("type") == "text"]
+    assert text_blocks
+    assert any(block.get("text") for block in text_blocks)
 
     _check_usage_metadata(result)
     assert result.usage_metadata is not None

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -353,6 +353,53 @@ def test_chat_google_genai_invoke_thinking(
         assert result.usage_metadata["output_token_details"]["reasoning"] > 0
 
 
+@pytest.mark.parametrize("reasoning_effort", ["minimal", "low", "medium", "high"])
+def test_chat_google_genai_invoke_reasoning_effort(
+    reasoning_effort: str, backend_config: dict
+) -> None:
+    """Test invoke with `reasoning_effort`, the alias for `thinking_level`."""
+    llm = ChatGoogleGenerativeAI(
+        model=_THINKING_MODEL,
+        reasoning_effort=reasoning_effort,
+        **backend_config,
+    )
+    assert llm.thinking_level == reasoning_effort
+
+    result = llm.invoke(
+        "How many O's are in Google? Please tell me how you double checked the result",
+    )
+
+    assert isinstance(result, AIMessage)
+    if isinstance(result.content, list):
+        text_content = "".join(
+            block.get("text", "")
+            for block in result.content
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+        assert len(text_content) > 0
+    else:
+        assert isinstance(result.content, str)
+
+    _check_usage_metadata(result)
+    assert result.usage_metadata is not None
+
+
+def test_chat_google_genai_invoke_reasoning_effort_call_time_kwarg(
+    backend_config: dict,
+) -> None:
+    """Test `reasoning_effort` also works as a call-time kwarg, not just constructor."""
+    llm = ChatGoogleGenerativeAI(model=_THINKING_MODEL, **backend_config)
+
+    result = llm.invoke(
+        "How many O's are in Google?",
+        reasoning_effort="low",
+    )
+
+    assert isinstance(result, AIMessage)
+    _check_usage_metadata(result)
+    assert result.usage_metadata is not None
+
+
 def _check_thinking_output(content: list, output_version: str) -> None:
     """Check thinking output format, handling both structured and simple responses."""
     if output_version == "v0":

--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -357,12 +357,13 @@ def test_chat_google_genai_invoke_thinking(
 def test_chat_google_genai_invoke_reasoning_effort(
     reasoning_effort: str, backend_config: dict
 ) -> None:
-    """Test invoke with `reasoning_effort`, the alias for `thinking_level`."""
+    """Test invoke with `reasoning_effort` (`thinking_level` is its native alias)."""
     llm = ChatGoogleGenerativeAI(
         model=_THINKING_MODEL,
         reasoning_effort=reasoning_effort,
         **backend_config,
     )
+    assert llm.reasoning_effort == reasoning_effort
     assert llm.thinking_level == reasoning_effort
 
     result = llm.invoke(

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4703,6 +4703,164 @@ def test_thinking_config_object_is_propagated() -> None:
     assert config.thinking_config.thinking_budget == 512
 
 
+def test_reasoning_effort_none_maps_to_thinking_budget_zero() -> None:
+    """Test `reasoning_effort='none'` disables thinking via `thinking_budget=0`."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        reasoning_effort="none",
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg])
+    config = request["config"]
+    assert config.thinking_config is not None
+    assert config.thinking_config.thinking_budget == 0
+    assert config.thinking_config.thinking_level is None
+
+
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_level"),
+    [
+        ("low", ThinkingLevel.LOW),
+        ("medium", ThinkingLevel.MEDIUM),
+        ("high", ThinkingLevel.HIGH),
+    ],
+)
+def test_reasoning_effort_maps_to_thinking_level(
+    reasoning_effort: str, expected_level: ThinkingLevel
+) -> None:
+    """Test `reasoning_effort` translates into the matching `thinking_level`."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        reasoning_effort=reasoning_effort,
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg])
+    config = request["config"]
+    assert config.thinking_config is not None
+    assert config.thinking_config.thinking_level == expected_level
+    assert config.thinking_config.thinking_budget is None
+
+
+def test_reasoning_effort_ignored_when_thinking_level_set() -> None:
+    """Test the native `thinking_level` wins over `reasoning_effort`, no warning."""
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+
+        llm = ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            google_api_key=SecretStr(FAKE_API_KEY),
+            reasoning_effort="low",
+            thinking_level="high",
+        )
+
+        msg = HumanMessage(content="test")
+        request = llm._prepare_request([msg])
+        config = request["config"]
+
+        assert len(warning_list) == 0
+        assert config.thinking_config is not None
+        assert config.thinking_config.thinking_level == ThinkingLevel.HIGH
+        assert config.thinking_config.thinking_budget is None
+
+
+def test_reasoning_effort_ignored_when_thinking_budget_set() -> None:
+    """Test the native `thinking_budget` wins over `reasoning_effort`, no warning."""
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+
+        llm = ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            google_api_key=SecretStr(FAKE_API_KEY),
+            reasoning_effort="none",
+            thinking_budget=128,
+        )
+
+        msg = HumanMessage(content="test")
+        request = llm._prepare_request([msg])
+        config = request["config"]
+
+        assert len(warning_list) == 0
+        assert config.thinking_config is not None
+        assert config.thinking_config.thinking_budget == 128
+        assert config.thinking_config.thinking_level is None
+
+
+def test_reasoning_effort_ignored_when_thinking_config_set() -> None:
+    """Test raw `thinking_config` wins over `reasoning_effort`, no warning."""
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+
+        llm = ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            google_api_key=SecretStr(FAKE_API_KEY),
+            reasoning_effort="high",
+            thinking_config={"thinking_budget": 64},
+        )
+
+        msg = HumanMessage(content="test")
+        request = llm._prepare_request([msg])
+        config = request["config"]
+
+        assert len(warning_list) == 0
+        assert config.thinking_config is not None
+        assert config.thinking_config.thinking_budget == 64
+        assert config.thinking_config.thinking_level is None
+
+
+def test_reasoning_effort_call_time_kwarg_override() -> None:
+    """Test a call-time `reasoning_effort` kwarg overrides the constructor value."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        reasoning_effort="low",
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg], reasoning_effort="high")
+    config = request["config"]
+    assert config.thinking_config is not None
+    assert config.thinking_config.thinking_level == ThinkingLevel.HIGH
+
+
+def test_reasoning_effort_not_leaked_as_unrecognized_kwarg() -> None:
+    """Test `reasoning_effort` doesn't leak through as a stray request kwarg."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg], reasoning_effort="high")
+    assert "reasoning_effort" not in request
+
+
+def test_reasoning_effort_profile_fields() -> None:
+    """Test `reasoning_effort_levels`/`reasoning_effort_default` load from profile."""
+    llm = ChatGoogleGenerativeAI(
+        model="gemini-3-pro-preview",
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+    assert llm.profile is not None
+    assert llm.profile.get("reasoning_effort_levels") == [
+        "none",
+        "low",
+        "medium",
+        "high",
+    ]
+    assert llm.profile.get("reasoning_effort_default") == "high"
+
+    legacy_llm = ChatGoogleGenerativeAI(
+        model="gemini-2.5-pro",
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+    assert legacy_llm.profile is not None
+    assert legacy_llm.profile.get("reasoning_effort_levels") is None
+
+
 def test_kwargs_override_max_output_tokens() -> None:
     """Test that max_output_tokens can be overridden via kwargs."""
     llm = ChatGoogleGenerativeAI(

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4732,7 +4732,13 @@ def test_reasoning_effort_is_alias_for_thinking_level(
 
 
 def test_thinking_level_wins_when_both_constructor_kwargs_given() -> None:
-    """Test `thinking_level` takes precedence when both aliases are passed."""
+    """Test `thinking_level` takes precedence when both are passed.
+
+    `reasoning_effort` is now the canonical field (`Field(alias="thinking_level")`),
+    but `thinking_level` -- Gemini's native name -- is the alias, and Pydantic's
+    alias-resolution precedence has the alias win over the field's own name when
+    both are supplied.
+    """
     llm = ChatGoogleGenerativeAI(
         model=MODEL_NAME,
         google_api_key=SecretStr(FAKE_API_KEY),
@@ -4775,7 +4781,10 @@ def test_reasoning_effort_call_time_kwarg_override() -> None:
 
 
 def test_reasoning_effort_call_time_kwarg_yields_to_thinking_level_kwarg() -> None:
-    """Test a call-time `thinking_level` kwarg wins over `reasoning_effort`."""
+    """Test a call-time `thinking_level` kwarg wins over `reasoning_effort`.
+
+    Mirrors the construction-time alias-resolution precedence.
+    """
     llm = ChatGoogleGenerativeAI(
         model=MODEL_NAME,
         google_api_key=SecretStr(FAKE_API_KEY),

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4703,39 +4703,25 @@ def test_thinking_config_object_is_propagated() -> None:
     assert config.thinking_config.thinking_budget == 512
 
 
-def test_reasoning_effort_none_maps_to_thinking_budget_zero() -> None:
-    """Test `reasoning_effort='none'` disables thinking via `thinking_budget=0`."""
-    llm = ChatGoogleGenerativeAI(
-        model=MODEL_NAME,
-        google_api_key=SecretStr(FAKE_API_KEY),
-        reasoning_effort="none",
-    )
-
-    msg = HumanMessage(content="test")
-    request = llm._prepare_request([msg])
-    config = request["config"]
-    assert config.thinking_config is not None
-    assert config.thinking_config.thinking_budget == 0
-    assert config.thinking_config.thinking_level is None
-
-
 @pytest.mark.parametrize(
     ("reasoning_effort", "expected_level"),
     [
+        ("minimal", ThinkingLevel.MINIMAL),
         ("low", ThinkingLevel.LOW),
         ("medium", ThinkingLevel.MEDIUM),
         ("high", ThinkingLevel.HIGH),
     ],
 )
-def test_reasoning_effort_maps_to_thinking_level(
+def test_reasoning_effort_is_alias_for_thinking_level(
     reasoning_effort: str, expected_level: ThinkingLevel
 ) -> None:
-    """Test `reasoning_effort` translates into the matching `thinking_level`."""
+    """Test `reasoning_effort` sets the same underlying `thinking_level` value."""
     llm = ChatGoogleGenerativeAI(
         model=MODEL_NAME,
         google_api_key=SecretStr(FAKE_API_KEY),
         reasoning_effort=reasoning_effort,
     )
+    assert llm.thinking_level == reasoning_effort
 
     msg = HumanMessage(content="test")
     request = llm._prepare_request([msg])
@@ -4745,70 +4731,32 @@ def test_reasoning_effort_maps_to_thinking_level(
     assert config.thinking_config.thinking_budget is None
 
 
-def test_reasoning_effort_ignored_when_thinking_level_set() -> None:
-    """Test the native `thinking_level` wins over `reasoning_effort`, no warning."""
-    with warnings.catch_warnings(record=True) as warning_list:
-        warnings.simplefilter("always")
-
-        llm = ChatGoogleGenerativeAI(
-            model=MODEL_NAME,
-            google_api_key=SecretStr(FAKE_API_KEY),
-            reasoning_effort="low",
-            thinking_level="high",
-        )
-
-        msg = HumanMessage(content="test")
-        request = llm._prepare_request([msg])
-        config = request["config"]
-
-        assert len(warning_list) == 0
-        assert config.thinking_config is not None
-        assert config.thinking_config.thinking_level == ThinkingLevel.HIGH
-        assert config.thinking_config.thinking_budget is None
+def test_thinking_level_wins_when_both_constructor_kwargs_given() -> None:
+    """Test `thinking_level` takes precedence when both aliases are passed."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        thinking_level="low",
+        reasoning_effort="high",
+    )
+    assert llm.thinking_level == "low"
 
 
-def test_reasoning_effort_ignored_when_thinking_budget_set() -> None:
-    """Test the native `thinking_budget` wins over `reasoning_effort`, no warning."""
-    with warnings.catch_warnings(record=True) as warning_list:
-        warnings.simplefilter("always")
+def test_reasoning_effort_composes_with_include_thoughts() -> None:
+    """Test `include_thoughts` composes with `reasoning_effort`."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        reasoning_effort="high",
+        include_thoughts=True,
+    )
 
-        llm = ChatGoogleGenerativeAI(
-            model=MODEL_NAME,
-            google_api_key=SecretStr(FAKE_API_KEY),
-            reasoning_effort="none",
-            thinking_budget=128,
-        )
-
-        msg = HumanMessage(content="test")
-        request = llm._prepare_request([msg])
-        config = request["config"]
-
-        assert len(warning_list) == 0
-        assert config.thinking_config is not None
-        assert config.thinking_config.thinking_budget == 128
-        assert config.thinking_config.thinking_level is None
-
-
-def test_reasoning_effort_ignored_when_thinking_config_set() -> None:
-    """Test raw `thinking_config` wins over `reasoning_effort`, no warning."""
-    with warnings.catch_warnings(record=True) as warning_list:
-        warnings.simplefilter("always")
-
-        llm = ChatGoogleGenerativeAI(
-            model=MODEL_NAME,
-            google_api_key=SecretStr(FAKE_API_KEY),
-            reasoning_effort="high",
-            thinking_config={"thinking_budget": 64},
-        )
-
-        msg = HumanMessage(content="test")
-        request = llm._prepare_request([msg])
-        config = request["config"]
-
-        assert len(warning_list) == 0
-        assert config.thinking_config is not None
-        assert config.thinking_config.thinking_budget == 64
-        assert config.thinking_config.thinking_level is None
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg])
+    config = request["config"]
+    assert config.thinking_config is not None
+    assert config.thinking_config.thinking_level == ThinkingLevel.HIGH
+    assert config.thinking_config.include_thoughts is True
 
 
 def test_reasoning_effort_call_time_kwarg_override() -> None:
@@ -4826,6 +4774,20 @@ def test_reasoning_effort_call_time_kwarg_override() -> None:
     assert config.thinking_config.thinking_level == ThinkingLevel.HIGH
 
 
+def test_reasoning_effort_call_time_kwarg_yields_to_thinking_level_kwarg() -> None:
+    """Test a call-time `thinking_level` kwarg wins over `reasoning_effort`."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+
+    msg = HumanMessage(content="test")
+    request = llm._prepare_request([msg], thinking_level="low", reasoning_effort="high")
+    config = request["config"]
+    assert config.thinking_config is not None
+    assert config.thinking_config.thinking_level == ThinkingLevel.LOW
+
+
 def test_reasoning_effort_not_leaked_as_unrecognized_kwarg() -> None:
     """Test `reasoning_effort` doesn't leak through as a stray request kwarg."""
     llm = ChatGoogleGenerativeAI(
@@ -4838,6 +4800,17 @@ def test_reasoning_effort_not_leaked_as_unrecognized_kwarg() -> None:
     assert "reasoning_effort" not in request
 
 
+def test_reasoning_effort_constructor_kwarg_does_not_warn() -> None:
+    """Test `reasoning_effort` doesn't log an unexpected-argument warning."""
+    with patch("langchain_google_genai.chat_models.logger.warning") as mock_warning:
+        ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            google_api_key=SecretStr(FAKE_API_KEY),
+            reasoning_effort="high",
+        )
+    mock_warning.assert_not_called()
+
+
 def test_reasoning_effort_profile_fields() -> None:
     """Test `reasoning_effort_levels`/`reasoning_effort_default` load from profile."""
     llm = ChatGoogleGenerativeAI(
@@ -4846,7 +4819,7 @@ def test_reasoning_effort_profile_fields() -> None:
     )
     assert llm.profile is not None
     assert llm.profile.get("reasoning_effort_levels") == [
-        "none",
+        "minimal",
         "low",
         "medium",
         "high",

--- a/libs/genai/uv.lock
+++ b/libs/genai/uv.lock
@@ -500,8 +500,8 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.7"
-source = { registry = "https://pypi.org/simple" }
+version = "1.4.9"
+source = { git = "https://github.com/langchain-ai/langchain?subdirectory=libs%2Fcore&branch=nm%2Freasoning-effort#1f618aec1c9965028dfd4c0cc995bd57123b60a1" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langchain-protocol" },
@@ -512,10 +512,6 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "uuid-utils" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/2b/fffaff399d20a56d40b9562fa19701e91abd72d8c9d9bc8c2673077b56b6/langchain_core-1.4.7.tar.gz", hash = "sha256:7a825d77de0a3f39adbd9d09612a75e85527e14a52c1601089bcc062972d9f2b", size = 952522, upload-time = "2026-06-12T19:23:57.588Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/3e/dcdffa60078ae7b3a00ebb4cbbf1a204a14c3609983c604886523a7d4418/langchain_core-1.4.7-py3-none-any.whl", hash = "sha256:bcadd51951140ecdcba98311dbd931ba5de02a5ba8a2288dad5069c1eea2a13d", size = 554941, upload-time = "2026-06-12T19:23:55.826Z" },
 ]
 
 [[package]]
@@ -565,7 +561,7 @@ typing = [
 requires-dist = [
     { name = "filetype", specifier = ">=1.2.0,<2.0.0" },
     { name = "google-genai", specifier = ">=1.65.0,<3.0.0" },
-    { name = "langchain-core", specifier = ">=1.4.7,<2.0.0" },
+    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain?subdirectory=libs%2Fcore&branch=nm%2Freasoning-effort" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
 ]
 
@@ -598,14 +594,14 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.15"
+version = "0.0.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload-time = "2026-05-01T22:30:03.877Z" },
+    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary

Adds support for the standard `reasoning_effort` parameter in `ChatGoogleGenerativeAI`. Like `temperature`, it can be passed at model construction or per call and is translated into Gemini's native `thinking_level`.

This extends the cross-provider `reasoning_effort` interface supported by other providers (langchain-ai/langchain#38887), allowing callers to configure reasoning consistently across Gemini as well. Supported values (`"minimal"`, `"low"`, `"medium"`, `"high"`) and the provider default are exposed via `ModelProfile` for Gemini 3.x models.

```python
from langchain_google_genai import ChatGoogleGenerativeAI

model = ChatGoogleGenerativeAI(model="gemini-3-pro-preview")
model.invoke(
    "Why do parrots have colorful feathers?",
    reasoning_effort="high",
)
```

`thinking_level` is an alias for `reasoning_effort`; `reasoning_effort` remains the canonical field. The supported values match Gemini's native `thinking_level` exactly: `"minimal"`, `"low"`, `"medium"`, and `"high"`.

`ChatVertexAI` is not included because the underlying `google-cloud-aiplatform` SDK has no equivalent to `thinking_level`.

### Release note

`ChatGoogleGenerativeAI` now accepts `reasoning_effort`/ `thinking_level` on Gemini 3.x models. Supported values (`"minimal"`, `"low"`, `"medium"`, `"high"`) and the default are exposed via `ModelProfile`.