### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/libs/community/scripts/check_imports.py
+++ b/libs/community/scripts/check_imports.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
         try:
             SourceFileLoader("x", file).load_module()
         except Exception:
-            has_faillure = True
+            has_failure = True
             print(file)
             traceback.print_exc()
             print()

--- a/libs/genai/scripts/check_imports.py
+++ b/libs/genai/scripts/check_imports.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
         try:
             SourceFileLoader("x", file).load_module()
         except Exception:
-            has_faillure = True
+            has_failure = True
             traceback.print_exc()
 
     sys.exit(1 if has_failure else 0)


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `libs/community/scripts/check_imports.py:L11`

In the `check_imports.py` script, the variable `has_failure` is initialized, but in the exception handler, it is assigned to a misspelled variable `has_faillure`. As a result, the original `has_failure` variable remains `False` even when an import fails, causing the script to exit with code 0 (success) and silently ignore import errors.

## Solution

Change `has_faillure = True` to `has_failure = True` in the exception handler so that the script correctly tracks and reports failures.

## Changes

- `libs/community/scripts/check_imports.py` (modified)
- `libs/genai/scripts/check_imports.py` (modified)