### PR TITLE
fix(genai): align reasoning effort profiles with Gemini docs

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2030,8 +2030,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         for more info.
 
         Gemini 3+ models use [`thinking_level`][langchain_google_genai.ChatGoogleGenerativeAI.thinking_level]
-        (`'low'`, `'medium'`, or `'high'`) to control reasoning depth. If not specified,
-        defaults to `'high'`.
+        to control reasoning depth. Supported levels and defaults vary by model.
 
         ```python
         model = ChatGoogleGenerativeAI(
@@ -2427,8 +2426,8 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         `thinking_budget` is deprecated for Gemini 3+ models. If both parameters are
         provided, this field takes precedence.
 
-        If left unspecified, the model's default thinking level is used. For Gemini 3+,
-        this defaults to `'high'`.
+        If left unspecified, the model's default thinking level is used. Supported
+        levels and defaults vary by model.
 
     !!! note "`thinking_level` alias"
 

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2030,7 +2030,9 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         for more info.
 
         Gemini 3+ models use [`thinking_level`][langchain_google_genai.ChatGoogleGenerativeAI.thinking_level]
-        to control reasoning depth. Supported levels and defaults vary by model.
+        to control reasoning depth. Supported levels and defaults vary by model. Check
+        `model.profile` for `reasoning_effort_levels` and
+        `reasoning_effort_default`.
 
         ```python
         model = ChatGoogleGenerativeAI(
@@ -2415,19 +2417,22 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     )
     """Indicates the thinking level.
 
-    Supported values:
+    Possible values (support varies by model):
         * `'minimal'`: Lowest available reasoning depth.
         * `'low'`: Minimizes latency and cost.
         * `'medium'`: Balances latency/cost with reasoning depth.
         * `'high'`: Maximizes reasoning depth.
+
+    Check the model profile's `reasoning_effort_levels` and
+    `reasoning_effort_default` fields, then confirm current support in the upstream
+    [Gemini API docs](https://ai.google.dev/gemini-api/docs/generate-content/thinking#thinking-levels-gemini-3).
 
     !!! note "Replaces `thinking_budget`"
 
         `thinking_budget` is deprecated for Gemini 3+ models. If both parameters are
         provided, this field takes precedence.
 
-        If left unspecified, the model's default thinking level is used. Supported
-        levels and defaults vary by model.
+        If left unspecified, the model's default thinking level is used.
 
     !!! note "`thinking_level` alias"
 

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -2424,7 +2424,8 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         * `'high'`: Maximizes reasoning depth.
 
     Check the model profile's `reasoning_effort_levels` and
-    `reasoning_effort_default` fields, then confirm current support in the upstream
+    `reasoning_effort_default` fields for model-specific support. If those fields are
+    unavailable, consult the upstream
     [Gemini API docs](https://ai.google.dev/gemini-api/docs/generate-content/thinking#thinking-levels-gemini-3).
 
     !!! note "Replaces `thinking_budget`"

--- a/libs/genai/langchain_google_genai/data/_profiles.py
+++ b/libs/genai/langchain_google_genai/data/_profiles.py
@@ -270,13 +270,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
-        "reasoning_effort_levels": [
-            "minimal",
-            "low",
-            "medium",
-            "high",
-        ],
-        "reasoning_effort_default": "high",
     },
     "gemini-3-pro-preview": {
         "name": "Gemini 3 Pro Preview",
@@ -304,9 +297,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "minimal",
             "low",
-            "medium",
             "high",
         ],
         "reasoning_effort_default": "high",
@@ -336,11 +327,9 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "tool_choice": True,
         "reasoning_effort_levels": [
             "minimal",
-            "low",
-            "medium",
             "high",
         ],
-        "reasoning_effort_default": "high",
+        "reasoning_effort_default": "minimal",
     },
     "gemini-3.1-flash-lite": {
         "name": "Gemini 3.1 Flash Lite",
@@ -372,7 +361,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
             "medium",
             "high",
         ],
-        "reasoning_effort_default": "high",
+        "reasoning_effort_default": "minimal",
     },
     "gemini-3.1-flash-lite-preview": {
         "name": "Gemini 3.1 Flash Lite Preview",
@@ -405,7 +394,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
             "medium",
             "high",
         ],
-        "reasoning_effort_default": "high",
+        "reasoning_effort_default": "minimal",
     },
     "gemini-3.1-pro-preview": {
         "name": "Gemini 3.1 Pro Preview",
@@ -432,7 +421,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "minimal",
             "low",
             "medium",
             "high",
@@ -464,7 +452,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "reasoning_effort_levels": [
-            "minimal",
             "low",
             "medium",
             "high",
@@ -501,7 +488,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
             "medium",
             "high",
         ],
-        "reasoning_effort_default": "high",
+        "reasoning_effort_default": "medium",
     },
     "gemini-3.5-flash-lite": {
         "name": "Gemini 3.5 Flash Lite",
@@ -527,6 +514,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
+        "reasoning_effort_levels": [
+            "minimal",
+            "low",
+            "medium",
+            "high",
+        ],
+        "reasoning_effort_default": "minimal",
     },
     "gemini-3.6-flash": {
         "name": "Gemini 3.6 Flash",
@@ -552,6 +546,13 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_url_inputs": True,
         "image_tool_message": True,
         "tool_choice": True,
+        "reasoning_effort_levels": [
+            "minimal",
+            "low",
+            "medium",
+            "high",
+        ],
+        "reasoning_effort_default": "medium",
     },
     "gemini-embedding-001": {
         "name": "Gemini Embedding 001",

--- a/libs/genai/langchain_google_genai/data/profile_augmentations.toml
+++ b/libs/genai/langchain_google_genai/data/profile_augmentations.toml
@@ -10,34 +10,38 @@ tool_choice = true
 reasoning_effort_levels = ["minimal", "low", "medium", "high"]
 reasoning_effort_default = "high"
 
-[overrides."gemini-3-pro-image-preview"]
-reasoning_effort_levels = ["minimal", "low", "medium", "high"]
-reasoning_effort_default = "high"
-
 [overrides."gemini-3-pro-preview"]
-reasoning_effort_levels = ["minimal", "low", "medium", "high"]
+reasoning_effort_levels = ["low", "high"]
 reasoning_effort_default = "high"
 
 [overrides."gemini-3.1-flash-image-preview"]
-reasoning_effort_levels = ["minimal", "low", "medium", "high"]
-reasoning_effort_default = "high"
+reasoning_effort_levels = ["minimal", "high"]
+reasoning_effort_default = "minimal"
 
 [overrides."gemini-3.1-flash-lite"]
 reasoning_effort_levels = ["minimal", "low", "medium", "high"]
-reasoning_effort_default = "high"
+reasoning_effort_default = "minimal"
 
 [overrides."gemini-3.1-flash-lite-preview"]
 reasoning_effort_levels = ["minimal", "low", "medium", "high"]
-reasoning_effort_default = "high"
+reasoning_effort_default = "minimal"
 
 [overrides."gemini-3.1-pro-preview"]
-reasoning_effort_levels = ["minimal", "low", "medium", "high"]
+reasoning_effort_levels = ["low", "medium", "high"]
 reasoning_effort_default = "high"
 
 [overrides."gemini-3.1-pro-preview-customtools"]
-reasoning_effort_levels = ["minimal", "low", "medium", "high"]
+reasoning_effort_levels = ["low", "medium", "high"]
 reasoning_effort_default = "high"
 
 [overrides."gemini-3.5-flash"]
 reasoning_effort_levels = ["minimal", "low", "medium", "high"]
-reasoning_effort_default = "high"
+reasoning_effort_default = "medium"
+
+[overrides."gemini-3.5-flash-lite"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
+reasoning_effort_default = "minimal"
+
+[overrides."gemini-3.6-flash"]
+reasoning_effort_levels = ["minimal", "low", "medium", "high"]
+reasoning_effort_default = "medium"

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4887,27 +4887,48 @@ def test_reasoning_effort_constructor_kwarg_does_not_warn() -> None:
     mock_warning.assert_not_called()
 
 
-def test_reasoning_effort_profile_fields() -> None:
-    """Test `reasoning_effort_levels`/`reasoning_effort_default` load from profile."""
-    llm = ChatGoogleGenerativeAI(
-        model="gemini-3-pro-preview",
-        google_api_key=SecretStr(FAKE_API_KEY),
-    )
-    assert llm.profile is not None
-    assert llm.profile.get("reasoning_effort_levels") == [
-        "minimal",
-        "low",
-        "medium",
-        "high",
-    ]
-    assert llm.profile.get("reasoning_effort_default") == "high"
+_ALL_REASONING_EFFORT_LEVELS = ["minimal", "low", "medium", "high"]
 
-    legacy_llm = ChatGoogleGenerativeAI(
-        model="gemini-2.5-pro",
+
+@pytest.mark.parametrize(
+    ("model_name", "expected_levels", "expected_default"),
+    [
+        ("gemini-3-flash-preview", _ALL_REASONING_EFFORT_LEVELS, "high"),
+        ("gemini-3-pro-image-preview", None, None),
+        ("gemini-3-pro-preview", ["low", "high"], "high"),
+        ("gemini-3.1-flash-image-preview", ["minimal", "high"], "minimal"),
+        ("gemini-3.1-flash-lite", _ALL_REASONING_EFFORT_LEVELS, "minimal"),
+        (
+            "gemini-3.1-flash-lite-preview",
+            _ALL_REASONING_EFFORT_LEVELS,
+            "minimal",
+        ),
+        ("gemini-3.1-pro-preview", ["low", "medium", "high"], "high"),
+        (
+            "gemini-3.1-pro-preview-customtools",
+            ["low", "medium", "high"],
+            "high",
+        ),
+        ("gemini-3.5-flash", _ALL_REASONING_EFFORT_LEVELS, "medium"),
+        ("gemini-3.5-flash-lite", _ALL_REASONING_EFFORT_LEVELS, "minimal"),
+        ("gemini-3.6-flash", _ALL_REASONING_EFFORT_LEVELS, "medium"),
+        ("gemini-2.5-pro", None, None),
+    ],
+)
+def test_reasoning_effort_profile_fields(
+    model_name: str,
+    expected_levels: list[str] | None,
+    expected_default: str | None,
+) -> None:
+    """Test reasoning effort profile fields match the supported model settings."""
+    llm = ChatGoogleGenerativeAI(
+        model=model_name,
         google_api_key=SecretStr(FAKE_API_KEY),
     )
-    assert legacy_llm.profile is not None
-    assert legacy_llm.profile.get("reasoning_effort_levels") is None
+
+    assert llm.profile is not None
+    assert llm.profile.get("reasoning_effort_levels") == expected_levels
+    assert llm.profile.get("reasoning_effort_default") == expected_default
 
 
 def test_kwargs_override_max_output_tokens() -> None:


### PR DESCRIPTION
## Description

`ChatGoogleGenerativeAI` accepts `reasoning_effort` as a flat parameter, but its generated model profiles did not consistently describe the levels each Gemini model supports. Some profiles advertised unsupported values or the wrong default, while Gemini 3.5 Flash-Lite and Gemini 3.6 Flash omitted the metadata entirely. Callers using profile metadata could therefore present invalid choices or select the wrong default.

This aligns the overrides with Google's documented thinking controls, regenerates the profiles, and makes the parameter documentation explicit that supported levels and defaults vary by model. The regression test now covers every documented Gemini profile in the package, including models for which configurable levels are intentionally absent.

Sources:
- https://ai.google.dev/gemini-api/docs/generate-content/thinking
- https://ai.google.dev/gemini-api/docs/image-generation#controlling-thinking-levels

Review note: `gemini-3-pro-image-preview` no longer advertises `reasoning_effort_levels` or `reasoning_effort_default`. Google documents mandatory thinking for this model, but does not document configurable levels or a configurable default.