### PR TITLE
release(genai): 4.3.1

### DIFF
--- a/libs/genai/pyproject.toml
+++ b/libs/genai/pyproject.toml
@@ -9,7 +9,7 @@ license = {text = "MIT"}
 readme = "README.md"
 authors = []
 
-version = "4.3.0"
+version = "4.3.1"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.5.0,<2.0.0",

--- a/libs/genai/uv.lock
+++ b/libs/genai/uv.lock
@@ -520,7 +520,7 @@ wheels = [
 
 [[package]]
 name = "langchain-google-genai"
-version = "4.3.0"
+version = "4.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "filetype" },


### PR DESCRIPTION
Bumps `langchain-google-genai` from 4.3.0 to 4.3.1.

This patch release includes the corrected `reasoning_effort` model-profile levels and defaults from #1899, so callers using profile metadata do not offer unsupported choices or select the wrong default.
