### PR TITLE
docs: fix broken CONTRIBUTING.md link and stale branch references

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,7 +56,7 @@ cd libs/{LIBRARY}
 make format
 ```
 
-Additionally, you can run the formatter only on the files that have been modified in your current branch as compared to the master branch using the format_diff command:
+Additionally, you can run the formatter only on the files that have been modified in your current branch as compared to the main branch using the format_diff command:
 
 ```bash
 make format_diff
@@ -81,7 +81,7 @@ cd libs/{LIBRARY}
 make lint
 ```
 
-In addition, you can run the linter only on the files that have been modified in your current branch as compared to the master branch using the lint_diff command:
+In addition, you can run the linter only on the files that have been modified in your current branch as compared to the main branch using the lint_diff command:
 
 ```bash
 make lint_diff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This document provides context to understand the LangChain Python project and as
 
 This is a Python monorepo with multiple independently versioned packages that use `uv`.
 
-### Development tools & commands**
+### Development tools & commands
 
 - `uv` – Fast Python package installer and resolver (replaces pip/poetry)
 - `make` – Task runner for common development commands. Feel free to look at the `Makefile` for available commands and usage patterns.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This document provides context to understand the LangChain Python project and as
 
 This is a Python monorepo with multiple independently versioned packages that use `uv`.
 
-### Development tools & commands**
+### Development tools & commands
 
 - `uv` – Fast Python package installer and resolver (replaces pip/poetry)
 - `make` – Task runner for common development commands. Feel free to look at the `Makefile` for available commands and usage patterns.

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ As an open-source project in a rapidly developing field, we are extremely open t
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
 
-For contributing to this specific package, see the [`langchain-google` Contributing Guide](./CONTRIBUTING.md).
+For contributing to this specific package, see the [`langchain-google` Contributing Guide](./.github/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

- Fix broken link in README.md: `./CONTRIBUTING.md` should be `./.github/CONTRIBUTING.md` (the file lives in `.github/`)
- Fix stale 'master branch' references on lines 59 and 84 of `.github/CONTRIBUTING.md` (default branch is 'main')
- Fix broken markdown formatting in CLAUDE.md and AGENTS.md line 11: orphaned `**` bold markers on heading

## Testing

Verified link target exists at `.github/CONTRIBUTING.md`. Verified default branch is `main` via git. Markdown formatting fix is visually obvious.