### PR TITLE
fix(genai): convert ClientError raised during streaming iteration

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -177,6 +177,31 @@ def _handle_client_error(e: ClientError, request: dict[str, Any]) -> None:
     raise ChatGoogleGenerativeAIError(msg) from e
 
 
+def _stream_with_client_error_handling(
+    stream: Iterator[GenerateContentResponse], request: dict[str, Any]
+) -> Iterator[GenerateContentResponse]:
+    """Yield from ``stream``, converting a `ClientError` raised while iterating.
+
+    The streaming clients are lazy, so a `ClientError` surfaces on the first
+    iteration rather than when the stream object is created.
+    """
+    try:
+        yield from stream
+    except ClientError as e:
+        _handle_client_error(e, request)
+
+
+async def _astream_with_client_error_handling(
+    stream: AsyncIterator[GenerateContentResponse], request: dict[str, Any]
+) -> AsyncIterator[GenerateContentResponse]:
+    """Async counterpart of `_stream_with_client_error_handling`."""
+    try:
+        async for chunk in stream:
+            yield chunk
+    except ClientError as e:
+        _handle_client_error(e, request)
+
+
 def _get_default_model_profile(model_name: str) -> ModelProfile:
     default = _MODEL_PROFILES.get(model_name) or {}
     return default.copy()
@@ -3469,7 +3494,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         prev_usage_metadata: UsageMetadata | None = None  # Cumulative usage
         index = -1
         index_type = ""
-        for chunk in response:
+        for chunk in _stream_with_client_error_handling(response, request):
             if chunk:
                 _chat_result = _response_to_result(
                     chunk, stream=True, prev_usage=prev_usage_metadata
@@ -3538,7 +3563,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         except ClientError as e:
             _handle_client_error(e, request)
 
-        async for chunk in stream:
+        async for chunk in _astream_with_client_error_handling(stream, request):
             _chat_result = _response_to_result(
                 chunk, stream=True, prev_usage=prev_usage_metadata
             )

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4,7 +4,7 @@ import base64
 import json
 import os
 import warnings
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Literal, cast
 from unittest.mock import ANY, AsyncMock, Mock, patch
@@ -6271,6 +6271,75 @@ def test_context_overflow_error_stream_sync() -> None:
             match="exceeds the maximum number of tokens allowed",
         ):
             list(chat.stream("test"))
+
+
+def _overflow_client_error() -> ClientError:
+    return ClientError(
+        code=400,
+        response_json={
+            "error": {
+                "message": (
+                    "The input token count (1632254) exceeds the maximum "
+                    "number of tokens allowed (1048576)."
+                ),
+                "status": "INVALID_ARGUMENT",
+            }
+        },
+        response=None,
+    )
+
+
+def test_context_overflow_error_stream_sync_raised_during_iteration() -> None:
+    """Token overflow raised while iterating the stream is still converted."""
+    mock_client = Mock()
+    mock_models = Mock()
+
+    def raising_stream() -> Iterator[Any]:
+        raise _overflow_client_error()
+        yield  # pragma: no cover
+
+    mock_models.generate_content_stream = Mock(return_value=raising_stream())
+    mock_client.return_value.models = mock_models
+
+    with patch("langchain_google_genai.chat_models.Client", mock_client):
+        chat = ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            google_api_key=SecretStr(FAKE_API_KEY),
+            max_retries=0,
+        )
+
+        with pytest.raises(
+            ContextOverflowError,
+            match="exceeds the maximum number of tokens allowed",
+        ):
+            list(chat.stream("test"))
+
+
+async def test_context_overflow_error_stream_async_raised_during_iteration() -> None:
+    """Token overflow raised while iterating the async stream is converted."""
+    mock_client = Mock()
+    mock_aio_models = Mock()
+
+    async def raising_stream() -> AsyncIterator[Any]:
+        raise _overflow_client_error()
+        yield  # pragma: no cover
+
+    mock_aio_models.generate_content_stream = AsyncMock(return_value=raising_stream())
+    mock_client.return_value.aio.models = mock_aio_models
+
+    with patch("langchain_google_genai.chat_models.Client", mock_client):
+        chat = ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            google_api_key=SecretStr(FAKE_API_KEY),
+            max_retries=0,
+        )
+
+        with pytest.raises(
+            ContextOverflowError,
+            match="exceeds the maximum number of tokens allowed",
+        ):
+            async for _ in chat.astream("test"):
+                pass
 
 
 def test_context_overflow_error_backwards_compatibility() -> None:


### PR DESCRIPTION
## Description

`_stream` and `_astream` in `ChatGoogleGenerativeAI` only wrapped the *creation* of the stream object in `try/except ClientError`. The google-genai streaming clients are lazy, so the request is not actually sent until the stream is iterated — the `ClientError` therefore escapes unconverted and `GoogleContextOverflowError` is never raised for token-limit errors on streaming calls (non-streaming calls convert correctly).

The fix funnels the iteration itself through small helper generators that call the existing `_handle_client_error`, so streaming matches the non-streaming behaviour.

## Relevant issues

Fixes #1923

## Type

🐛 Bug Fix

## Changes(optional)

- `_stream_with_client_error_handling` / `_astream_with_client_error_handling` helpers in `chat_models.py`
- `_stream` and `_astream` iterate through those helpers

## Testing(optional)

Two regression tests added beside the existing context-overflow stream tests in `tests/unit_tests/test_chat_models.py`, raising the `ClientError` during iteration rather than at construction. Both fail without the source change and pass with it; `tests/unit_tests/test_chat_models.py` is 302 passed, and `ruff check` / `ruff format` are clean on both changed files.

This change was prepared with AI assistance; the regression tests were run locally and fail without the fix.
