### PR TITLE
fix(vertexai): convert v1 content blocks and stamp model_provider for Claude on Vertex

### DIFF
--- a/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import re
 import urllib.parse
 import warnings
@@ -142,6 +143,90 @@ def _format_text_content(text: str) -> dict[str, str | dict[str, Any]]:
     return content
 
 
+def _convert_v1_block_to_anthropic(block: dict) -> dict:
+    """Convert a LangChain v1 content block to Anthropic wire format.
+
+    Builds new dicts and never mutates `block` in place. Unrecognized types are
+    returned unchanged. `reasoning` is intentionally not handled here — the
+    dedicated branch in `_format_message_anthropic` supports `cache_control`.
+
+    Args:
+        block: A content block dict, possibly in LangChain v1 shape.
+
+    Returns:
+        An Anthropic-native content block dict, or the original block when no
+        conversion applies.
+    """
+    block_type = block.get("type")
+
+    if block_type == "tool_call":
+        return {
+            "type": "tool_use",
+            "name": block.get("name", ""),
+            "input": block.get("args", {}),
+            "id": block.get("id", ""),
+        }
+
+    if block_type == "tool_call_chunk":
+        args = block.get("args")
+        if isinstance(args, str):
+            try:
+                input_ = json.loads(args or "{}")
+            except json.JSONDecodeError:
+                input_ = {}
+        else:
+            input_ = args or {}
+        return {
+            "type": "tool_use",
+            "name": block.get("name", ""),
+            "input": input_,
+            "id": block.get("id", ""),
+        }
+
+    if block_type == "non_standard" and "value" in block:
+        # `_clean_content` only strips streaming keys at the top level, so
+        # nested `index` / `partial_json` / `caller` inside `value` survive
+        # merge. Clean the unwrapped block before returning.
+        return _clean_content_block(block["value"])
+
+    if block_type == "server_tool_call":
+        new_block: dict[str, Any] = {}
+        if "id" in block:
+            new_block["id"] = block["id"]
+        new_block["input"] = block.get("args", {})
+        if partial_json := block.get("extras", {}).get("partial_json"):
+            new_block["input"] = {}
+            new_block["partial_json"] = partial_json
+        if block.get("name") == "code_interpreter":
+            new_block["name"] = "code_execution"
+        elif block.get("name") == "remote_mcp":
+            if "tool_name" in block.get("extras", {}):
+                new_block["name"] = block["extras"]["tool_name"]
+            if "server_name" in block.get("extras", {}):
+                new_block["server_name"] = block["extras"]["server_name"]
+        else:
+            new_block["name"] = block.get("name", "")
+        if block.get("name") == "remote_mcp":
+            new_block["type"] = "mcp_tool_use"
+        else:
+            new_block["type"] = "server_tool_use"
+        return new_block
+
+    if block_type == "server_tool_result":
+        new_block = {}
+        if "output" in block:
+            new_block["content"] = block["output"]
+        server_tool_result_type = block.get("extras", {}).get("block_type", "")
+        if server_tool_result_type == "mcp_tool_result":
+            new_block["is_error"] = block.get("status") == "error"
+        if "tool_call_id" in block:
+            new_block["tool_use_id"] = block["tool_call_id"]
+        new_block["type"] = server_tool_result_type
+        return new_block
+
+    return block
+
+
 def _format_message_anthropic(
     message: HumanMessage | AIMessage | SystemMessage, project: str | None
 ):
@@ -179,6 +264,8 @@ def _format_message_anthropic(
                 if "type" not in block:
                     msg = "Dict content block must have a type key"
                     raise ValueError(msg)
+
+                block = _convert_v1_block_to_anthropic(block)
 
                 new_block = {}
 
@@ -418,9 +505,9 @@ def _clean_content_block(block: Any) -> Any:
     # 'partial_json' - added during streaming for incremental JSON parsing
     keys_to_remove = {"index", "partial_json", "caller"}
 
-    # The id field is required for tool_use blocks and some image blocks,
-    # but forbidden in text blocks (specifically inside tool_results).
-    if block.get("type") not in ("tool_use", "image"):
+    # Keep id for tool_use/image and v1 tool_call(s) — format dedup needs
+    # that id after conversion. Strip it from text (esp. inside tool_results).
+    if block.get("type") not in ("tool_use", "image", "tool_call", "tool_call_chunk"):
         keys_to_remove.add("id")
 
     return {k: v for k, v in block.items() if k not in keys_to_remove}
@@ -630,6 +717,8 @@ def _make_message_chunk_from_anthropic_event(
         )
     else:
         pass
+    if message_chunk:
+        message_chunk.response_metadata["model_provider"] = "anthropic"
     return message_chunk
 
 

--- a/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
+++ b/libs/vertexai/langchain_google_vertexai/_anthropic_utils.py
@@ -160,12 +160,15 @@ def _convert_v1_block_to_anthropic(block: dict) -> dict:
     block_type = block.get("type")
 
     if block_type == "tool_call":
-        return {
+        tool_use_block = {
             "type": "tool_use",
             "name": block.get("name", ""),
             "input": block.get("args", {}),
             "id": block.get("id", ""),
         }
+        if "caller" in block.get("extras", {}):
+            tool_use_block["caller"] = block["extras"]["caller"]
+        return tool_use_block
 
     if block_type == "tool_call_chunk":
         args = block.get("args")
@@ -338,7 +341,7 @@ def _format_message_anthropic(
                         is_unique = block["id"] not in [
                             tc["id"] for tc in message.tool_calls
                         ]
-                        if not is_unique:
+                        if not is_unique and not block.get("caller"):
                             continue
 
                 content.append(block)
@@ -347,7 +350,15 @@ def _format_message_anthropic(
         raise ValueError(msg)
 
     if isinstance(message, AIMessage) and message.tool_calls:
-        for tc in message.tool_calls:
+        tool_use_ids = [
+            b["id"]
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "tool_use"
+        ]
+        missing_tool_calls = [
+            tc for tc in message.tool_calls if tc["id"] not in tool_use_ids
+        ]
+        for tc in missing_tool_calls:
             tu = cast("dict[str, Any]", _lc_tool_call_to_anthropic_tool_use_block(tc))
             content.append(tu)
 

--- a/libs/vertexai/langchain_google_vertexai/model_garden.py
+++ b/libs/vertexai/langchain_google_vertexai/model_garden.py
@@ -390,15 +390,22 @@ class ChatAnthropicVertex(_VertexAICommon, BaseChatModel):
             if llm_model is not None:
                 llm_output["model_name"] = llm_model
         if len(content) == 1 and content[0]["type"] == "text":
-            msg = AIMessage(content=content[0]["text"])
+            msg = AIMessage(
+                content=content[0]["text"],
+                response_metadata={"model_provider": "anthropic"},
+            )
         elif any(block["type"] == "tool_use" for block in content):
             tool_calls = _extract_tool_calls(content)
             msg = AIMessage(
                 content=content,
                 tool_calls=tool_calls,
+                response_metadata={"model_provider": "anthropic"},
             )
         else:
-            msg = AIMessage(content=content)
+            msg = AIMessage(
+                content=content,
+                response_metadata={"model_provider": "anthropic"},
+            )
         # Collect token usage using the reusable function (matches langchain_anthropic)
         msg.usage_metadata = _create_usage_metadata(data.usage)
         return ChatResult(

--- a/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
@@ -1,14 +1,25 @@
 """Unit tests for _anthropic_utils.py."""
 
 import base64
+import copy
 from unittest.mock import patch
 
 import pytest
 from anthropic.types import (
+    ContentBlockParam,
+    Message,
+    MessageDeltaUsage,
     RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawMessageDeltaEvent,
+    RawMessageStartEvent,
     SignatureDelta,
+    TextDelta,
     ThinkingDelta,
+    ToolUseBlock,
+    Usage,
 )
+from anthropic.types.raw_message_delta_event import Delta
 from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
@@ -18,8 +29,10 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.content import create_image_block, create_text_block
 from langchain_core.messages.tool import tool_call as create_tool_call
+from pydantic import TypeAdapter, ValidationError
 
 from langchain_google_vertexai._anthropic_utils import (
+    _convert_v1_block_to_anthropic,
     _documents_in_params,
     _format_image,
     _format_message_anthropic,
@@ -929,7 +942,8 @@ def test_make_thinking_message_chunk_from_anthropic_event() -> None:
                 "type": "thinking",
                 "thinking": "thoughts of the model...",
             }
-        ]
+        ],
+        response_metadata={"model_provider": "anthropic"},
     )
     assert signature_chunk == AIMessageChunk(
         content=[
@@ -938,7 +952,8 @@ def test_make_thinking_message_chunk_from_anthropic_event() -> None:
                 "type": "thinking",
                 "signature": "thoughts-signature",
             }
-        ]
+        ],
+        response_metadata={"model_provider": "anthropic"},
     )
     assert isinstance(thinking_chunk, AIMessageChunk)
     assert isinstance(signature_chunk, AIMessageChunk)
@@ -1696,3 +1711,258 @@ def test_format_messages_anthropic_preserves_trailing_thinking_block() -> None:
     ]
     _, formatted = _format_messages_anthropic(messages, project="test-project")
     assert formatted[-1]["content"][0]["thinking"] == "considering...  "
+
+
+def test_format_messages_v1_tool_call_round_trip() -> None:
+    """v1 `tool_call` blocks convert to a single Anthropic `tool_use` (#1930)."""
+    ai_message = AIMessage(
+        content=[
+            {
+                "type": "tool_call",
+                "id": "toolu_vrtx_01",
+                "name": "reference_lookup",
+                "args": {"query": "test"},
+            }
+        ],
+        tool_calls=[
+            {
+                "type": "tool_call",
+                "id": "toolu_vrtx_01",
+                "name": "reference_lookup",
+                "args": {"query": "test"},
+            }
+        ],
+    )
+    messages = [
+        HumanMessage("test"),
+        ai_message,
+        ToolMessage(
+            content="result",
+            tool_call_id="toolu_vrtx_01",
+            name="reference_lookup",
+        ),
+    ]
+
+    _, formatted = _format_messages_anthropic(messages, project="my-project")
+
+    assert formatted[1]["content"] == [
+        {
+            "type": "tool_use",
+            "name": "reference_lookup",
+            "input": {"query": "test"},
+            "id": "toolu_vrtx_01",
+        }
+    ]
+
+
+def test_format_messages_v1_tool_call_validates_as_content_block_param() -> None:
+    """Formatted v1 tool_call payload validates as Anthropic ContentBlockParam."""
+    ai_message = AIMessage(
+        content=[
+            {
+                "type": "tool_call",
+                "id": "toolu_vrtx_01",
+                "name": "reference_lookup",
+                "args": {"query": "test"},
+            }
+        ],
+        tool_calls=[
+            {
+                "type": "tool_call",
+                "id": "toolu_vrtx_01",
+                "name": "reference_lookup",
+                "args": {"query": "test"},
+            }
+        ],
+    )
+    _, formatted = _format_messages_anthropic(
+        [
+            HumanMessage("test"),
+            ai_message,
+            ToolMessage(
+                content="result",
+                tool_call_id="toolu_vrtx_01",
+                name="reference_lookup",
+            ),
+        ],
+        project="my-project",
+    )
+
+    adapter: TypeAdapter[ContentBlockParam] = TypeAdapter(ContentBlockParam)
+    for block in formatted[1]["content"]:
+        adapter.validate_python(block)
+
+    with pytest.raises(ValidationError):
+        adapter.validate_python(
+            {
+                "type": "tool_call",
+                "id": "toolu_vrtx_01",
+                "name": "reference_lookup",
+                "args": {"query": "test"},
+            }
+        )
+
+
+def test_convert_v1_tool_call_chunk_partial_and_valid_json() -> None:
+    """`tool_call_chunk` args: invalid JSON becomes `{}`; valid JSON parses."""
+    invalid = _convert_v1_block_to_anthropic(
+        {
+            "type": "tool_call_chunk",
+            "id": "toolu_1",
+            "name": "reference_lookup",
+            "args": '{"que',
+        }
+    )
+    assert invalid == {
+        "type": "tool_use",
+        "name": "reference_lookup",
+        "input": {},
+        "id": "toolu_1",
+    }
+
+    valid = _convert_v1_block_to_anthropic(
+        {
+            "type": "tool_call_chunk",
+            "id": "toolu_1",
+            "name": "reference_lookup",
+            "args": '{"query": "test"}',
+        }
+    )
+    assert valid == {
+        "type": "tool_use",
+        "name": "reference_lookup",
+        "input": {"query": "test"},
+        "id": "toolu_1",
+    }
+
+
+def test_convert_v1_non_standard_strips_nested_streaming_keys() -> None:
+    """Unwrap `non_standard` and strip nested streaming metadata (#1930)."""
+    converted = _convert_v1_block_to_anthropic(
+        {
+            "type": "non_standard",
+            "value": {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "t",
+                "input": {},
+                "caller": None,
+                "index": 0,
+                "partial_json": "x",
+            },
+        }
+    )
+    assert converted == {
+        "type": "tool_use",
+        "id": "toolu_1",
+        "name": "t",
+        "input": {},
+    }
+    assert "caller" not in converted
+    assert "index" not in converted
+    assert "partial_json" not in converted
+
+
+def test_format_messages_v1_tool_call_does_not_mutate_input() -> None:
+    """Formatting must not mutate shared message content (agent checkpoints)."""
+    original_block = {
+        "type": "tool_call",
+        "id": "toolu_vrtx_01",
+        "name": "reference_lookup",
+        "args": {"query": "test"},
+    }
+    ai_message = AIMessage(
+        content=[original_block],
+        tool_calls=[
+            {
+                "type": "tool_call",
+                "id": "toolu_vrtx_01",
+                "name": "reference_lookup",
+                "args": {"query": "test"},
+            }
+        ],
+    )
+    messages = [
+        HumanMessage("test"),
+        ai_message,
+        ToolMessage(
+            content="result",
+            tool_call_id="toolu_vrtx_01",
+            name="reference_lookup",
+        ),
+    ]
+    content_before = copy.deepcopy(ai_message.content)
+
+    _format_messages_anthropic(messages, project="my-project")
+
+    assert ai_message.content == content_before
+    assert original_block == {
+        "type": "tool_call",
+        "id": "toolu_vrtx_01",
+        "name": "reference_lookup",
+        "args": {"query": "test"},
+    }
+
+
+def test_make_message_chunk_sets_model_provider() -> None:
+    """Streaming chunks stamp `model_provider=\"anthropic\"` (#1754)."""
+    message_start = _make_message_chunk_from_anthropic_event(
+        event=RawMessageStartEvent(
+            type="message_start",
+            message=Message(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                content=[],
+                model="claude-sonnet-4-6",
+                stop_reason=None,
+                stop_sequence=None,
+                usage=Usage(input_tokens=1, output_tokens=0),
+            ),
+        ),
+        stream_usage=True,
+        coerce_content_to_string=True,
+    )
+    assert message_start is not None
+    assert message_start.response_metadata["model_provider"] == "anthropic"
+
+    content_block_start = _make_message_chunk_from_anthropic_event(
+        event=RawContentBlockStartEvent(
+            type="content_block_start",
+            index=0,
+            content_block=ToolUseBlock(
+                type="tool_use",
+                id="toolu_1",
+                name="reference_lookup",
+                input={},
+            ),
+        ),
+        stream_usage=True,
+        coerce_content_to_string=False,
+    )
+    assert content_block_start is not None
+    assert content_block_start.response_metadata["model_provider"] == "anthropic"
+
+    content_block_delta = _make_message_chunk_from_anthropic_event(
+        event=RawContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=0,
+            delta=TextDelta(type="text_delta", text="hello"),
+        ),
+        stream_usage=True,
+        coerce_content_to_string=True,
+    )
+    assert content_block_delta is not None
+    assert content_block_delta.response_metadata["model_provider"] == "anthropic"
+
+    message_delta = _make_message_chunk_from_anthropic_event(
+        event=RawMessageDeltaEvent(
+            type="message_delta",
+            delta=Delta(stop_reason="end_turn", stop_sequence=None),
+            usage=MessageDeltaUsage(output_tokens=5),
+        ),
+        stream_usage=True,
+        coerce_content_to_string=True,
+    )
+    assert message_delta is not None
+    assert message_delta.response_metadata["model_provider"] == "anthropic"

--- a/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
@@ -1755,6 +1755,50 @@ def test_format_messages_v1_tool_call_round_trip() -> None:
     ]
 
 
+def test_format_messages_v1_tool_call_preserves_caller() -> None:
+    """v1 `tool_call` with programmatic `caller` survives dedup (#1933)."""
+    caller = {"type": "code_execution_20250825"}
+    tool_call_id = "toolu_vrtx_01"
+    ai_message = AIMessage(
+        content=[
+            {
+                "type": "tool_call",
+                "id": tool_call_id,
+                "name": "get_weather",
+                "args": {"location": "Boston"},
+                "extras": {"caller": caller},
+            }
+        ],
+        tool_calls=[
+            {
+                "type": "tool_call",
+                "id": tool_call_id,
+                "name": "get_weather",
+                "args": {"location": "Boston"},
+            }
+        ],
+    )
+    messages = [
+        HumanMessage("What's the weather in Boston?"),
+        ai_message,
+        ToolMessage(
+            content="It's sunny.",
+            tool_call_id=tool_call_id,
+            name="get_weather",
+        ),
+    ]
+
+    _, formatted = _format_messages_anthropic(messages, project="my-project")
+
+    tool_use_blocks = [
+        block
+        for block in formatted[1]["content"]
+        if block.get("type") == "tool_use" and block.get("id") == tool_call_id
+    ]
+    assert len(tool_use_blocks) == 1
+    assert tool_use_blocks[0]["caller"] == caller
+
+
 def test_format_messages_v1_tool_call_validates_as_content_block_param() -> None:
     """Formatted v1 tool_call payload validates as Anthropic ContentBlockParam."""
     ai_message = AIMessage(

--- a/libs/vertexai/tests/unit_tests/test_chat_models.py
+++ b/libs/vertexai/tests/unit_tests/test_chat_models.py
@@ -1833,6 +1833,7 @@ def test_anthropic_format_output() -> None:
     assert len(message.tool_calls) == 1
     assert message.tool_calls[0]["name"] == "calculator"
     assert message.tool_calls[0]["args"] == {"number": 42}
+    assert message.response_metadata["model_provider"] == "anthropic"
     assert message.usage_metadata == {
         "input_tokens": 4,  # 2 + 1 + 1 (original + cache_read + cache_creation)
         "output_tokens": 1,
@@ -1842,6 +1843,49 @@ def test_anthropic_format_output() -> None:
             "cache_read": 1,
         },
     }
+
+
+def test_anthropic_format_output_single_text_sets_model_provider() -> None:
+    """Single-text `_format_output` branch stamps `model_provider` (#1754)."""
+
+    @dataclass
+    class Usage:
+        input_tokens: int
+        output_tokens: int
+        cache_creation_input_tokens: int | None
+        cache_read_input_tokens: int | None
+
+    @dataclass
+    class Message:
+        def model_dump(self):
+            return {
+                "content": [{"type": "text", "text": "Hello"}],
+                "model": "baz",
+                "role": "assistant",
+                "usage": Usage(
+                    input_tokens=2,
+                    output_tokens=1,
+                    cache_creation_input_tokens=None,
+                    cache_read_input_tokens=None,
+                ),
+                "type": "message",
+            }
+
+        usage: Usage
+
+    test_msg = Message(
+        usage=Usage(
+            input_tokens=2,
+            output_tokens=1,
+            cache_creation_input_tokens=None,
+            cache_read_input_tokens=None,
+        )
+    )
+    model = ChatAnthropicVertex(project="test-project", location="test-location")
+    message = model._format_output(test_msg).generations[0].message
+    assert isinstance(message, AIMessage)
+    assert message.content == "Hello"
+    assert message.response_metadata["model_provider"] == "anthropic"
 
 
 def test_anthropic_format_output_with_chain_of_thoughts() -> None:
@@ -1902,6 +1946,7 @@ def test_anthropic_format_output_with_chain_of_thoughts() -> None:
     assert isinstance(message, AIMessage)
     assert len(message.content) == 3
     assert message.content == test_msg.model_dump()["content"]
+    assert message.response_metadata["model_provider"] == "anthropic"
     assert message.usage_metadata == {
         "input_tokens": 4,  # 2 + 1 + 1 (original + cache_read + cache_creation)
         "output_tokens": 1,


### PR DESCRIPTION
## Description

Fixes two related bugs in ChatAnthropicVertex when handling
LangChain v1 content blocks:

1. `model_provider` was never set on response/stream metadata, so
`AIMessage.content_blocks` had no Anthropic translator and native
content degraded to `non_standard` blocks. On the streaming path this
was worse: `non_standard` blocks were replaced rather than concatenated
on chunk merge, so streamed tool-call arguments collapsed to the last
JSON fragment instead of the full payload.
2. `_format_message_anthropic` only converted `reasoning` blocks back to
Anthropic-native shape. Other v1-only types (`tool_call`,
`tool_call_chunk`, `non_standard`, `server_tool_call`,
`server_tool_result`) fell through to the catch-all and were sent to
the API unchanged, which Anthropic rejected with a 400.

Together these made tool calling impossible for any agent using
streaming Claude on Vertex, since replaying a tool result after a streamed
call would trigger both issues simultaneously.

Fix:
- Set `response_metadata["model_provider"] = "anthropic"` on
`_format_output` (all branches) and at the end of
`_make_message_chunk_from_anthropic_event`, as
`langchain_anthropic` does.
- Add `_convert_v1_block_to_anthropic` to convert the affected v1 types
before the type dispatch in `_format_message_anthropic`, so a converted
`tool_call` would be deduped against `message.tool_calls` by the
existing `tool_use` logic, with no need for new dedup code.
- Fix a related bug this exposed: `_clean_content_block` was stripping
  `id` from `tool_call`/`tool_call_chunk` blocks (its allowlist only
  included native `tool_use`/`image`), which defeated the new dedup
  logic — a converted block with `id=""` was never considered a
  duplicate. This manifested as a test failure until the fix landed.

All new dict-building code is non-mutating; content blocks may be shared
with agent state/checkpoints so in-place edits would have been unsafe.

## Relevant issues

Fixes #1754
Fixes #1930

## Type

🐛 Bug Fix
✅ Test

## Changes(optional)

- `_anthropic_utils.py`: new `_convert_v1_block_to_anthropic`; call site
in `_format_message_anthropic`; `model_provider` stamp in
`_make_message_chunk_from_anthropic_event`; `_clean_content_block`
allowlist extended to keep `id` for `tool_call`/`tool_call_chunk`.
- `model_garden.py`: `model_provider` stamp in `_format_output` (all
three branches).

## Testing(optional)

Added unit tests covering: v1 `tool_call` round-trip with no duplicate
block, validation against Anthropic SDK's `ContentBlockParam`,
`tool_call_chunk` partial-JSON fallback, `non_standard` unwrapping with
nested streaming keys stripped, non-mutation of input messages, and
`model_provider` on all four streaming event types. Verified each new/
modified assertion fails on the pre-fix code and passes post-fix.

`make lint` (ruff, ruff format, mypy) and full unit test suite for
`libs/vertexai` pass.

## Note(optional)

Two `server_tool_call`/`server_tool_result` branches were ported
alongside the reported types since they hit the same catch-all gap, but
have no dedicated test - no local repro path exists for
`code_interpreter`/`remote_mcp` blocks without live server-tool
responses. Happy to add coverage if useful.