### PR TITLE
fix(genai): keep source required and nullable in nested tool schemas

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -584,9 +584,10 @@ def _get_properties_from_schema(schema: dict) -> dict[str, Any]:
                     v_properties
                 )
                 if isinstance(v_properties, dict):
-                    properties_item["required"] = [
-                        k for k, v in v_properties.items() if "default" not in v
-                    ]
+                    required = v.get("required")
+                    properties_item["required"] = (
+                        list(required) if isinstance(required, list) else []
+                    )
             elif not v.get("additionalProperties"):
                 # Only provide dummy type for object without properties AND without
                 # additionalProperties
@@ -674,6 +675,8 @@ def _get_nullable_type_from_schema(schema: dict[str, Any]) -> types.Type | None:
 
 
 def _is_nullable_schema(schema: dict[str, Any]) -> bool:
+    if schema.get("nullable") is True:
+        return True
     if "anyOf" in schema:
         schema_types = [
             _get_nullable_type_from_schema(sub_schema) for sub_schema in schema["anyOf"]

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -251,6 +251,49 @@ def test_tool_with_nested_object_anyof_nullable_param() -> None:
     )
 
 
+def _nested_contact_tool() -> dict:
+    return {
+        "name": "create_contact",
+        "description": "Create an administrative contact under a group.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "contact": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "role": {"type": "string"},
+                        "email": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                        "phone": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                    },
+                    "required": ["name", "role"],
+                },
+            },
+            "required": ["contact"],
+        },
+    }
+
+
+def test_nested_object_keeps_source_required() -> None:
+    fn = _format_to_genai_function_declaration(_nested_contact_tool())
+    assert fn.parameters is not None
+    assert fn.parameters.properties is not None
+    contact = fn.parameters.properties["contact"]
+    # The source schema's `required` must be honored, not rebuilt from which
+    # properties lack a `default`.
+    assert list(contact.required or []) == ["name", "role"]
+
+
+def test_nested_object_keeps_nullable_on_leaf() -> None:
+    fn = _format_to_genai_function_declaration(_nested_contact_tool())
+    assert fn.parameters is not None
+    assert fn.parameters.properties is not None
+    contact = fn.parameters.properties["contact"]
+    assert contact.properties is not None
+    assert contact.properties["email"].nullable is True
+    assert contact.properties["phone"].nullable is True
+
+
 def test_tool_with_enum_anyof_nullable_param() -> None:
     """Checks a parameter with an enum, marked as optional.
 


### PR DESCRIPTION
Fixes #1725.

Converting a nested-object tool schema to Gemini's format drops two things.

`required` on a nested object gets rebuilt from "properties without a default", so optional fields like `email`/`phone` come back required. Now it just uses the schema's own `required` array.

And a leaf `anyOf: [T, null]` becomes `nullable: true` on the first pass, but `_is_nullable_schema` didn't recognize that key on the second pass, so the flag got dropped. It does now. (#1470 fixes the same thing from the producing side, no conflict.)

Two unit tests from the issue's `create_contact` schema. Both fail on main, pass with the fix.