### PR TITLE
fix: normalize empty AI content for Vertex

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -3161,7 +3161,11 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 warnings.warn(
                     "HumanMessage with empty content was removed to prevent API error"
                 )
-            elif isinstance(message, AIMessage) and message.content == []:
+            elif (
+                self._use_vertexai  # type: ignore[attr-defined]
+                and isinstance(message, AIMessage)
+                and message.content == []
+            ):
                 filtered_messages.append(message.model_copy(update={"content": ""}))
             else:
                 filtered_messages.append(message)

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -805,6 +805,7 @@ def _parse_chat_history(
         if (
             isinstance(message, AIMessage)
             and message.response_metadata.get("output_version") == "v1"
+            and message.content
         ):
             # Unpack known v1 content to v1beta format for the request
             #
@@ -923,7 +924,10 @@ def _parse_chat_history(
                     args=json.loads(raw_function_call["arguments"]),
                 )
                 parts = [Part(function_call=function_call)]
-            elif message.response_metadata.get("output_version") == "v1":
+            elif (
+                message.response_metadata.get("output_version") == "v1"
+                and message.content
+            ):
                 # Already converted to v1beta format above
                 parts = message.content  # type: ignore[assignment]
             else:
@@ -3150,13 +3154,15 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         return None
 
     def _filter_messages(self, messages: list[BaseMessage]) -> list[BaseMessage]:
-        """Filter out messages with empty content."""
-        filtered_messages = []
+        """Normalize messages with empty content."""
+        filtered_messages: list[BaseMessage] = []
         for message in messages:
             if isinstance(message, HumanMessage) and not message.content:
                 warnings.warn(
                     "HumanMessage with empty content was removed to prevent API error"
                 )
+            elif isinstance(message, AIMessage) and message.content == []:
+                filtered_messages.append(message.model_copy(update={"content": ""}))
             else:
                 filtered_messages.append(message)
         return filtered_messages

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -805,7 +805,6 @@ def _parse_chat_history(
         if (
             isinstance(message, AIMessage)
             and message.response_metadata.get("output_version") == "v1"
-            and message.content
         ):
             # Unpack known v1 content to v1beta format for the request
             #
@@ -924,10 +923,7 @@ def _parse_chat_history(
                     args=json.loads(raw_function_call["arguments"]),
                 )
                 parts = [Part(function_call=function_call)]
-            elif (
-                message.response_metadata.get("output_version") == "v1"
-                and message.content
-            ):
+            elif message.response_metadata.get("output_version") == "v1":
                 # Already converted to v1beta format above
                 parts = message.content  # type: ignore[assignment]
             else:
@@ -3166,7 +3162,11 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 and isinstance(message, AIMessage)
                 and message.content == []
             ):
-                filtered_messages.append(message.model_copy(update={"content": ""}))
+                filtered_messages.append(
+                    message.model_copy(
+                        update={"content": [{"type": "text", "text": ""}]}
+                    )
+                )
             else:
                 filtered_messages.append(message)
         return filtered_messages

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -158,6 +158,30 @@ def test_integration_initialization() -> None:
         assert "Did you mean: 'safety_settings'?" in call_args
 
 
+@pytest.mark.parametrize("response_metadata", [{}, {"output_version": "v1"}])
+def test_empty_ai_message_content_is_normalized(
+    response_metadata: dict[str, str],
+) -> None:
+    """Test empty AI content lists become empty text parts."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+    messages = [
+        HumanMessage(content="Hello"),
+        AIMessage(content=[], response_metadata=response_metadata),
+        HumanMessage(content="What is your name?"),
+    ]
+
+    request = llm._prepare_request(messages)
+
+    empty_ai_content = request["contents"][1]
+    assert empty_ai_content.role == "model"
+    assert empty_ai_content.parts is not None
+    assert len(empty_ai_content.parts) == 1
+    assert empty_ai_content.parts[0].text == ""
+
+
 def test_seed_initialization() -> None:
     """Test chat model initialization with `seed` parameter."""
     # Test with explicit seed

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -159,13 +159,16 @@ def test_integration_initialization() -> None:
 
 
 @pytest.mark.parametrize("response_metadata", [{}, {"output_version": "v1"}])
-def test_empty_ai_message_content_is_normalized(
-    response_metadata: dict[str, str],
+@pytest.mark.parametrize("vertexai", [False, True])
+def test_empty_ai_message_content_is_normalized_for_vertex(
+    response_metadata: dict[str, str], vertexai: bool
 ) -> None:
-    """Test empty AI content lists become empty text parts."""
+    """Test empty AI content lists become empty text parts for Vertex only."""
     llm = ChatGoogleGenerativeAI(
         model=MODEL_NAME,
         google_api_key=SecretStr(FAKE_API_KEY),
+        project="test-project" if vertexai else None,
+        vertexai=vertexai,
     )
     messages = [
         HumanMessage(content="Hello"),
@@ -178,8 +181,11 @@ def test_empty_ai_message_content_is_normalized(
     empty_ai_content = request["contents"][1]
     assert empty_ai_content.role == "model"
     assert empty_ai_content.parts is not None
-    assert len(empty_ai_content.parts) == 1
-    assert empty_ai_content.parts[0].text == ""
+    if vertexai:
+        assert len(empty_ai_content.parts) == 1
+        assert empty_ai_content.parts[0].text == ""
+    else:
+        assert empty_ai_content.parts == []
 
 
 def test_seed_initialization() -> None:


### PR DESCRIPTION
## Description
Vertex rejects `AIMessage(content=[])` because each message must contain a part. Preserve the model turn by converting an empty content list to an empty text part only for the Vertex backend, including v1-formatted history.

## Test Plan
- [x] Verify Vertex normalizes empty AI lists for standard and v1 history
- [x] Verify the Gemini Developer API retains existing behavior

Made by [Open SWE](https://openswe.vercel.app/agents/a78cb37a-9cb4-bc15-6b10-775c34821dc0)

## References
- Plan: https://openswe.vercel.app/agents/a78cb37a-9cb4-bc15-6b10-775c34821dc0/plan