### PR TITLE
fix(genai): read model_kwargs when building the request config

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -3026,6 +3026,12 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Prepare the request configuration for the API call."""
+        # Constructor keywords that aren't declared fields are collected into
+        # `model_kwargs` by `_build_model_kwargs`. Merge them in here so they take the
+        # same path as invoke-time kwargs and reach `GenerateContentConfig`; per-call
+        # values win over the ones fixed at construction.
+        kwargs = {**self.model_kwargs, **kwargs}
+
         # Process tools and functions
         formatted_tools = self._format_tools(tools, functions)
 

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -1564,6 +1564,65 @@ def test_model_kwargs(mock_client: Mock) -> None:
 
 
 @pytest.mark.parametrize(
+    "param,value",
+    [
+        ("response_logprobs", True),
+        ("logprobs", 3),
+        ("audio_timestamp", True),
+    ],
+)
+def test_model_kwargs_reach_request_config(param: str, value: Any) -> None:
+    """`model_kwargs` should configure the request, like the same kwarg at invoke."""
+    msg = HumanMessage(content="test")
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        model_kwargs={param: value},
+    )
+
+    from_constructor = getattr(llm._prepare_request([msg])["config"], param)
+    invoked = llm._prepare_request([msg], **{param: value})
+    from_invoke = getattr(invoked["config"], param)
+
+    assert from_constructor == value
+    assert from_constructor == from_invoke
+
+
+def test_invoke_kwargs_override_model_kwargs() -> None:
+    """A per-call value wins over the one fixed at construction."""
+    msg = HumanMessage(content="test")
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        model_kwargs={"logprobs": 3},
+    )
+
+    assert llm._prepare_request([msg], logprobs=7)["config"].logprobs == 7
+    # The override is per-call, so it must not leak into the next request.
+    assert llm._prepare_request([msg])["config"].logprobs == 3
+    assert llm.model_kwargs == {"logprobs": 3}
+
+
+def test_unknown_model_kwargs_raise_like_invoke_kwargs() -> None:
+    """An unsupported key fails the same way from either entry point."""
+    msg = HumanMessage(content="test")
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+        model_kwargs={"not_a_real_param": 1},
+    )
+    with pytest.raises(ValidationError, match="not_a_real_param"):
+        llm._prepare_request([msg])
+
+    plain = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+    with pytest.raises(ValidationError, match="not_a_real_param"):
+        plain._prepare_request([msg], not_a_real_param=1)
+
+
+@pytest.mark.parametrize(
     "is_async,method_name,client_method",
     [
         (False, "_generate", "models.generate_content"),  # Sync


### PR DESCRIPTION
Closes #1938.

## Why

`ChatGoogleGenerativeAI` declares `model_kwargs` and fills it through `_build_model_kwargs`, but nothing ever read it back. There were three references in `chat_models.py` and none was a read. So a constructor keyword that is not a declared field warned and then vanished, while the same keyword passed at invoke time worked, because unknown invoke kwargs survive in `remaining_kwargs` and get spread into `GenerateContentConfig`.

The two entry points disagreed, and the one that silently did nothing is the one people reach for first. It is also the root cause behind several reports that were each fixed by promoting one more parameter to a real field (#1497 / #1869 `thinking_config`, #1366 `thinking_level`, #1682 `service_tier`). Every fix works, and then the next unlisted parameter fails the same quiet way.

## What changed

One line at the top of `_prepare_request`:

```python
kwargs = {**self.model_kwargs, **kwargs}
```

`model_kwargs` now takes the same path as invoke-time kwargs, so it flows through `_prepare_params`, the `_consumed_kwargs` filter and `remaining_kwargs` into `_build_request_config`. Per-call values win over the ones fixed at construction.

The issue offered two directions and asked which you preferred. This implements the first (spread `model_kwargs` into the config, matching the OpenAI integration). Happy to switch to the second (raise at construction instead of warning) if you would rather go that way.

Worth noting the two converge more than expected: because `GenerateContentConfig` forbids extra inputs, an unsupported key now raises `ValidationError` instead of being dropped. That is the same error the invoke path already raised for the same key, so this is the constructor catching up to existing behavior rather than new behavior being invented. Test `test_unknown_model_kwargs_raise_like_invoke_kwargs` pins both halves.

## Verification

Before, using the repro from the issue:

```
response_logprobs | model_kwargs: {'response_logprobs': True} | ctor: None | invoke: True
logprobs          | model_kwargs: {'logprobs': 3}             | ctor: None | invoke: 3
audio_timestamp   | model_kwargs: {'audio_timestamp': True}   | ctor: None | invoke: True
```

After:

```
response_logprobs | model_kwargs: {'response_logprobs': True} | ctor: True | invoke: True
logprobs          | model_kwargs: {'logprobs': 3}             | ctor: 3    | invoke: 3
audio_timestamp   | model_kwargs: {'audio_timestamp': True}   | ctor: True | invoke: True
```

Mutation check: reverting the source hunk and keeping the tests gives 5 failed, 1 passed. Restoring it gives 6 passed. The one that passes either way is the pre-existing `test_model_kwargs`, which only asserts on construction.

Full run: `387 passed` in `libs/genai` unit tests, `make lint` clean (ruff, format, import order, mypy on 35 source files).

## Risks

The behavior change worth reviewing is the one above: a model constructed today with a key that `GenerateContentConfig` does not accept currently ignores it at request time, and after this it raises. Nothing in the existing suite depended on that, which is why 387 tests pass untouched, but it is a real change for anyone parking arbitrary values in `model_kwargs`. If you want it strictly additive I can filter to keys `GenerateContentConfig` accepts and keep warning on the rest, though that reintroduces the silent drop this issue is about.

Scope is `libs/genai` only, matching the issue's package checkbox. `vertexai` has its own `model_kwargs` handling and is not touched here.

## Pre-merge

Nothing required. No new dependencies, no public signature changes.

## Post-merge

The `service_tier` promotion in #1937 stays useful as a typed field, and does not conflict with this.

---

Part of the work was done using an AI coding assistant, but tests and quality were manually reviewed.
