### PR TITLE
chore(genai): update tests for LangSmith gateway

### DIFF
--- a/libs/genai/tests/integration_tests/test_chat_models.py
+++ b/libs/genai/tests/integration_tests/test_chat_models.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 import requests
+from google.genai.errors import ServerError
 from google.genai.types import (
     FunctionCallingConfig,
     FunctionCallingConfigMode,
@@ -54,6 +55,16 @@ _IMAGE_EDITING_MODEL = "gemini-3-pro-image-preview"
 _AUDIO_OUTPUT_MODEL = "gemini-2.5-flash-preview-tts"
 _THINKING_MODEL = "gemini-3.5-flash"
 _B64_string = """iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAABhGlDQ1BJQ0MgUHJvZmlsZQAAeJx9kT1Iw0AcxV8/xCIVQTuIKGSoTi2IijhqFYpQIdQKrTqYXPoFTRqSFBdHwbXg4Mdi1cHFWVcHV0EQ/ABxdXFSdJES/5cUWsR4cNyPd/ced+8Af6PCVDM4DqiaZaSTCSGbWxW6XxHECPoRQ0hipj4niil4jq97+Ph6F+dZ3uf+HL1K3mSATyCeZbphEW8QT29aOud94ggrSQrxOXHMoAsSP3JddvmNc9FhP8+MGJn0PHGEWCh2sNzBrGSoxFPEUUXVKN+fdVnhvMVZrdRY6578heG8trLMdZrDSGIRSxAhQEYNZVRgIU6rRoqJNO0nPPxDjl8kl0yuMhg5FlCFCsnxg//B727NwuSEmxROAF0vtv0xCnTvAs26bX8f23bzBAg8A1da219tADOfpNfbWvQI6NsGLq7bmrwHXO4Ag0+6ZEiOFKDpLxSA9zP6phwwcAv0rLm9tfZx+gBkqKvUDXBwCIwVKXvd492hzt7+PdPq7wdzbXKn5swsVgAAA8lJREFUeJx90dtPHHUUB/Dz+81vZhb2wrDI3soUKBSRcisF21iqqCRNY01NTE0k8aHpi0k18VJfjOFvUF9M44MmGrHFQqSQiKSmFloL5c4CXW6Fhb0vO3ufvczMzweiBGI9+eW8ffI95/yQqqrwv4UxBgCfJ9w/2NfSVB+Nyn6/r+vdLo7H6FkYY6yoABR2PJujj34MSo/d/nHeVLYbydmIp/bEO0fEy/+NMcbTU4/j4Vs6Lr0ccKeYuUKWS4ABVCVHmRdszbfvTgfjR8kz5Jjs+9RREl9Zy2lbVK9wU3/kWLJLCXnqza1bfVe7b9jLbIeTMcYu13Jg/aMiPrCwVFcgtDiMhnxwJ/zXVDwSdVCVMRV7nqzl2i9e/fKrw8mqSp84e2sFj3Oj8/SrF/MaicmyYhAaXu58NPAbeAeyzY0NLecmh2+ODN3BewYBAkAY43giI3kebrnsRmvV9z2D4ciOa3EBAf31Tp9sMgdxMTFm6j74/Ogb70VCYQKAAIDCXkOAIC6pkYBWdwwnpHEdf6L9dJtJKPh95DZhzFKMEWRAGL927XpWTmMA+s8DAOBYAoR483l/iHZ/8bXoODl8b9UfyH72SXepzbyRJNvjFGHKMlhvMBze+cH9+4lEuOOlU2X1tVkFTU7Om03q080NDGXV1cflRpHwaaoiiiildB8jhDLZ7HDfz2Yidba6Vn2L4fhzFrNRKy5OZ2QOZ1U5W8VtqlVH/iUHcM933zZYWS7Wtj66zZr65bzGJQt0glHgudi9XVzEl4vKw2kUPhO020oPYI1qYc+2Xc0bRXFwTLY0VXa2VibD/lBaIXm1UChN5JSRUcQQ1Tk/47Cf3x8bY7y17Y17PVYTG1UkLPBFcqik7Zoa9JcLYoHBqHhXNgd6gS1k9EJ1TQ2l9EDy1saErmQ2kGpwGC2MLOtCM8nZEV1K0tKJtEksSm26J/rHg2zzmabKisq939nHzqUH7efzd4f/nPGW6NP8ybNFrOsWQhpoCuuhnJ4hAnPhFam01K4oQMjBg/mzBjVhuvw2O++KKT+BIVxJKzQECBDLF2qu2WTMmCovtDQ1f8iyoGkUADBCCGPsdnvTW2OtFm01VeB06msvdWlpPZU0wJRG85ns84umU3k+VyxeEcWqvYUBAGsUrbvme4be99HFeisP/pwUOIZaOqQX31ISgrKmZhLHtXNXuJq68orrr5/9mBCglCLAGGPyy81votEbcjlKLrC9E8mhH3wdHRdcyyvjidSlxjftPJpD+o25JYvRHGFoZDdks1mBQhxJu9uxvwEiXuHnHbLd1AAAAABJRU5ErkJggg=="""  # noqa: E501
+
+
+# Whether requests route through the LangSmith gateway. Mirrors the truthiness
+# used by `langchain_core`'s gateway resolution.
+_GATEWAY_ENABLED = (os.environ.get("LANGSMITH_GATEWAY") or "").lower() not in (
+    "",
+    "false",
+    "0",
+    "no",
+)
 
 
 @tool
@@ -990,6 +1001,11 @@ def test_chat_google_genai_system_message(
 
 def test_generativeai_get_num_tokens_gemini(backend_config: dict) -> None:
     """Test model tokenizer."""
+    if _GATEWAY_ENABLED and not backend_config.get("vertexai"):
+        pytest.skip(
+            "The LangSmith gateway does not proxy Gemini's countTokens action; "
+            "see test_gateway_gemini_counttokens_unsupported."
+        )
     llm = ChatGoogleGenerativeAI(temperature=0, model=_MODEL, **backend_config)
     output = llm.get_num_tokens("How are you?")
     assert output == 4
@@ -997,11 +1013,35 @@ def test_generativeai_get_num_tokens_gemini(backend_config: dict) -> None:
 
 def test_get_num_tokens_from_messages(backend_config: dict) -> None:
     """Test token counting from messages."""
+    if _GATEWAY_ENABLED and not backend_config.get("vertexai"):
+        pytest.skip(
+            "The LangSmith gateway does not proxy Gemini's countTokens action; "
+            "see test_gateway_gemini_counttokens_unsupported."
+        )
     model = ChatGoogleGenerativeAI(temperature=0.0, model=_MODEL, **backend_config)
     message = HumanMessage(content="Hello")
     token = model.get_num_tokens_from_messages(messages=[message])
     assert isinstance(token, int)
     assert token == 3
+
+
+@pytest.mark.skipif(
+    not _GATEWAY_ENABLED,
+    reason="Only meaningful when routing through the LangSmith gateway.",
+)
+def test_gateway_gemini_counttokens_unsupported() -> None:
+    """Canary for the gateway's missing Gemini ``countTokens`` support.
+
+    The gateway currently returns 501 for Gemini's ``countTokens`` action, so
+    the ``get_num_tokens*`` tests above are skipped when gateway-routed on the
+    ``google_ai`` backend. When the gateway adds support, this test will start
+    to fail (no error raised). At that point, delete this test and remove the
+    ``_GATEWAY_ENABLED`` skip guards from the token-count tests in this file and
+    in ``test_llms.py``.
+    """
+    llm = ChatGoogleGenerativeAI(temperature=0, model=_MODEL)
+    with pytest.raises(ServerError, match="countTokens"):
+        llm.get_num_tokens_from_messages([HumanMessage(content="How are you?")])
 
 
 def test_single_call_previous_blocked_response(backend_config: dict) -> None:

--- a/libs/genai/tests/integration_tests/test_llms.py
+++ b/libs/genai/tests/integration_tests/test_llms.py
@@ -3,6 +3,7 @@
 Chat model tests are in `test_chat_models.py` and use `ChatGoogleGenerativeAI`.
 """
 
+import os
 from collections.abc import Generator
 
 import pytest
@@ -11,6 +12,15 @@ from langchain_core.outputs import LLMResult
 from langchain_google_genai import GoogleGenerativeAI, HarmBlockThreshold, HarmCategory
 
 MODEL_NAMES = ["gemini-3.5-flash"]
+
+# Whether requests route through the LangSmith gateway. Mirrors the truthiness
+# used by `langchain_core`'s gateway resolution.
+_GATEWAY_ENABLED = (os.environ.get("LANGSMITH_GATEWAY") or "").lower() not in (
+    "",
+    "false",
+    "0",
+    "no",
+)
 
 
 @pytest.mark.parametrize(
@@ -85,6 +95,11 @@ def test_generativeai_stream(model_name: str, backend_config: dict) -> None:
 def test_generativeai_get_num_tokens_gemini(
     model_name: str, backend_config: dict
 ) -> None:
+    if _GATEWAY_ENABLED and not backend_config.get("vertexai"):
+        pytest.skip(
+            "The LangSmith gateway does not proxy Gemini's countTokens action; "
+            "see test_gateway_gemini_counttokens_unsupported in test_chat_models.py."
+        )
     llm = GoogleGenerativeAI(temperature=0, model=model_name, **backend_config)
     output = llm.get_num_tokens("How are you?")
     assert output == 4


### PR DESCRIPTION
The LangSmith [LLM Gateway](https://docs.langchain.com/langsmith/llm-gateway) does not yet support Gemini's token counting API, so we conditionally skip those tests.