### PR TITLE
fix(genai): preserve all ToolConfig fields when merging tool_choice

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -3228,11 +3228,16 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
 
             # Merge with tool_config if it exists
             if normalized_config:
-                # Merge: take function_calling_config from choice_config
-                # and other fields from normalized_config
-                return ToolConfig(
-                    function_calling_config=choice_config.function_calling_config,
-                    retrieval_config=normalized_config.retrieval_config,
+                # Overlay `function_calling_config` onto the caller's config rather
+                # than rebuilding it from an enumerated field list, so fields this
+                # method doesn't know about (e.g.
+                # `include_server_side_tool_invocations`) survive the merge. The
+                # conflict check above guarantees
+                # `normalized_config.function_calling_config` is None here.
+                return normalized_config.model_copy(
+                    update={
+                        "function_calling_config": choice_config.function_calling_config
+                    }
                 )
             return choice_config
 

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -17,6 +17,7 @@ from google.genai.types import (
     Content,
     FinishReason,
     FunctionCall,
+    FunctionCallingConfigMode,
     FunctionResponse,
     GenerateContentResponse,
     GenerateContentResponseUsageMetadata,
@@ -24,8 +25,11 @@ from google.genai.types import (
     HttpRetryOptions,
     Language,
     Part,
+    RetrievalConfig,
     ThinkingConfig,
     ThinkingLevel,
+    Tool,
+    ToolConfig,
 )
 from google.genai.types import (
     Outcome as CodeExecutionResultOutcome,
@@ -60,6 +64,9 @@ from langchain_google_genai import (
 )
 from langchain_google_genai._compat import (
     _convert_from_v1_to_generativelanguage_v1beta,
+)
+from langchain_google_genai._function_utils import (
+    convert_to_genai_function_declarations,
 )
 from langchain_google_genai.chat_models import (
     ChatGoogleGenerativeAI,
@@ -6343,3 +6350,63 @@ def test_context_overflow_error_backwards_compatibility() -> None:
         assert isinstance(exc_info.value, ClientError)
         assert isinstance(exc_info.value, ContextOverflowError)
         assert isinstance(exc_info.value, GoogleContextOverflowError)
+
+
+def _mixed_builtin_and_function_tools() -> list[Tool]:
+    """A server-side built-in tool bound alongside a client-side function."""
+    return convert_to_genai_function_declarations(
+        [
+            {"google_search": {}},
+            {
+                "type": "function",
+                "function": {
+                    "name": "my_tool",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ]
+    )
+
+
+def test_process_tool_config_merge_preserves_unenumerated_fields() -> None:
+    """`tool_choice` must not discard other fields the caller set on `tool_config`.
+
+    The Gemini Developer API rejects requests that mix built-in tools with function
+    declarations unless `include_server_side_tool_invocations` is set, so dropping it
+    while merging turns a request the caller had already made valid into a 400.
+    """
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+
+    result = llm._process_tool_config(
+        "any",
+        {"include_server_side_tool_invocations": True},
+        _mixed_builtin_and_function_tools(),
+    )
+
+    assert result is not None
+    assert result.include_server_side_tool_invocations is True
+    assert result.function_calling_config is not None
+    assert result.function_calling_config.mode == FunctionCallingConfigMode.ANY
+    assert result.function_calling_config.allowed_function_names == ["my_tool"]
+
+
+def test_process_tool_config_merge_preserves_retrieval_config() -> None:
+    """Merging `tool_choice` keeps the caller's `retrieval_config`."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+    retrieval_config = RetrievalConfig(language_code="en-US")
+
+    result = llm._process_tool_config(
+        "any",
+        ToolConfig(retrieval_config=retrieval_config),
+        _mixed_builtin_and_function_tools(),
+    )
+
+    assert result is not None
+    assert result.retrieval_config == retrieval_config
+    assert result.function_calling_config is not None


### PR DESCRIPTION
## Why

When a caller passes **both** `tool_choice` and `tool_config`, `_process_tool_config` rebuilds `ToolConfig` from a hard-coded field list instead of copying the object the caller gave it. Every field not named in that list is silently discarded — no warning, no error.

Today that drops exactly one field: `include_server_side_tool_invocations`. The Gemini Developer API **requires** it whenever a request mixes a server-side built-in tool (`google_search`, `code_execution`, `url_context`) with client-side function declarations. Dropping it turns a valid request into:

```
400 INVALID_ARGUMENT
Please enable tool_config.include_server_side_tool_invocations to use
Built-in tools with Function calling.
```

…which is precisely what the caller had already set.

The combination is not contrived. `create_agent` passes `tool_choice="any"` whenever the response format is a `ToolStrategy`, and agent frameworks routinely inject their own function tools alongside a bound built-in. The confusing part in practice: **without** `response_format` the flag survives (`tool_choice` is `None`, so the merge branch is never taken), so the same configuration works or 400s depending on whether structured output is requested.

Worth noting where the drop happens. Just above the merge there is an early return for the built-ins-only case that passes `tool_config` through untouched:

```python
if not all_names:
    if normalized_config:
        return normalized_config
    return None
```

So the field is preserved everywhere it doesn't matter, and dropped only when built-ins are mixed with function declarations — the one case that needs it.

## What

Overlay `function_calling_config` onto the caller's config with `model_copy` rather than reconstructing it:

```python
return normalized_config.model_copy(
    update={"function_calling_config": choice_config.function_calling_config}
)
```

This is safe because the conflict check earlier in the same method already raises when `tool_choice` and `tool_config.function_calling_config` are both set — so `normalized_config.function_calling_config` is guaranteed `None` at the merge point. The merge has exactly one job, and nothing else can conflict.

It also fixes the category rather than the symptom: any field added to `ToolConfig` in a future `google-genai` release would have been dropped the same way. The enumeration arrived with the `google-genai` migration (#1330) and was written against the `ToolConfig` shape as it existed then.

## Tests

`_process_tool_config` had **zero** unit tests before this. Adds two to `tests/unit_tests/test_chat_models.py`:

- `test_process_tool_config_merge_preserves_unenumerated_fields` — the regression: `include_server_side_tool_invocations` survives a `tool_choice` merge.
- `test_process_tool_config_merge_preserves_retrieval_config` — locks in the existing `retrieval_config` merge behavior.

On `main` the first fails and the second passes (so it isn't over-constrained):

```
>       assert result.include_server_side_tool_invocations is True
E       AssertionError: assert None is True
1 failed, 1 passed
```

With the fix, both pass. Full `libs/genai` unit suite green (384 passed); `make lint` and `make format` clean.

## Review notes

The one thing worth a careful look is the claim that the conflict guard makes the overlay safe — if that guard ever moves or gains an escape hatch, `model_copy` would start overwriting a caller-supplied `function_calling_config` instead of raising.

## Follow-up, deliberately not in this PR

`langchain-google-genai` could **auto-enable** `include_server_side_tool_invocations` when it detects a request mixing built-in tools with function declarations — it has the information at request-build time, and today users get a raw Google 400 with no guidance from the integration layer. That is out of scope here because it changes response *content* (server-side tool calls begin appearing in `Content`), and it must be gated to the Developer API path, since `_ToolConfig_to_vertex` raises outright when the field is set. This PR is narrow: stop discarding what the caller explicitly asked for.

Related: #1289 covers built-in tools being lost under structured output via a different mechanism (`with_structured_output(method="function_calling")` replacing bound tools). This PR does **not** close it, but the `bind_tools(tool_config=...)` path it fixes is the one users are steered to as the workaround.

---

🤖 *AI disclosure:* found by an automated code-review pass; fix and tests written and verified with Claude Code (an AI coding agent), reviewed by me before opening.
