### PR TITLE
feat(genai): surface usage_metadata.traffic_type in response_metadata

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1351,10 +1351,11 @@ def _response_to_result(
     # `usage_metadata.traffic_type` is only populated on the Vertex AI backend and
     # reports which quota (e.g. on-demand vs. provisioned throughput) served the
     # request.
-    traffic_type: str | None = None
-    if response.usage_metadata and response.usage_metadata.traffic_type:
-        raw_traffic_type = response.usage_metadata.traffic_type
-        traffic_type = getattr(raw_traffic_type, "name", str(raw_traffic_type))
+    traffic_type = (
+        response.usage_metadata.traffic_type.name
+        if response.usage_metadata and response.usage_metadata.traffic_type
+        else None
+    )
 
     generations: list[ChatGeneration] = []
 
@@ -1374,8 +1375,6 @@ def _response_to_result(
             generation_info["model_name"] = response.model_version or ""
             # Set for final chunk
             model_name_for_metadata = response.model_version
-            if traffic_type:
-                generation_info["traffic_type"] = traffic_type
         generation_info["safety_ratings"] = (
             [safety_rating.model_dump() for safety_rating in candidate.safety_ratings]
             if candidate.safety_ratings
@@ -1398,6 +1397,7 @@ def _response_to_result(
         # Only include traffic_type in the final chunk (when finish_reason exists)
         # to avoid duplication when chunks are concatenated with +=
         if candidate.finish_reason and traffic_type:
+            generation_info["traffic_type"] = traffic_type
             message.response_metadata["traffic_type"] = traffic_type
 
         try:
@@ -2332,6 +2332,8 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             "model_provider": "google_genai",
             "prompt_feedback": {"block_reason": 0, "safety_ratings": []},
             "finish_reason": "STOP",
+            # Only present on the Vertex AI backend
+            "traffic_type": "ON_DEMAND",
             "safety_ratings": [
                 {
                     "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1348,6 +1348,14 @@ def _response_to_result(
     except AttributeError:
         lc_usage = None
 
+    # `usage_metadata.traffic_type` is only populated on the Vertex AI backend and
+    # reports which quota (e.g. on-demand vs. provisioned throughput) served the
+    # request.
+    traffic_type: str | None = None
+    if response.usage_metadata and response.usage_metadata.traffic_type:
+        raw_traffic_type = response.usage_metadata.traffic_type
+        traffic_type = getattr(raw_traffic_type, "name", str(raw_traffic_type))
+
     generations: list[ChatGeneration] = []
 
     for candidate in response.candidates or []:
@@ -1366,6 +1374,8 @@ def _response_to_result(
             generation_info["model_name"] = response.model_version or ""
             # Set for final chunk
             model_name_for_metadata = response.model_version
+            if traffic_type:
+                generation_info["traffic_type"] = traffic_type
         generation_info["safety_ratings"] = (
             [safety_rating.model_dump() for safety_rating in candidate.safety_ratings]
             if candidate.safety_ratings
@@ -1384,6 +1394,11 @@ def _response_to_result(
 
         if not hasattr(message, "response_metadata"):
             message.response_metadata = {}
+
+        # Only include traffic_type in the final chunk (when finish_reason exists)
+        # to avoid duplication when chunks are concatenated with +=
+        if candidate.finish_reason and traffic_type:
+            message.response_metadata["traffic_type"] = traffic_type
 
         try:
             if candidate.grounding_metadata:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -1381,6 +1381,115 @@ def test_streaming_chunk_concatenation_no_model_name_duplication() -> None:
     )
 
 
+def test_response_to_result_includes_traffic_type() -> None:
+    """Test that Vertex `usage_metadata.traffic_type` is surfaced on the message."""
+    raw_candidate = {
+        "content": {"parts": [{"text": "Hello, world!"}]},
+        "finish_reason": "STOP",
+        "safety_ratings": [],
+    }
+    candidate = Candidate.model_validate(raw_candidate)
+    response = GenerateContentResponse(
+        candidates=[candidate],
+        model_version=MODEL_NAME,
+        usage_metadata={
+            "prompt_token_count": 1,
+            "candidates_token_count": 1,
+            "total_token_count": 2,
+            "traffic_type": "ON_DEMAND_PRIORITY",
+        },
+    )
+
+    result = _response_to_result(response, stream=False)
+
+    generation = result.generations[0]
+    assert generation.generation_info is not None
+    assert generation.generation_info["traffic_type"] == "ON_DEMAND_PRIORITY"
+    assert generation.message.response_metadata["traffic_type"] == "ON_DEMAND_PRIORITY"
+
+
+def test_response_to_result_omits_traffic_type_when_absent() -> None:
+    """Test that `traffic_type` is omitted when not reported (Gemini API backend)."""
+    raw_candidate = {
+        "content": {"parts": [{"text": "Hello, world!"}]},
+        "finish_reason": "STOP",
+        "safety_ratings": [],
+    }
+    candidate = Candidate.model_validate(raw_candidate)
+    response = GenerateContentResponse(
+        candidates=[candidate],
+        model_version=MODEL_NAME,
+        usage_metadata={
+            "prompt_token_count": 1,
+            "candidates_token_count": 1,
+            "total_token_count": 2,
+        },
+    )
+
+    result = _response_to_result(response, stream=False)
+
+    generation = result.generations[0]
+    assert generation.generation_info is not None
+    assert "traffic_type" not in generation.generation_info
+    assert "traffic_type" not in generation.message.response_metadata
+
+
+def test_streaming_chunk_concatenation_no_traffic_type_duplication() -> None:
+    """Test that `traffic_type` only appears on the final chunk when streaming.
+
+    String values in `response_metadata` are concatenated when chunks are combined
+    with the += operator, so `traffic_type` must only be set on the last chunk
+    (when `finish_reason` exists).
+    """
+    usage_metadata = {
+        "prompt_token_count": 1,
+        "candidates_token_count": 1,
+        "total_token_count": 2,
+        "traffic_type": "PROVISIONED_THROUGHPUT",
+    }
+
+    chunk1_candidate = Candidate.model_validate(
+        {"content": {"parts": [{"text": "Hello"}]}, "safety_ratings": []}
+    )
+    response1 = GenerateContentResponse(
+        candidates=[chunk1_candidate],
+        model_version=MODEL_NAME,
+        usage_metadata=usage_metadata,
+    )
+
+    chunk2_candidate = Candidate.model_validate(
+        {
+            "content": {"parts": [{"text": " world"}]},
+            "finish_reason": "STOP",
+            "safety_ratings": [],
+        }
+    )
+    response2 = GenerateContentResponse(
+        candidates=[chunk2_candidate],
+        model_version=MODEL_NAME,
+        usage_metadata=usage_metadata,
+    )
+
+    result1 = _response_to_result(response1, stream=True)
+    result2 = _response_to_result(response2, stream=True)
+
+    msg1 = cast("AIMessageChunk", result1.generations[0].message)
+    msg2 = cast("AIMessageChunk", result2.generations[0].message)
+
+    # Intermediate chunk should NOT have traffic_type in response_metadata
+    assert "traffic_type" not in msg1.response_metadata
+
+    # Only the final chunk should have traffic_type
+    assert msg2.response_metadata["traffic_type"] == "PROVISIONED_THROUGHPUT"
+    generation_info2 = result2.generations[0].generation_info
+    assert generation_info2 is not None
+    assert generation_info2["traffic_type"] == "PROVISIONED_THROUGHPUT"
+
+    # Concatenate chunks (simulating user code with +=)
+    full = msg1 + msg2
+    assert full.response_metadata["traffic_type"] == "PROVISIONED_THROUGHPUT"
+
+
 def test_serialize() -> None:
     llm = ChatGoogleGenerativeAI(model=MODEL_NAME, google_api_key="test-key")
     serialized = dumps(llm)


### PR DESCRIPTION
## Description

On the Vertex AI backend, `GenerateContentResponse.usage_metadata` includes `traffic_type` (`ON_DEMAND`, `ON_DEMAND_PRIORITY`, `ON_DEMAND_FLEX`, `PROVISIONED_THROUGHPUT`), reporting which quota served the request. `_response_to_result` reads token counts off that same object but drops this field, so there is no supported way to tell (e.g.) whether Priority Pay-as-you-go was granted for a given request. The raw response isn't kept on the `ChatResult`, so the value is unrecoverable downstream without monkeypatching.

This PR copies `usage_metadata.traffic_type` (as the enum name) onto `message.response_metadata["traffic_type"]` and `generation_info["traffic_type"]`.

**Areas for careful review:** placement is gated on `candidate.finish_reason` so the value only appears on the final chunk when streaming — the same pattern `model_name` uses to avoid string duplication when chunks are concatenated with `+=`. When the backend doesn't report a traffic type (Gemini Developer API), the key is omitted entirely; an explicit `TRAFFIC_TYPE_UNSPECIFIED` is passed through as-is rather than filtered.

## Relevant issues

Fixes #1947

## Type

🆕 New Feature

## Changes(optional)

- `_response_to_result`: extract `traffic_type` from `response.usage_metadata` (via `.name`) and attach it to `generation_info` and `response_metadata` in a single `finish_reason`-gated block (final chunk only).
- Class docstring: `traffic_type` added to the response metadata example (noted as Vertex-only).
- Unit tests: happy path (both locations populated), omission when absent, and streaming (intermediate chunks clean, no duplication after `+=` concatenation).

## Testing(optional)

- `make test`: 385 passed
- `make lint`: ruff format, ruff check, and mypy all clean

## Note(optional)

Disclaimer: this contribution was developed with the assistance of an AI agent (Claude Code), reviewed and directed by the issue author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
