### PR TITLE
fix(genai): preserve format/example fields and support integer enums in schema conversion

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -58,6 +58,8 @@ _ALLOWED_SCHEMA_FIELDS = [
     "minItems",
     "maxItems",
     "title",
+    "example",
+    "examples",
 ]
 _ALLOWED_SCHEMA_FIELDS_SET = set(_ALLOWED_SCHEMA_FIELDS)
 
@@ -118,6 +120,11 @@ def _format_json_schema_to_gapic(schema: dict[str, Any]) -> dict[str, Any]:
             else:
                 msg = f"Invalid type: {value}"
                 raise ValueError(msg)
+        elif key == "examples":
+            # google.genai.types.Schema.example is singular; JSON Schema's plural
+            # "examples" list is collapsed to its first element.
+            if value:
+                converted_schema["example"] = value[0]
         elif key not in _ALLOWED_SCHEMA_FIELDS_SET:
             logger.warning(f"Key '{key}' is not supported in schema, ignoring")
         else:
@@ -176,6 +183,10 @@ def _dict_to_genai_schema(
             )  # type: ignore[assignment]
         if "enum" in formatted_schema:
             schema_dict["enum"] = formatted_schema["enum"]
+        if "format" in formatted_schema:
+            schema_dict["format"] = formatted_schema["format"]
+        if "example" in formatted_schema:
+            schema_dict["example"] = formatted_schema["example"]
         if "nullable" in formatted_schema:
             schema_dict["nullable"] = formatted_schema["nullable"]
         if "anyOf" in formatted_schema:
@@ -514,6 +525,9 @@ def _get_properties_from_schema(schema: dict) -> dict[str, Any]:
         original_description = v.get("description")
         original_enum = v.get("enum")
         original_items = v.get("items")
+        original_example = v.get("example")
+        if original_example is None and v.get("examples"):
+            original_example = v["examples"][0]
 
         if v.get("anyOf") and all(
             anyOf_type.get("type") != "null" for anyOf_type in v.get("anyOf", [])
@@ -560,10 +574,31 @@ def _get_properties_from_schema(schema: dict) -> dict[str, Any]:
         if v.get("enum"):
             properties_item["enum"] = v["enum"]
 
+        if (
+            properties_item.get("type")
+            in (types.Type.INTEGER, types.Type.NUMBER, types.Type.BOOLEAN)
+            and properties_item.get("enum") is not None
+        ):
+            # Gemini's Schema.enum only accepts string values, even when the
+            # underlying type is INTEGER/NUMBER/BOOLEAN. `format: "enum"` is
+            # required for the API to treat these as enum constraints.
+            properties_item["enum"] = [str(enum_value) for enum_value in v["enum"]]
+            properties_item["format"] = "enum"
+        elif v.get("format"):
+            properties_item["format"] = v["format"]
+
         # Prefer description from the filtered schema, fall back to original
         description = v.get("description") or original_description
         if description and isinstance(description, str):
             properties_item["description"] = description
+
+        example = v.get("example")
+        if example is None and v.get("examples"):
+            example = v["examples"][0]
+        if example is None:
+            example = original_example
+        if example is not None:
+            properties_item["example"] = example
 
         if (
             properties_item.get("type") == types.Type.ARRAY
@@ -621,12 +656,17 @@ def _get_items_from_schema(schema: dict | list | str) -> dict[str, Any]:
             items["description"] = schema.get("description") or schema.get("title")
         if "enum" in schema:
             items["enum"] = schema["enum"]
+            if items["type"] in (
+                types.Type.INTEGER,
+                types.Type.NUMBER,
+                types.Type.BOOLEAN,
+            ):
+                items["enum"] = [str(enum_value) for enum_value in items["enum"]]
+                items["format"] = "enum"
         if _is_nullable_schema(schema):
             items["nullable"] = True
         if "required" in schema:
             items["required"] = schema["required"]
-        if "enum" in schema:
-            items["enum"] = schema["enum"]
     elif schema:
         # str
         items["type"] = _get_type_from_schema({"type": schema})

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -1536,6 +1536,74 @@ def test_tool_field_enum_array() -> None:
     assert items_property["enum"] == ["foo", "bar"]
 
 
+def test_tool_field_format_is_preserved() -> None:
+    """`format` (e.g. `date-time`) must reach the final Gemini schema.
+
+    `_dict_to_genai_schema` never copied `format` from the intermediate
+    dict into the final `schema_dict`, so it was silently dropped for every
+    property even though it passed the `_ALLOWED_SCHEMA_FIELDS` allowlist.
+    """
+
+    class ToolInfo(BaseModel):
+        relate_date: str = Field(
+            description="RFC 3339 date-time.", json_schema_extra={"format": "date-time"}
+        )
+
+    genai_tools = convert_to_genai_function_declarations(
+        [convert_to_openai_tool(ToolInfo)]
+    )
+    genai_tool_dict = tool_to_dict(genai_tools[0])
+    properties = genai_tool_dict["function_declarations"][0]["parameters"]["properties"]
+
+    assert properties["relate_date"]["format"] == "date-time"
+
+
+def test_tool_field_example_is_preserved() -> None:
+    """`example`/`examples` should survive schema conversion for Gemini.
+
+    `google.genai.types.Schema` exposes a native `example` field, but the
+    conversion previously dropped both JSON Schema `example` and `examples`
+    keys because they weren't in `_ALLOWED_SCHEMA_FIELDS`.
+    """
+
+    class ToolInfo(BaseModel):
+        relate_date: str = Field(
+            description="RFC 3339 date-time.",
+            json_schema_extra={"example": "2026-08-10T00:00:00.000Z"},
+        )
+
+    genai_tools = convert_to_genai_function_declarations(
+        [convert_to_openai_tool(ToolInfo)]
+    )
+    genai_tool_dict = tool_to_dict(genai_tools[0])
+    properties = genai_tool_dict["function_declarations"][0]["parameters"]["properties"]
+
+    assert properties["relate_date"]["example"] == "2026-08-10T00:00:00.000Z"
+
+
+def test_tool_field_integer_enum() -> None:
+    """Integer-valued enums must use `format: "enum"` with stringified values.
+
+    Gemini's `Schema.enum` field only accepts strings, even when the
+    underlying `type` is INTEGER/NUMBER/BOOLEAN (see the Google-documented
+    example: `{type: INTEGER, format: "enum", enum: ["101", "201", "301"]}`).
+    """
+
+    class ToolInfo(BaseModel):
+        status_id: Literal[100, 110, 120]
+
+    genai_tools = convert_to_genai_function_declarations(
+        [convert_to_openai_tool(ToolInfo)]
+    )
+    genai_tool_dict = tool_to_dict(genai_tools[0])
+    properties = genai_tool_dict["function_declarations"][0]["parameters"]["properties"]
+
+    status_property = properties["status_id"]
+    assert_property_type(status_property, Type.INTEGER, "status_id")
+    assert status_property["format"] == "enum"
+    assert status_property["enum"] == ["100", "110", "120"]
+
+
 def test_tool_with_non_class_args_schema() -> None:
     """Test that tools with non-class `args_schema` are handled gracefully.
 


### PR DESCRIPTION
## Problem

While debugging why a Gemini agent kept sending a bare date (`"2026-08-17"`) instead of the RFC 3339 datetime declared in a tool's OpenAPI schema (`format: "date-time"`, with a matching `example`), I traced the root cause to `langchain_google_genai/_function_utils.py`'s schema conversion path (`_dict_to_genai_schema` / `_get_properties_from_schema`):

1. **`format` is silently dropped for every property.** `_dict_to_genai_schema` builds `schema_dict` from `formatted_schema`, but never copies `formatted_schema["format"]` into it — even though `"format"` is in `_ALLOWED_SCHEMA_FIELDS` and reaches `_format_json_schema_to_gapic` untouched. So a property declared with `format: "date-time"` never actually reaches the Gemini API call.
2. **`example`/`examples` are dropped entirely.** They aren't in `_ALLOWED_SCHEMA_FIELDS` at all, even though `google.genai.types.Schema` has a native `example: Optional[Any]` field:
   ```python
   example: Optional[Any] = Field(
       default=None,
       description="Optional. Example of the object. Will only populated when the object is the root.",
   )
   ```
3. **Integer/number/boolean enums are silently invalid.** `Schema.enum`'s own docstring documents the expected shape for non-string enums:
   ```
   2. We can define apartment number as: {type:INTEGER, format:"enum", enum:["101", "201", "301"]}
   ```
   i.e. `format: "enum"` must be set and enum values must be strings even when `type` is `INTEGER`/`NUMBER`/`BOOLEAN`. The current conversion just copies the raw (integer-typed) enum list and never sets `format`, so e.g. `Literal[100, 110, 120]` produces an enum Gemini doesn't recognize correctly.

Also found and removed a redundant duplicate `if "enum" in schema: items["enum"] = schema["enum"]` in `_get_items_from_schema` — harmless before this change, but it would have clobbered the new stringified array-item enum with the raw values.

## Fix

- `_dict_to_genai_schema`: copy `format` and `example` from `formatted_schema` into `schema_dict`.
- `_ALLOWED_SCHEMA_FIELDS`: add `"example"`/`"examples"`; `_format_json_schema_to_gapic` collapses plural JSON Schema `examples` to the singular `Schema.example`.
- `_get_properties_from_schema` / `_get_items_from_schema`: propagate `format` generally, and for `INTEGER`/`NUMBER`/`BOOLEAN` types with an `enum`, stringify the enum values and set `format: "enum"`, matching Gemini's documented requirement.

## Testing

- Added `test_tool_field_format_is_preserved`, `test_tool_field_example_is_preserved`, `test_tool_field_integer_enum` to `tests/unit_tests/test_function_utils.py`.
- `uv run pytest tests/unit_tests` — 385 passed (was 382 before, +3 new tests).
- `uv run mypy langchain_google_genai/` — no issues.
- `uv run ruff format` / `ruff check` — clean.

No existing tests changed behavior; this only adds previously-dropped fields and fixes previously-invalid enum output.
