### PR TITLE
fix(genai): stop warning about the $defs key in converted schemas

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -95,7 +95,10 @@ _ToolsType = Sequence[_ToolType]
 def _format_json_schema_to_gapic(schema: dict[str, Any]) -> dict[str, Any]:
     converted_schema: dict[str, Any] = {}
     for key, value in schema.items():
-        if key == "definitions":
+        # `definitions` (Pydantic v1) and `$defs` (v2) hold the sub-schemas that
+        # `dereference_refs` has already inlined by this point, so they carry no
+        # further information and are not part of the GAPIC schema.
+        if key in ("definitions", "$defs"):
             continue
         if key == "items":
             if value is not None:

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from collections.abc import Generator
 from typing import Annotated, Any, Literal
 from unittest.mock import MagicMock, patch
@@ -1647,3 +1648,47 @@ def test_tool_with_union_int_float() -> None:
         assert b_property.get("type") is None, (
             "When 'any_of' is present, 'type' field must NOT be set."
         )
+
+
+class _Address(BaseModel):
+    street: str
+    city: str
+
+
+class _PersonWithAddress(BaseModel):
+    """Nested BaseModel field, so Pydantic v2 emits a `$defs` block."""
+
+    name: str
+    address: _Address
+
+
+def test_nested_model_does_not_warn_about_defs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`$defs` is redundant once `$ref`s are inlined, so it must not warn.
+
+    `_format_json_schema_to_gapic` already skips Pydantic v1's `definitions`;
+    it must skip v2's `$defs` the same way. See #1880.
+    """
+    with caplog.at_level(
+        logging.WARNING, logger="langchain_google_genai._function_utils"
+    ):
+        _convert_pydantic_to_genai_function(_PersonWithAddress)
+
+    assert "$defs" not in caplog.text, (
+        f"Expected no warning mentioning `$defs`, got: {caplog.text!r}"
+    )
+
+
+def test_nested_model_keeps_inlined_properties() -> None:
+    """Skipping `$defs` must not cost us the dereferenced sub-schema.
+
+    Guards against 'fixing' the warning by removing `$defs` before
+    `dereference_refs` runs, which would leave `#/$defs/...` unresolvable.
+    """
+    declaration = _convert_pydantic_to_genai_function(_PersonWithAddress)
+
+    assert declaration.parameters is not None
+    address = declaration.parameters.properties["address"]
+    assert address.properties is not None, "Nested model lost its inlined properties."
+    assert sorted(address.properties) == ["city", "street"]

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -1689,6 +1689,8 @@ def test_nested_model_keeps_inlined_properties() -> None:
     declaration = _convert_pydantic_to_genai_function(_PersonWithAddress)
 
     assert declaration.parameters is not None
-    address = declaration.parameters.properties["address"]
+    properties = declaration.parameters.properties
+    assert properties is not None
+    address = properties["address"]
     assert address.properties is not None, "Nested model lost its inlined properties."
     assert sorted(address.properties) == ["city", "street"]


### PR DESCRIPTION
Fixes #1880.

## Why

`_format_json_schema_to_gapic` already skips Pydantic v1's `definitions` key, but has no branch for v2's `$defs`. `dereference_refs` inlines every `$ref` before the conversion loop runs and leaves the now-redundant `$defs` block in the dict, so `$defs` falls through to the unsupported-key branch and logs:

```
WARNING:langchain_google_genai._function_utils:Key '$defs' is not supported in schema, ignoring
```

That fires on every `with_structured_output(..., method="function_calling")` call — and by extension every `create_agent(..., response_format=...)` — whenever the model has a nested `BaseModel`, an `Enum`, or a `list[SomeModel]` field. Nothing is lost (the `$ref`s are already resolved), but the message reads like a real problem; see #659 for users hitting it and not being able to tell.

## Worth a careful look

The fix is deliberately applied at one site only. `_convert_pydantic_to_genai_function` has a similar `schema.pop("definitions", None)`, but `$defs` must **not** be removed there: that runs before `dereference_refs`, and dropping it early makes the refs unresolvable —

```
KeyError: "Reference '#/$defs/Inner' not found."
```

So `$defs` is skipped after dereferencing, never before. `test_nested_model_keeps_inlined_properties` exists to catch anyone (including future me) who tries to "tidy up" that second site.

## Verification

- Repro first: nested `BaseModel`, `list[Model]`, and `Enum` each logged one `$defs` warning; a flat model logged none.
- The new warning test fails without the change (at `_function_utils.py:122`) and passes with it.
- Full `libs/genai` unit suite: 371 passed, with failure/error counts identical to `main` on the same machine (the remaining errors are `pytest_socket` on Windows, pre-existing).
- `mypy` reports the same error count with and without the change; `ruff check` and `ruff format` clean.
- Nested sub-schemas still resolve after the fix (`inner` → `['a', 'n']`), confirming the skipped block was pure duplication.

The investigation and patch here were AI-assisted; I reviewed and verified all of it locally.
