### PR TITLE
fix(genai): populate token_usage in llm_output

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1295,7 +1295,7 @@ def _response_to_result(
     prev_usage: UsageMetadata | None = None,
 ) -> ChatResult:
     """Converts a Google AI response into a LangChain `ChatResult`."""
-    llm_output = (
+    llm_output: dict[str, Any] = (
         {"prompt_feedback": response.prompt_feedback.model_dump()}
         if response.prompt_feedback
         else {}
@@ -1347,6 +1347,19 @@ def _response_to_result(
             lc_usage = None
     except AttributeError:
         lc_usage = None
+
+    # `llm_output` is what `BaseCallbackHandler.on_llm_end` reads for token
+    # accounting. Without these keys, callback-based token trackers report zero
+    # even though the counts are available on `AIMessage.usage_metadata`.
+    if lc_usage is not None:
+        llm_output["token_usage"] = {
+            "prompt_tokens": lc_usage["input_tokens"],
+            "completion_tokens": lc_usage["output_tokens"],
+            "total_tokens": lc_usage["total_tokens"],
+        }
+        llm_output["usage_metadata"] = lc_usage
+    if response.model_version:
+        llm_output["model_name"] = response.model_version
 
     generations: list[ChatGeneration] = []
 
@@ -3353,6 +3366,36 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             **request_params,
             **kwargs,
         )
+
+    def _combine_llm_outputs(
+        self, llm_outputs: list[dict[str, Any] | None], /
+    ) -> dict[str, Any]:
+        """Merge per-generation `llm_output` payloads for the final `LLMResult`.
+
+        `BaseChatModel` returns an empty dict by default, which would discard the
+        token counts populated in `_response_to_result` whenever a caller reads
+        `LLMResult.llm_output`. Summing the counts keeps a batched result
+        consistent with the per-generation values.
+
+        Args:
+            llm_outputs: Per-generation `llm_output` dicts, which may be `None`.
+
+        Returns:
+            The summed `token_usage` and the model name, when available.
+        """
+        combined: dict[str, Any] = {}
+        token_usage: dict[str, int] = {}
+        for llm_output in llm_outputs:
+            if not llm_output:
+                continue
+            for key, value in (llm_output.get("token_usage") or {}).items():
+                if value is not None:
+                    token_usage[key] = token_usage.get(key, 0) + value
+            if "model_name" in llm_output:
+                combined.setdefault("model_name", llm_output["model_name"])
+        if token_usage:
+            combined["token_usage"] = token_usage
+        return combined
 
     def _generate(
         self,

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -6336,3 +6336,108 @@ def test_context_overflow_error_backwards_compatibility() -> None:
         assert isinstance(exc_info.value, ClientError)
         assert isinstance(exc_info.value, ContextOverflowError)
         assert isinstance(exc_info.value, GoogleContextOverflowError)
+
+
+def test_response_to_result_populates_llm_output_token_usage() -> None:
+    """`llm_output` carries token usage so `on_llm_end` can track tokens."""
+    raw_response = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello there"}], "role": "model"},
+                "finish_reason": "STOP",
+            }
+        ],
+        "model_version": MODEL_NAME,
+        "usage_metadata": {
+            "prompt_token_count": 10,
+            "candidates_token_count": 20,
+            "total_token_count": 30,
+        },
+    }
+
+    result = _response_to_result(
+        GenerateContentResponse.model_validate(raw_response), stream=False
+    )
+
+    assert result.llm_output is not None
+    assert result.llm_output["token_usage"] == {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+    }
+    assert result.llm_output["model_name"] == MODEL_NAME
+
+    # The callback-facing counts must agree with the message-level ones.
+    usage_metadata = result.generations[0].message.usage_metadata
+    assert usage_metadata is not None
+    assert result.llm_output["usage_metadata"] == usage_metadata
+    assert (
+        result.llm_output["token_usage"]["total_tokens"]
+        == usage_metadata["total_tokens"]
+    )
+
+
+def test_response_to_result_llm_output_without_usage_metadata() -> None:
+    """A response with no usage metadata must not gain a `token_usage` key."""
+    raw_response = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello there"}], "role": "model"},
+                "finish_reason": "STOP",
+            }
+        ],
+    }
+
+    result = _response_to_result(
+        GenerateContentResponse.model_validate(raw_response), stream=False
+    )
+
+    assert result.llm_output is not None
+    assert "token_usage" not in result.llm_output
+
+
+def test_combine_llm_outputs_sums_token_usage() -> None:
+    """Batched generations sum their token usage instead of discarding it."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME, google_api_key=SecretStr(FAKE_API_KEY)
+    )
+
+    combined = llm._combine_llm_outputs(
+        [
+            {
+                "token_usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 20,
+                    "total_tokens": 30,
+                },
+                "model_name": MODEL_NAME,
+            },
+            {
+                "token_usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 2,
+                    "total_tokens": 3,
+                },
+                "model_name": MODEL_NAME,
+            },
+            None,
+        ]
+    )
+
+    assert combined == {
+        "model_name": MODEL_NAME,
+        "token_usage": {
+            "prompt_tokens": 11,
+            "completion_tokens": 22,
+            "total_tokens": 33,
+        },
+    }
+
+
+def test_combine_llm_outputs_without_token_usage() -> None:
+    """Outputs carrying no token usage produce no `token_usage` key."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME, google_api_key=SecretStr(FAKE_API_KEY)
+    )
+
+    assert llm._combine_llm_outputs([None, {}]) == {}


### PR DESCRIPTION
## Why

Token counts are attached to `AIMessage.usage_metadata` but never reach `LLMResult.llm_output`. Callback-based token tracking reads `llm_output` in `BaseCallbackHandler.on_llm_end`, so any such handler observes zero tokens for `ChatGoogleGenerativeAI`.

Reproduced on 4.3.4 with `gemini-2.5-flash`:

```
on_llm_end -> llm_output:             {}
on_llm_end -> message.usage_metadata: {'input_tokens': 8, 'output_tokens': 592, 'total_tokens': 600}
```

## What changed

Two sites are involved, and fixing only the first is not sufficient:

1. `_response_to_result` mirrors the counts it already computes for `AIMessage.usage_metadata` into `llm_output`, using the `token_usage` key convention shared with other LangChain chat integrations, alongside `usage_metadata` and `model_name`.

2. `BaseChatModel._combine_llm_outputs` returns `{}` by default, and `generate()` builds the returned `LLMResult` through it. Without an override the counts are still discarded for callers reading `LLMResult.llm_output` directly, so `ChatGoogleGenerativeAI` now overrides it to sum usage across generations.

After:

```
on_llm_end -> llm_output: {'token_usage': {'prompt_tokens': 8, 'completion_tokens': 642, 'total_tokens': 650}, ...}
generate()  -> llm_output: {'model_name': 'gemini-2.5-flash', 'token_usage': {...}}
```

## Areas needing careful review

- **Streaming semantics.** `_response_to_result` is shared with the streaming path, where `lc_usage` is a per-chunk delta via `subtract_usage`. The new `llm_output` therefore carries the same delta as `message.usage_metadata` on each chunk, keeping the two consistent. Streaming aggregation itself is deliberately unchanged.
- **Summing in `_combine_llm_outputs`** assumes one entry per prompt in a batch, matching `langchain-openai`.
- `llm_output` needed an explicit `dict[str, Any]` annotation; it was previously inferred as `dict[str, dict[str, Any]]` from its initializer.

## Tests

Four unit tests added in `tests/unit_tests/test_chat_models.py`, covering both sites plus the no-usage-metadata path. Full `tests/unit_tests` suite (377) passes; `ruff check`, `ruff format --check`, and `mypy` are clean.

Fixes #957.
