### PR TITLE
fix(genai): preserve anyOf in array items schema conversion

### DIFF
--- a/libs/genai/langchain_google_genai/_function_utils.py
+++ b/libs/genai/langchain_google_genai/_function_utils.py
@@ -612,6 +612,18 @@ def _get_items_from_schema(schema: dict | list | str) -> dict[str, Any]:
         for i, v in enumerate(schema):
             items[f"item{i}"] = _get_properties_from_schema_any(v)
     elif isinstance(schema, dict):
+        if schema.get("anyOf") and all(
+            any_of_type.get("type") != "null" for any_of_type in schema.get("anyOf", [])
+        ):
+            # Mirror the anyOf handling in _get_properties_from_schema: convert
+            # each variant and don't set type, as they're mutually exclusive.
+            items["anyOf"] = [
+                _format_json_schema_to_gapic(any_of_type)
+                for any_of_type in schema["anyOf"]
+            ]
+            if "title" in schema or "description" in schema:
+                items["description"] = schema.get("description") or schema.get("title")
+            return items
         items["type"] = _get_type_from_schema(schema)
         if items["type"] == types.Type.OBJECT and "properties" in schema:
             items["properties"] = _get_properties_from_schema_any(schema["properties"])

--- a/libs/genai/tests/unit_tests/test_function_utils.py
+++ b/libs/genai/tests/unit_tests/test_function_utils.py
@@ -194,6 +194,87 @@ def test_tool_with_array_anyof_nullable_param() -> None:
     assert_property_type(items, Type.STRING, "array items")
 
 
+def test_tool_with_array_items_anyof_variants() -> None:
+    """Checks that ``anyOf`` inside array ``items`` is preserved.
+
+    Regression test: variants used to be silently dropped when the array was
+    nested under ``properties``, leaving an items schema with no fields.
+    """
+    oai_tool = {
+        "type": "function",
+        "function": {
+            "name": "submit_ops",
+            "description": "Submit a list of operations.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "ops": {
+                        "type": "array",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "op": {"type": "string", "enum": ["add"]},
+                                        "item": {"type": "string"},
+                                    },
+                                    "required": ["op", "item"],
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "op": {"type": "string", "enum": ["remove"]}
+                                    },
+                                    "required": ["op"],
+                                },
+                            ]
+                        },
+                    }
+                },
+                "required": ["ops"],
+            },
+        },
+    }
+
+    genai_tools = convert_to_genai_function_declarations([oai_tool])
+    genai_tool_dict = tool_to_dict(genai_tools[0])
+    assert isinstance(genai_tool_dict, dict), "Expected a dict."
+
+    function_declarations = genai_tool_dict.get("function_declarations")
+    assert isinstance(function_declarations, list), "Expected a list."
+
+    fn_decl = function_declarations[0]
+    assert isinstance(fn_decl, dict), "Expected a dict."
+
+    parameters = fn_decl.get("parameters")
+    assert isinstance(parameters, dict), "Expected a dict."
+
+    properties = parameters.get("properties")
+    assert isinstance(properties, dict), "Expected a dict."
+
+    ops_property = properties.get("ops")
+    assert isinstance(ops_property, dict), "Expected a dict."
+    assert_property_type(ops_property, Type.ARRAY, "ops")
+
+    items = ops_property.get("items")
+    assert isinstance(items, dict), "Expected 'items' to be a dict."
+
+    variants = items.get("any_of")
+    assert isinstance(variants, list), "Expected 'any_of' variants to be preserved."
+    assert len(variants) == 2, "Expected both variants to survive conversion."
+
+    first_properties = variants[0].get("properties")
+    assert isinstance(first_properties, dict), "Expected variant properties."
+    assert set(first_properties) == {"op", "item"}
+    assert first_properties["op"].get("enum") == ["add"]
+    assert variants[0].get("required") == ["op", "item"]
+
+    second_properties = variants[1].get("properties")
+    assert isinstance(second_properties, dict), "Expected variant properties."
+    assert set(second_properties) == {"op"}
+    assert second_properties["op"].get("enum") == ["remove"]
+
+
 def test_tool_with_nested_object_anyof_nullable_param() -> None:
     """Checks an object parameter (`dict`) marked as optional.
 


### PR DESCRIPTION
## Description

`_get_items_from_schema` handles `type` / `properties` / `items` / `enum` / `required` for array item schemas, but not `anyOf` — so a discriminated-union array (e.g. an "operations" list where each item is one of several object variants) nested under `properties` loses all its variants during conversion. The model receives an items schema with no fields and returns empty objects.

Property-level `anyOf` is already handled in `_get_properties_from_schema`, and top-level array items survive via `_format_json_schema_to_gapic`; this fills the remaining gap by mirroring the same branch: convert each variant with `_format_json_schema_to_gapic` and skip `type` (mutually exclusive with `any_of` on the Gemini side). Nullable unions (`[X, null]`) keep going through the existing type + `nullable` path, unchanged.

## Relevant issues

Fixes #1965 (related converter-family issue: #1725)

## Type

🐛 bug fix

## Testing

- New regression test `test_tool_with_array_items_anyof_variants`: OpenAI-style tool dict with two object variants in array items → asserts both variants survive with their `properties` / `enum` / `required` intact
- `make format`, `make lint` (ruff + mypy), and full `tests/unit_tests` (394 passed) from `libs/genai`

## Note

The `google-genai` SDK side needs no change — `types.Schema` supports recursive `any_of` (including inside `items`); the variants were only being lost in this converter.
