### PR TITLE
fix(genai): preserve text and reasoning content for AIMessages with tool calls in `_parse_chat_history`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
 .envrc
 .venv
 .venvs
@@ -121,6 +122,12 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Local credentials and certificates
+*.pem
+*.key
+*.crt
+credentials.json
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ celerybeat.pid
 .env
 .env.*
 !.env.example
+!.env.*.example
 .envrc
 .venv
 .venvs

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ celerybeat.pid
 # Environments
 .env
 .env.*
+!.env.example
 .envrc
 .venv
 .venvs

--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -178,9 +178,7 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                 new_block = {
                     "inline_data": {
                         "mime_type": block_dict.get("mime_type", "image/jpeg"),
-                        "data": base64.encode("utf-8")
-                        if isinstance(base64, str)
-                        else base64,
+                        "data": base64,
                     }
                 }
                 new_content.append(new_block)
@@ -204,9 +202,7 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                         "mime_type": block_dict.get(
                             "mime_type", "application/octet-stream"
                         ),
-                        "data": base64.encode("utf-8")
-                        if isinstance(base64, str)
-                        else base64,
+                        "data": base64,
                     }
                 }
                 new_content.append(new_block)

--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -8,26 +8,13 @@ from langchain_core.messages import content as types
 
 logger = logging.getLogger(__name__)
 
-#: Providers whose content blocks and thought signatures Gemini can consume
-#: directly. Vertex AI serves the same Gemini models, so its signatures are valid
-#: here and must not be stripped.
-#:
-#: Defined here because both v1 projection and chat-history replay use the same
-#: provider classification rules.
+# Vertex and the Gemini Developer API share content and signature formats.
 _NATIVE_MODEL_PROVIDERS = frozenset({"google_genai", "google_vertexai"})
 _ModelProviderKind = Literal["native", "foreign", "unknown"]
 
 
 def _classify_model_provider(model_provider: str | None) -> _ModelProviderKind:
-    """Classify a model provider for content-block replay.
-
-    Args:
-        model_provider: Provider recorded on the source message, if known.
-
-    Returns:
-        Whether the message is native to Gemini, known to be foreign, or lacks
-        provider metadata.
-    """
+    """Classify a source provider for Gemini content replay."""
     if model_provider is None:
         return "unknown"
     if model_provider in _NATIVE_MODEL_PROVIDERS:
@@ -36,15 +23,10 @@ def _classify_model_provider(model_provider: str | None) -> _ModelProviderKind:
 
 
 def _is_file_uri_supported(file_uri: Any, *, use_vertexai: bool) -> bool:
-    """Whether a file URI can be replayed through the target Google backend.
+    """Check whether the target Google backend accepts a file URI.
 
-    Args:
-        file_uri: File reference carried by a content block.
-        use_vertexai: Whether the target is the Vertex AI backend.
-
-    Returns:
-        `False` for a Google Cloud Storage URI sent to the Gemini Developer API;
-            otherwise `True`.
+    Google Cloud Storage references are supported by Vertex AI but not by the
+    Gemini Developer API.
     """
     return not (
         isinstance(file_uri, str) and file_uri.startswith("gs://") and not use_vertexai
@@ -57,17 +39,7 @@ def _file_data_block(
     *,
     use_vertexai: bool,
 ) -> dict[str, Any] | None:
-    """Build file data only when the target backend accepts its URI.
-
-    Args:
-        file_uri: File reference carried by a content block.
-        mime_type: MIME type carried by a content block.
-        use_vertexai: Whether the target is the Vertex AI backend.
-
-    Returns:
-        A Gemini file-data block, or `None` when the URI is target-specific and
-            unsupported.
-    """
+    """Build file data when the target backend accepts its URI."""
     if not _is_file_uri_supported(file_uri, use_vertexai=use_vertexai):
         logger.warning(
             "Dropping Google Cloud Storage file URI because the target Gemini "
@@ -276,11 +248,7 @@ def _convert_from_v1_to_generativelanguage_v1beta(
 
         # ImageContentBlock
         elif block_dict["type"] == "image":
-            # `Blob.data` accepts a base64 `str` and decodes it (the field sets
-            # `val_json_bytes="base64"`), so pass it through untouched. Named
-            # `b64_data` rather than `base64`: the latter shadows the stdlib
-            # module name and previously caused this payload to be corrupted by
-            # a stray `base64.encode("utf-8")` call.
+            # SDK validation decodes base64 strings; do not pre-encode them.
             if b64_data := block_dict.get("base64"):
                 new_block = {
                     "inline_data": {
@@ -303,11 +271,6 @@ def _convert_from_v1_to_generativelanguage_v1beta(
 
         # FileContentBlock (documents)
         elif block_dict["type"] == "file":
-            # `Blob.data` accepts a base64 `str` and decodes it (the field sets
-            # `val_json_bytes="base64"`), so pass it through untouched. Named
-            # `b64_data` rather than `base64`: the latter shadows the stdlib
-            # module name and previously caused this payload to be corrupted by
-            # a stray `base64.encode("utf-8")` call.
             if b64_data := block_dict.get("base64"):
                 new_block = {
                     "inline_data": {

--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -206,7 +206,10 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                     }
                 }
                 new_content.append(new_block)
-            elif file_id := block_dict.get("file_id"):
+            elif (file_id := block_dict.get("file_id")) and model_provider in (
+                "google_genai",
+                "google_vertexai",
+            ):
                 # File ID from uploaded file
                 new_block = {
                     "file_data": {

--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -186,9 +186,11 @@ def _convert_from_v1_to_generativelanguage_v1beta(
         # TextContentBlock
         if block_dict["type"] == "text":
             new_block = {"text": block_dict.get("text", "")}
-            if (
-                thought_signature := (block_dict.get("extras") or {}).get("signature")  # type: ignore[attr-defined]
-            ) and provider_kind != "foreign":
+            extras = block_dict.get("extras")
+            thought_signature = block_dict.get("thought_signature") or (
+                extras.get("signature") if isinstance(extras, dict) else None
+            )
+            if thought_signature and provider_kind != "foreign":
                 new_block["thought_signature"] = thought_signature
             new_content.append(new_block)
             # Citations are only handled on output. Can't pass them back :/
@@ -196,7 +198,9 @@ def _convert_from_v1_to_generativelanguage_v1beta(
         # ReasoningContentBlock -> thinking
         elif block_dict["type"] == "reasoning":
             extras = block_dict.get("extras")
-            signature = extras.get("signature") if isinstance(extras, dict) else None
+            signature = block_dict.get("thought_signature") or (
+                extras.get("signature") if isinstance(extras, dict) else None
+            )
             if provider_kind == "native" and not signature:
                 logger.warning(
                     "Dropping v1 reasoning block with no thought signature; "

--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -1,9 +1,20 @@
 """Go from v1 content blocks to generativelanguage_v1beta format."""
 
 import json
+import logging
 from typing import Any, cast
 
 from langchain_core.messages import content as types
+
+logger = logging.getLogger(__name__)
+
+#: Providers whose content blocks and thought signatures Gemini can consume
+#: directly. Vertex AI serves the same Gemini models, so its signatures are valid
+#: here and must not be stripped.
+#:
+#: Defined here rather than in `chat_models` because `chat_models` imports this
+#: module; `chat_models` re-exports it for use on the non-v1 path.
+_NATIVE_MODEL_PROVIDERS = frozenset({"google_genai", "google_vertexai"})
 
 
 def translate_citations_to_grounding_metadata(
@@ -136,10 +147,21 @@ def _convert_from_v1_to_generativelanguage_v1beta(
     Returns:
         List of dictionaries in `generativelanguage_v1beta` `Content` format, ready to
             be sent to the API.
+
+    Note:
+        Every shape emitted here must have a matching branch in
+        `chat_models._convert_to_parts`, which converts these dicts to `Part`
+        objects. The tool-call history path converts native content strictly, so
+        adding an emitted shape without a converter branch turns it into a hard
+        `ValueError` rather than a dropped block.
     """
     new_content: list = []
     for block in content:
         if not isinstance(block, dict) or "type" not in block:
+            logger.warning(
+                "Dropping v1 content block that is not a typed mapping (got: %s).",
+                type(block) if not isinstance(block, dict) else "dict without 'type'",
+            )
             continue
 
         block_dict = dict(block)  # (For typing)
@@ -149,40 +171,53 @@ def _convert_from_v1_to_generativelanguage_v1beta(
             new_block = {"text": block_dict.get("text", "")}
             if (
                 thought_signature := (block_dict.get("extras") or {}).get("signature")  # type: ignore[attr-defined]
-            ) and model_provider == "google_genai":
+            ) and model_provider in _NATIVE_MODEL_PROVIDERS:
                 new_block["thought_signature"] = thought_signature
             new_content.append(new_block)
             # Citations are only handled on output. Can't pass them back :/
 
         # ReasoningContentBlock -> thinking
-        elif block_dict["type"] == "reasoning" and model_provider == "google_genai":
+        elif (
+            block_dict["type"] == "reasoning"
+            and model_provider in _NATIVE_MODEL_PROVIDERS
+        ):
             # Google requires passing back the thought_signature when available.
             # Signatures are only provided when function calling is enabled.
-            if "extras" in block_dict and isinstance(block_dict["extras"], dict):
-                extras = block_dict["extras"]
-                if "signature" in extras:
-                    new_block = {
-                        "thought": True,
-                        "text": block_dict.get("reasoning", ""),
-                        "thought_signature": extras["signature"],
-                    }
-                    new_content.append(new_block)
-                # else: skip reasoning blocks without signatures
-                # TODO: log a warning?
-            # else: skip reasoning blocks without extras
-            # TODO: log a warning?
+            extras = block_dict.get("extras")
+            signature = extras.get("signature") if isinstance(extras, dict) else None
+            if signature:
+                new_block = {
+                    "thought": True,
+                    "text": block_dict.get("reasoning", ""),
+                    "thought_signature": signature,
+                }
+                new_content.append(new_block)
+            else:
+                # An unsigned reasoning block cannot be echoed back: Gemini
+                # rejects a thought part with no signature. The text goes with it.
+                logger.warning(
+                    "Dropping v1 reasoning block with no thought signature; "
+                    "its text will not be sent back to the model."
+                )
 
         # ImageContentBlock
         elif block_dict["type"] == "image":
-            if base64 := block_dict.get("base64"):
+            # `Blob.data` accepts a base64 `str` and decodes it (the field sets
+            # `val_json_bytes="base64"`), so pass it through untouched. Named
+            # `b64_data` rather than `base64`: the latter shadows the stdlib
+            # module name and previously caused this payload to be corrupted by
+            # a stray `base64.encode("utf-8")` call.
+            if b64_data := block_dict.get("base64"):
                 new_block = {
                     "inline_data": {
                         "mime_type": block_dict.get("mime_type", "image/jpeg"),
-                        "data": base64,
+                        "data": b64_data,
                     }
                 }
                 new_content.append(new_block)
-            elif (url := block_dict.get("url")) and model_provider == "google_genai":
+            elif (
+                url := block_dict.get("url")
+            ) and model_provider in _NATIVE_MODEL_PROVIDERS:
                 # Google file service
                 new_block = {
                     "file_data": {
@@ -196,20 +231,24 @@ def _convert_from_v1_to_generativelanguage_v1beta(
 
         # FileContentBlock (documents)
         elif block_dict["type"] == "file":
-            if base64 := block_dict.get("base64"):
+            # `Blob.data` accepts a base64 `str` and decodes it (the field sets
+            # `val_json_bytes="base64"`), so pass it through untouched. Named
+            # `b64_data` rather than `base64`: the latter shadows the stdlib
+            # module name and previously caused this payload to be corrupted by
+            # a stray `base64.encode("utf-8")` call.
+            if b64_data := block_dict.get("base64"):
                 new_block = {
                     "inline_data": {
                         "mime_type": block_dict.get(
                             "mime_type", "application/octet-stream"
                         ),
-                        "data": base64,
+                        "data": b64_data,
                     }
                 }
                 new_content.append(new_block)
-            elif (file_id := block_dict.get("file_id")) and model_provider in (
-                "google_genai",
-                "google_vertexai",
-            ):
+            elif (
+                file_id := block_dict.get("file_id")
+            ) and model_provider in _NATIVE_MODEL_PROVIDERS:
                 # File ID from uploaded file
                 new_block = {
                     "file_data": {
@@ -220,7 +259,9 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                     }
                 }
                 new_content.append(new_block)
-            elif (url := block_dict.get("url")) and model_provider == "google_genai":
+            elif (
+                url := block_dict.get("url")
+            ) and model_provider in _NATIVE_MODEL_PROVIDERS:
                 # Google file service
                 new_block = {
                     "file_data": {
@@ -305,6 +346,21 @@ def _convert_from_v1_to_generativelanguage_v1beta(
         elif block_dict["type"] == "non_standard":
             # Opaque provider payloads cannot be represented by Gemini. Unwrapping
             # them would send an unknown block type into the Gemini part converter.
-            continue
+            # `chat_models._convert_to_parts` logs the same drop on the v0 path.
+            value = block_dict.get("value")
+            logger.warning(
+                "Dropping non-standard v1 content block that cannot be "
+                "represented as a Gemini part (inner type: %s).",
+                value.get("type") if isinstance(value, dict) else None,
+            )
+
+        else:
+            # No branch matched. A block type this whitelist does not know is
+            # dropped, which is right for another provider's blocks but is a bug
+            # signal for a newly added core block type -- hence the warning.
+            logger.warning(
+                "Dropping v1 content block with no Gemini equivalent (type: %s).",
+                block_dict["type"],
+            )
 
     return new_content

--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -300,6 +300,8 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                 )
 
         elif block_dict["type"] == "non_standard":
-            new_content.append(block_dict["value"])
+            # Opaque provider payloads cannot be represented by Gemini. Unwrapping
+            # them would send an unknown block type into the Gemini part converter.
+            continue
 
     return new_content

--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from langchain_core.messages import content as types
 
@@ -12,9 +12,27 @@ logger = logging.getLogger(__name__)
 #: directly. Vertex AI serves the same Gemini models, so its signatures are valid
 #: here and must not be stripped.
 #:
-#: Defined here rather than in `chat_models` because `chat_models` imports this
-#: module; `chat_models` re-exports it for use on the non-v1 path.
+#: Defined here because both v1 projection and chat-history replay use the same
+#: provider classification rules.
 _NATIVE_MODEL_PROVIDERS = frozenset({"google_genai", "google_vertexai"})
+_ModelProviderKind = Literal["native", "foreign", "unknown"]
+
+
+def _classify_model_provider(model_provider: str | None) -> _ModelProviderKind:
+    """Classify a model provider for content-block replay.
+
+    Args:
+        model_provider: Provider recorded on the source message, if known.
+
+    Returns:
+        Whether the message is native to Gemini, known to be foreign, or lacks
+        provider metadata.
+    """
+    if model_provider is None:
+        return "unknown"
+    if model_provider in _NATIVE_MODEL_PROVIDERS:
+        return "native"
+    return "foreign"
 
 
 def translate_citations_to_grounding_metadata(
@@ -149,12 +167,11 @@ def _convert_from_v1_to_generativelanguage_v1beta(
             be sent to the API.
 
     Note:
-        Every shape emitted here must have a matching branch in
+        Every shape emitted here must be accepted by
         `chat_models._convert_to_parts`, which converts these dicts to `Part`
-        objects. The tool-call history path converts native content strictly, so
-        adding an emitted shape without a converter branch turns it into a hard
-        `ValueError` rather than a dropped block.
+        objects.
     """
+    provider_kind = _classify_model_provider(model_provider)
     new_content: list = []
     for block in content:
         if not isinstance(block, dict) or "type" not in block:
@@ -171,34 +188,41 @@ def _convert_from_v1_to_generativelanguage_v1beta(
             new_block = {"text": block_dict.get("text", "")}
             if (
                 thought_signature := (block_dict.get("extras") or {}).get("signature")  # type: ignore[attr-defined]
-            ) and model_provider in _NATIVE_MODEL_PROVIDERS:
+            ) and provider_kind != "foreign":
                 new_block["thought_signature"] = thought_signature
             new_content.append(new_block)
             # Citations are only handled on output. Can't pass them back :/
 
         # ReasoningContentBlock -> thinking
-        elif (
-            block_dict["type"] == "reasoning"
-            and model_provider in _NATIVE_MODEL_PROVIDERS
-        ):
-            # Google requires passing back the thought_signature when available.
-            # Signatures are only provided when function calling is enabled.
+        elif block_dict["type"] == "reasoning":
             extras = block_dict.get("extras")
             signature = extras.get("signature") if isinstance(extras, dict) else None
-            if signature:
-                new_block = {
-                    "thought": True,
-                    "text": block_dict.get("reasoning", ""),
-                    "thought_signature": signature,
-                }
-                new_content.append(new_block)
-            else:
-                # An unsigned reasoning block cannot be echoed back: Gemini
-                # rejects a thought part with no signature. The text goes with it.
+            if provider_kind == "native" and not signature:
                 logger.warning(
                     "Dropping v1 reasoning block with no thought signature; "
                     "its text will not be sent back to the model."
                 )
+                continue
+            reasoning_text = block_dict.get("reasoning")
+            summary = block_dict.get("summary")
+            if reasoning_text is None and isinstance(summary, list):
+                summary_texts = [
+                    text.strip()
+                    for item in summary
+                    if isinstance(item, dict)
+                    and isinstance((text := item.get("text")), str)
+                    and text.strip()
+                ]
+                reasoning_text = " ".join(summary_texts)
+            if not reasoning_text and not (signature and provider_kind != "foreign"):
+                continue
+            new_block = {
+                "thought": True,
+                "text": reasoning_text or "",
+            }
+            if signature and provider_kind != "foreign":
+                new_block["thought_signature"] = signature
+            new_content.append(new_block)
 
         # ImageContentBlock
         elif block_dict["type"] == "image":
@@ -215,9 +239,7 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                     }
                 }
                 new_content.append(new_block)
-            elif (
-                url := block_dict.get("url")
-            ) and model_provider in _NATIVE_MODEL_PROVIDERS:
+            elif (url := block_dict.get("url")) and provider_kind != "foreign":
                 # Google file service
                 new_block = {
                     "file_data": {
@@ -246,9 +268,7 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                     }
                 }
                 new_content.append(new_block)
-            elif (
-                file_id := block_dict.get("file_id")
-            ) and model_provider in _NATIVE_MODEL_PROVIDERS:
+            elif (file_id := block_dict.get("file_id")) and provider_kind != "foreign":
                 # File ID from uploaded file
                 new_block = {
                     "file_data": {
@@ -259,9 +279,7 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                     }
                 }
                 new_content.append(new_block)
-            elif (
-                url := block_dict.get("url")
-            ) and model_provider in _NATIVE_MODEL_PROVIDERS:
+            elif (url := block_dict.get("url")) and provider_kind != "foreign":
                 # Google file service
                 new_block = {
                     "file_data": {
@@ -344,15 +362,19 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                 )
 
         elif block_dict["type"] == "non_standard":
-            # Opaque provider payloads cannot be represented by Gemini. Unwrapping
-            # them would send an unknown block type into the Gemini part converter.
-            # `chat_models._convert_to_parts` logs the same drop on the v0 path.
             value = block_dict.get("value")
-            logger.warning(
-                "Dropping non-standard v1 content block that cannot be "
-                "represented as a Gemini part (inner type: %s).",
-                value.get("type") if isinstance(value, dict) else None,
-            )
+            if provider_kind != "foreign" and isinstance(value, dict):
+                # Core wraps provider-native blocks it cannot standardize (for
+                # example Gemini's `media` block) as `non_standard`. Preserve the
+                # raw value for native and provider-less checkpoints; the caller
+                # converts native content strictly and unknown content leniently.
+                new_content.append(value)
+            else:
+                logger.warning(
+                    "Dropping non-standard v1 content block that cannot be "
+                    "represented as a Gemini part (inner type: %s).",
+                    value.get("type") if isinstance(value, dict) else None,
+                )
 
         else:
             # No branch matched. A block type this whitelist does not know is

--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -363,6 +363,11 @@ def _convert_from_v1_to_generativelanguage_v1beta(
             }
             new_content.append(function_call)
 
+        elif block_dict["type"] == "function_call_signature":
+            # The caller extracts this legacy sidecar before v1 projection and
+            # attaches it to the function call rebuilt from `message.tool_calls`.
+            continue
+
         elif block_dict["type"] == "server_tool_call":
             if block_dict.get("name") == "code_interpreter":
                 # LangChain v0 format

--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -291,13 +291,13 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                 new_content.append(new_block)
             elif (url := block_dict.get("url")) and provider_kind != "foreign":
                 # Google file service
-                new_block = _file_data_block(
+                file_data_block = _file_data_block(
                     url,
                     block_dict.get("mime_type", "image/jpeg"),
                     use_vertexai=use_vertexai,
                 )
-                if new_block is not None:
-                    new_content.append(new_block)
+                if file_data_block is not None:
+                    new_content.append(file_data_block)
 
         # TODO: AudioContentBlock -> audio once models support passing back in
 
@@ -320,22 +320,22 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                 new_content.append(new_block)
             elif (file_id := block_dict.get("file_id")) and provider_kind != "foreign":
                 # File ID from uploaded file
-                new_block = _file_data_block(
+                file_data_block = _file_data_block(
                     file_id,
                     block_dict.get("mime_type", "application/octet-stream"),
                     use_vertexai=use_vertexai,
                 )
-                if new_block is not None:
-                    new_content.append(new_block)
+                if file_data_block is not None:
+                    new_content.append(file_data_block)
             elif (url := block_dict.get("url")) and provider_kind != "foreign":
                 # Google file service
-                new_block = _file_data_block(
+                file_data_block = _file_data_block(
                     url,
                     block_dict.get("mime_type", "application/octet-stream"),
                     use_vertexai=use_vertexai,
                 )
-                if new_block is not None:
-                    new_content.append(new_block)
+                if file_data_block is not None:
+                    new_content.append(file_data_block)
 
         # ToolCall -> FunctionCall
         elif block_dict["type"] == "tool_call":

--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -35,6 +35,48 @@ def _classify_model_provider(model_provider: str | None) -> _ModelProviderKind:
     return "foreign"
 
 
+def _is_file_uri_supported(file_uri: Any, *, use_vertexai: bool) -> bool:
+    """Whether a file URI can be replayed through the target Google backend.
+
+    Args:
+        file_uri: File reference carried by a content block.
+        use_vertexai: Whether the target is the Vertex AI backend.
+
+    Returns:
+        `False` for a Google Cloud Storage URI sent to the Gemini Developer API;
+            otherwise `True`.
+    """
+    return not (
+        isinstance(file_uri, str) and file_uri.startswith("gs://") and not use_vertexai
+    )
+
+
+def _file_data_block(
+    file_uri: Any,
+    mime_type: Any,
+    *,
+    use_vertexai: bool,
+) -> dict[str, Any] | None:
+    """Build file data only when the target backend accepts its URI.
+
+    Args:
+        file_uri: File reference carried by a content block.
+        mime_type: MIME type carried by a content block.
+        use_vertexai: Whether the target is the Vertex AI backend.
+
+    Returns:
+        A Gemini file-data block, or `None` when the URI is target-specific and
+            unsupported.
+    """
+    if not _is_file_uri_supported(file_uri, use_vertexai=use_vertexai):
+        logger.warning(
+            "Dropping Google Cloud Storage file URI because the target Gemini "
+            "Developer API does not support gs:// references."
+        )
+        return None
+    return {"file_data": {"mime_type": mime_type, "file_uri": file_uri}}
+
+
 def translate_citations_to_grounding_metadata(
     citations: list[types.Citation], web_search_queries: list[str] | None = None
 ) -> dict[str, Any]:
@@ -154,13 +196,17 @@ def translate_citations_to_grounding_metadata(
 
 
 def _convert_from_v1_to_generativelanguage_v1beta(
-    content: list[types.ContentBlock], model_provider: str | None
+    content: list[types.ContentBlock],
+    model_provider: str | None,
+    *,
+    use_vertexai: bool = False,
 ) -> list[dict[str, Any]]:
     """Convert v1 content blocks to `generativelanguage_v1beta` `Content`.
 
     Args:
         content: List of v1 `ContentBlock` objects.
         model_provider: The model provider name that generated the v1 content.
+        use_vertexai: Whether the content will be sent to the Vertex AI backend.
 
     Returns:
         List of dictionaries in `generativelanguage_v1beta` `Content` format, ready to
@@ -245,13 +291,13 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                 new_content.append(new_block)
             elif (url := block_dict.get("url")) and provider_kind != "foreign":
                 # Google file service
-                new_block = {
-                    "file_data": {
-                        "mime_type": block_dict.get("mime_type", "image/jpeg"),
-                        "file_uri": url,
-                    }
-                }
-                new_content.append(new_block)
+                new_block = _file_data_block(
+                    url,
+                    block_dict.get("mime_type", "image/jpeg"),
+                    use_vertexai=use_vertexai,
+                )
+                if new_block is not None:
+                    new_content.append(new_block)
 
         # TODO: AudioContentBlock -> audio once models support passing back in
 
@@ -274,26 +320,22 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                 new_content.append(new_block)
             elif (file_id := block_dict.get("file_id")) and provider_kind != "foreign":
                 # File ID from uploaded file
-                new_block = {
-                    "file_data": {
-                        "mime_type": block_dict.get(
-                            "mime_type", "application/octet-stream"
-                        ),
-                        "file_uri": file_id,
-                    }
-                }
-                new_content.append(new_block)
+                new_block = _file_data_block(
+                    file_id,
+                    block_dict.get("mime_type", "application/octet-stream"),
+                    use_vertexai=use_vertexai,
+                )
+                if new_block is not None:
+                    new_content.append(new_block)
             elif (url := block_dict.get("url")) and provider_kind != "foreign":
                 # Google file service
-                new_block = {
-                    "file_data": {
-                        "mime_type": block_dict.get(
-                            "mime_type", "application/octet-stream"
-                        ),
-                        "file_uri": url,
-                    }
-                }
-                new_content.append(new_block)
+                new_block = _file_data_block(
+                    url,
+                    block_dict.get("mime_type", "application/octet-stream"),
+                    use_vertexai=use_vertexai,
+                )
+                if new_block is not None:
+                    new_content.append(new_block)
 
         # ToolCall -> FunctionCall
         elif block_dict["type"] == "tool_call":

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1126,20 +1126,23 @@ def _may_hold_foreign_blocks(message: AIMessage) -> bool:
     )
 
 
-def _has_provider_native_blocks(message: AIMessage) -> bool:
-    """Whether native `message` content holds raw Gemini block shapes.
+def _as_gemini_media_block(block: Mapping[str, Any]) -> dict[str, Any]:
+    """Re-tag a raw Gemini `file_data` block as a `media` block.
+
+    `_convert_to_parts` has no `file_data` branch; the `media` shape with
+    `file_uri` is the Gemini-native equivalent it converts.
 
     Args:
-        message: The message to inspect.
+        block: A raw `file_data` block carrying a `file_uri`.
 
     Returns:
-        `True` if the content carries `function_call`/`file_data` blocks, which the
-        provider translator normalizes to standard tool-call and file blocks.
+        The equivalent `media` block.
     """
-    return isinstance(message.content, list) and any(
-        isinstance(block, dict) and block.get("type") in ("function_call", "file_data")
-        for block in message.content
-    )
+    return {
+        "type": "media",
+        "file_uri": block["file_uri"],
+        "mime_type": block.get("mime_type", "application/octet-stream"),
+    }
 
 
 def _is_rebuilt_tool_call_block(block: Mapping[str, Any]) -> bool:
@@ -1228,26 +1231,6 @@ def _is_empty_content_block(block: Mapping[str, Any]) -> bool:
     return not has_text and not _block_signature(block)
 
 
-def _as_gemini_file_block(block: Mapping[str, Any]) -> dict[str, Any]:
-    """Re-tag a standard file URL block as a Gemini file reference.
-
-    The native block translator represents Gemini `file_data` as a standard file
-    URL. Preserve the provider-owned URI as a file reference rather than trying to
-    download it as public HTTP content.
-
-    Args:
-        block: A `file` block carrying a `url`.
-
-    Returns:
-        The equivalent `media` block.
-    """
-    return {
-        "type": "media",
-        "file_uri": block["url"],
-        "mime_type": block.get("mime_type", "application/octet-stream"),
-    }
-
-
 def _prepare_content_for_tool_call_message(message: AIMessage) -> list[Any]:
     """Prepare `AIMessage` content for conversion when the message has tool calls.
 
@@ -1268,16 +1251,15 @@ def _prepare_content_for_tool_call_message(message: AIMessage) -> list[Any]:
         rule near the top of this module).
     """
     is_foreign = _is_foreign_provider(message)
-    is_native = message.response_metadata.get("model_provider") in (
-        _NATIVE_MODEL_PROVIDERS
-    )
-    # Read `content` rather than `content_blocks` for native and unstamped
-    # messages: core projects Google's own `thinking` and `media` blocks to
-    # `non_standard`, which would discard genuine signatures. Native Gemini
-    # `function_call` and `file_data` blocks are the exception -- the provider
-    # translator normalizes those to standard tool-call and file blocks.
-    read_blocks = is_foreign or (is_native and _has_provider_native_blocks(message))
-    content = message.content_blocks if read_blocks else message.content
+    # Only foreign messages are read from `content_blocks`: they need core's
+    # standardization to shapes `_convert_to_parts` understands, and anything
+    # core cannot standardize is safe to drop because it is not Google's.
+    # Native and unstamped messages are read from raw `content`: core projects
+    # Google's own `thinking` and `media` blocks to `non_standard`, which would
+    # discard genuine signatures and silently drop media blocks mixed with
+    # native function calls. Raw `function_call`/`file_data` blocks are
+    # normalized individually below.
+    content = message.content_blocks if is_foreign else message.content
 
     if not isinstance(content, list):
         # A bare string is returned as a single-element list so that callers never
@@ -1306,8 +1288,14 @@ def _prepare_content_for_tool_call_message(message: AIMessage) -> list[Any]:
 
         if _is_rebuilt_tool_call_block(block):
             continue
-        if is_native and block.get("type") == "file" and "url" in block:
-            filtered.append(_as_gemini_file_block(block))
+        block_type = block.get("type")
+        if block_type == "function_call":
+            # Raw Gemini function call: the equivalent part is rebuilt from
+            # `message.tool_calls`, so the block must not be converted twice.
+            continue
+        if block_type == "file_data" and "file_uri" in block:
+            # Raw Gemini file reference: re-tag so `_convert_to_parts` handles it.
+            filtered.append(_as_gemini_media_block(block))
             continue
         candidate: Mapping[str, Any] = block
         if is_foreign:

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -315,6 +315,59 @@ def _base64_to_bytes(input_str: str) -> bytes:
     return base64.b64decode(input_str.encode("utf-8"))
 
 
+#: Providers whose content blocks and thought signatures this package can consume
+#: directly. Vertex AI serves the same Gemini models, so its signatures are valid
+#: here and must not be stripped.
+_NATIVE_MODEL_PROVIDERS = frozenset({"google_genai", "google_vertexai"})
+
+
+def _block_signature(block: Mapping[str, Any]) -> Any:
+    """Return the thought signature carried by a content block, if any.
+
+    Signatures live at the top level on v0 `thinking` blocks and under `extras`
+    on v1 `reasoning` and `text` blocks.
+
+    Args:
+        block: The content block to inspect.
+
+    Returns:
+        The signature value, or `None` if the block carries none.
+    """
+    extras = block.get("extras")
+    return block.get("signature") or (
+        extras.get("signature") if isinstance(extras, Mapping) else None
+    )
+
+
+def _is_redundant_v1beta_part(block: Any) -> bool:
+    """Whether an already-converted v1beta part must be dropped before conversion.
+
+    Function calls are rebuilt from `message.tool_calls` so that they are emitted
+    exactly once, and the Gemini API rejects text parts that carry neither text
+    nor a thought signature. A part whose text is empty but which carries a
+    signature is kept: the signature is the payload Gemini requires to be echoed
+    back on thinking-enabled turns.
+
+    Args:
+        block: A block from an `AIMessage` whose content was already projected to
+            v1beta dicts by `_convert_from_v1_to_generativelanguage_v1beta`.
+
+    Returns:
+        `True` if the block must not be converted to a part.
+    """
+    if not isinstance(block, dict):
+        return False
+    if "function_call" in block:
+        return True
+    if block.get("text"):
+        return False
+    return set(block) <= {
+        "text",
+        "thought",
+        "thought_signature",
+    } and not block.get("thought_signature")
+
+
 def _merge_http_options(base: HttpOptions | None, override: HttpOptions) -> HttpOptions:
     """Merge a per-request `HttpOptions` over internally-derived options.
 
@@ -980,13 +1033,47 @@ DUMMY_THOUGHT_SIGNATURE = _base64_to_bytes(
 )
 
 
+def _convert_to_parts_dropping_unconvertible(
+    content: list[Any], model: str | None = None
+) -> list[Part]:
+    """Convert content to parts, dropping blocks that have no Gemini equivalent.
+
+    Used for `AIMessage`s that may carry another provider's content blocks. Such a
+    block is an expected occurrence in a multi-provider history rather than a
+    programming error, so it is dropped with a warning instead of raising. Blocks
+    that do convert are unaffected.
+
+    Args:
+        content: The content blocks to convert.
+        model: The model name, used for version-specific logic.
+
+    Returns:
+        The convertible blocks as parts, in their original order.
+    """
+    try:
+        return _convert_to_parts(content, model=model)
+    except ValueError:
+        # Retry per block so that one unconvertible block does not discard the rest.
+        parts: list[Part] = []
+        for block in content:
+            try:
+                parts.extend(_convert_to_parts([block], model=model))
+            except ValueError:
+                logger.warning(
+                    "Dropping content block that cannot be represented as a "
+                    "Gemini part (type: %s).",
+                    block.get("type") if isinstance(block, Mapping) else type(block),
+                )
+        return parts
+
+
 def _prepare_content_for_tool_call_message(
     message: AIMessage,
 ) -> str | list[Any]:
     """Prepare `AIMessage` content for conversion when the message has tool calls.
 
     Strips valid and invalid function-call content blocks (valid calls are rebuilt
-    from `message.tool_calls`) and normalizes foreign-provider reasoning blocks so
+    from `message.tool_calls`) and normalizes another provider's blocks so that
     conversion never crashes on shapes this package did not produce. Foreign server
     tools are retained only for matched code-interpreter call/result pairs.
 
@@ -994,11 +1081,21 @@ def _prepare_content_for_tool_call_message(
         message: The `AIMessage` whose content should be prepared.
 
     Returns:
-        The normalized message content, with function-call blocks removed and
-        unrepresentable reasoning blocks dropped.
+        The content to convert -- `message.content_blocks` for messages from
+        another provider, otherwise `message.content` -- with function-call blocks
+        removed, another provider's signatures stripped, unmatched foreign server
+        tool blocks dropped, and text/thought blocks that carry neither text nor a
+        signature dropped.
     """
     model_provider = message.response_metadata.get("model_provider")
-    is_foreign = model_provider is not None and model_provider != "google_genai"
+    is_foreign = (
+        model_provider is not None and model_provider not in _NATIVE_MODEL_PROVIDERS
+    )
+    # Messages with no `model_provider` (hand-built messages, checkpoints serialized
+    # before core stamped the field) may hold either shape. Read `content` rather
+    # than `content_blocks` for those: core projects Google's own `thinking` and
+    # `media` blocks to `non_standard`, which would discard genuine signatures.
+    # `_convert_to_parts_dropping_unconvertible` handles any foreign block instead.
     content = message.content_blocks if is_foreign else message.content
 
     if not isinstance(content, list):
@@ -1011,12 +1108,12 @@ def _prepare_content_for_tool_call_message(
     code_interpreter_call_ids: set[str] = set()
     if is_foreign:
         code_interpreter_call_ids = {
-            block["id"]
+            call_id
             for block in content
             if isinstance(block, dict)
             and block.get("type") == "server_tool_call"
             and block.get("name") == "code_interpreter"
-            and isinstance(block.get("id"), str)
+            and isinstance(call_id := block.get("id"), str)
         }
 
     filtered: list[Any] = []
@@ -1031,9 +1128,10 @@ def _prepare_content_for_tool_call_message(
 
         block_type = block.get("type")
         if block_type in ("tool_call", "tool_call_chunk", "invalid_tool_call"):
-            # Function-call parts are emitted from `message.tool_calls`; the
-            # v1 converter also translates these blocks, so including them here
-            # would duplicate each function call.
+            # Function calls are rebuilt from `message.tool_calls` below.
+            # `_convert_to_parts` has no `tool_call` branch, so leaving these in
+            # would raise; they would also duplicate every call. Foreign messages
+            # reach here via `content_blocks`, which does include these blocks.
             continue
         if is_foreign and block_type == "server_tool_call":
             if block.get("name") != "code_interpreter":
@@ -1044,30 +1142,24 @@ def _prepare_content_for_tool_call_message(
             and block.get("tool_call_id") not in code_interpreter_call_ids
         ):
             continue
-        if block_type == "text" and not block.get("text"):
-            # Skip empty text blocks; they carry no information and the Gemini
-            # API rejects empty parts.
-            continue
-        if block_type in ("thinking", "reasoning") and not (
-            block.get("thinking") or block.get("reasoning") or block.get("summary")
-        ):
-            # Skip empty thought blocks; the Gemini API rejects empty parts.
-            continue
-        if block_type == "reasoning" and "reasoning" not in block and not is_foreign:
-            # Reasoning block in a shape `_convert_to_parts` cannot represent
-            # (e.g. OpenAI's `summary` blocks on a message without provider
-            # metadata). Drop rather than crash. Foreign-provider messages get
-            # no filtering here so summary text can still be converted below.
-            continue
-        if is_foreign and (
-            block_type in ("thinking", "text")
-            or (
-                # A foreign reasoning block's signature is unusable by Google;
-                # strip it whether the block carries reasoning text or a summary.
-                block_type == "reasoning"
+        # Blocks with no text are dropped because the Gemini API rejects empty
+        # parts -- unless they carry a thought signature, which is itself the
+        # payload Gemini requires to be echoed back on thinking-enabled turns.
+        if (
+            block_type in ("text", "thinking", "reasoning")
+            and not (
+                block.get("text")
+                or block.get("thinking")
+                or block.get("reasoning")
+                or block.get("summary")
             )
+            and not _block_signature(block)
         ):
-            # Signatures from other providers are not meaningful to Google.
+            continue
+        # Signatures from other providers are not meaningful to Google. Strip them
+        # from reasoning blocks whether the block carries reasoning text or a
+        # summary.
+        if is_foreign and block_type in ("thinking", "text", "reasoning"):
             sanitized_block: dict[str, Any] = {
                 k: v for k, v in block.items() if k != "signature"
             }
@@ -1165,34 +1257,23 @@ def _parse_chat_history(
                 # when passing messages back to the API.
                 if message.response_metadata.get("output_version") == "v1":
                     # Content was already converted to v1beta dicts above by
-                    # `_convert_from_v1_to_generativelanguage_v1beta`. Keep
-                    # non-function-call blocks (function calls are rebuilt from
-                    # `message.tool_calls` below so they are emitted exactly once)
-                    # and drop empty text blocks (the Gemini API rejects empty
-                    # parts).
+                    # `_convert_from_v1_to_generativelanguage_v1beta`, so these
+                    # blocks carry no `type` key and need their own filter rather
+                    # than `_prepare_content_for_tool_call_message`.
                     ai_message_parts.extend(
-                        _convert_to_parts(
+                        _convert_to_parts_dropping_unconvertible(
                             [
                                 block
                                 for block in message.content
-                                if not (
-                                    isinstance(block, dict)
-                                    and (
-                                        "function_call" in block
-                                        or (
-                                            set(block) <= {"text", "thought_signature"}
-                                            and not block.get("text")
-                                        )
-                                    )
-                                )
+                                if not _is_redundant_v1beta_part(block)
                             ],
                             model=model,
                         )
                     )
                 else:
                     ai_message_parts.extend(
-                        _convert_to_parts(
-                            _prepare_content_for_tool_call_message(message),
+                        _convert_to_parts_dropping_unconvertible(
+                            _prepare_content_for_tool_call_message(message),  # type: ignore[arg-type]
                             model=model,
                         )
                     )

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1093,22 +1093,37 @@ def _prepare_content_for_tool_call_message(
         message: The `AIMessage` whose content should be prepared.
 
     Returns:
-        The content to convert -- `message.content_blocks` for messages from
-        another provider, otherwise `message.content` -- with function-call blocks
-        removed, another provider's signatures stripped, unmatched foreign server
-        tool blocks dropped, and text/thought blocks that carry neither text nor a
-        signature dropped.
+        The content to convert, with provider-native blocks normalized as needed,
+        function-call blocks removed, another provider's signatures stripped,
+        unmatched foreign server tool blocks dropped, and text/thought blocks that
+        carry neither text nor a signature dropped.
     """
     model_provider = message.response_metadata.get("model_provider")
     is_foreign = (
         model_provider is not None and model_provider not in _NATIVE_MODEL_PROVIDERS
     )
+    is_native = model_provider in _NATIVE_MODEL_PROVIDERS
+    has_provider_native_blocks = (
+        is_native
+        and isinstance(message.content, list)
+        and any(
+            isinstance(block, dict)
+            and block.get("type") in ("function_call", "file_data")
+            for block in message.content
+        )
+    )
     # Messages with no `model_provider` (hand-built messages, checkpoints serialized
     # before core stamped the field) may hold either shape. Read `content` rather
     # than `content_blocks` for those: core projects Google's own `thinking` and
     # `media` blocks to `non_standard`, which would discard genuine signatures.
+    # Native Gemini `function_call` and `file_data` blocks are the exception: the
+    # provider translator normalizes them to standard tool-call and file blocks.
     # `_convert_to_parts_dropping_unconvertible` handles any foreign block instead.
-    content = message.content_blocks if is_foreign else message.content
+    content = (
+        message.content_blocks
+        if is_foreign or has_provider_native_blocks
+        else message.content
+    )
 
     if not isinstance(content, list):
         if isinstance(content, str) and not content:
@@ -1144,6 +1159,18 @@ def _prepare_content_for_tool_call_message(
             # `_convert_to_parts` has no `tool_call` branch, so leaving these in
             # would raise; they would also duplicate every call. Foreign messages
             # reach here via `content_blocks`, which does include these blocks.
+            continue
+        if is_native and block_type == "file" and "url" in block:
+            # The native block translator represents Gemini `file_data` as a
+            # standard file URL. Preserve the provider-owned URI as a file reference
+            # rather than trying to download it as public HTTP content.
+            filtered.append(
+                {
+                    "type": "media",
+                    "file_uri": block["url"],
+                    "mime_type": block.get("mime_type", "application/octet-stream"),
+                }
+            )
             continue
         if is_foreign and block_type == "server_tool_call":
             if block.get("name") != "code_interpreter":

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1379,6 +1379,21 @@ def _parse_chat_history(
         # Final step; assemble the Content object to pass to the API
         # If version = "v1", the parts are already in v1beta format and will be
         # automatically converted using protobuf's auto-conversion
+        if role == "model" and not parts:
+            if isinstance(message.content, list) and message.content:
+                logger.warning(
+                    "AI message at index %d converted to no Gemini parts after all "
+                    "%d content block(s) were dropped; using an empty text part.",
+                    i,
+                    len(message.content),
+                )
+            else:
+                logger.warning(
+                    "AI message at index %d converted to no Gemini parts; using an "
+                    "empty text part.",
+                    i,
+                )
+            parts = [Part(text="")]
         formatted_messages.append(Content(role=role, parts=parts))
 
     # Enforce thought signatures for new Gemini models

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -985,17 +985,16 @@ def _prepare_content_for_tool_call_message(
 ) -> str | list[Any]:
     """Prepare `AIMessage` content for conversion when the message has tool calls.
 
-    Strips content blocks that are rebuilt from `message.tool_calls` instead
-    (function calls must be emitted exactly once) and normalizes foreign-provider
-    reasoning blocks so conversion never crashes on shapes this package did not
-    produce.
+    Strips valid and invalid function-call content blocks (valid calls are rebuilt
+    from `message.tool_calls`) and normalizes foreign-provider reasoning blocks so
+    conversion never crashes on shapes this package did not produce.
 
     Args:
         message: The `AIMessage` whose content should be prepared.
 
     Returns:
-        The normalized message content, with `tool_call`/`tool_call_chunk` blocks
-        removed and unrepresentable reasoning blocks dropped.
+        The normalized message content, with function-call blocks removed and
+        unrepresentable reasoning blocks dropped.
     """
     model_provider = message.response_metadata.get("model_provider")
     is_foreign = model_provider is not None and model_provider != "google_genai"
@@ -1019,7 +1018,7 @@ def _prepare_content_for_tool_call_message(
             continue
 
         block_type = block.get("type")
-        if block_type in ("tool_call", "tool_call_chunk"):
+        if block_type in ("tool_call", "tool_call_chunk", "invalid_tool_call"):
             # Function-call parts are emitted from `message.tool_calls`; the
             # v1 converter also translates these blocks, so including them here
             # would duplicate each function call.

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -129,7 +129,7 @@ from langchain_google_genai._common import (
     get_user_agent,
 )
 from langchain_google_genai._compat import (
-    _NATIVE_MODEL_PROVIDERS,
+    _classify_model_provider,
     _convert_from_v1_to_generativelanguage_v1beta,
 )
 from langchain_google_genai._function_utils import (
@@ -353,18 +353,6 @@ def _decode_signature(sig: Any) -> bytes | None:
     return None
 
 
-def _drop_none(mapping: Mapping[str, Any] | None) -> dict[str, Any]:
-    """Return `mapping` without its `None` values, for splatting into a `Part` field.
-
-    Args:
-        mapping: The mapping to filter, or `None`.
-
-    Returns:
-        A new dict holding only the entries whose value is not `None`.
-    """
-    return {k: v for k, v in (mapping or {}).items() if v is not None}
-
-
 def _block_signature(block: Mapping[str, Any]) -> str | bytes | None:
     """Return the thought signature carried by a content block, if any.
 
@@ -427,38 +415,9 @@ def _v1beta_dict_to_part(part: Mapping[str, Any]) -> Part | None:
         The corresponding `Part`, or `None` if `part` is not one of the shapes that
         function emits.
     """
-    if part.get("thought") is True and "text" in part:
-        # Projected from a v1 `reasoning` block.
-        return Part(
-            text=part["text"],
-            thought=True,
-            thought_signature=_decode_signature(part.get("thought_signature")),
-        )
-    if "inline_data" in part:
-        # Projected from a v1 `image`/`file` block carrying base64 data.
-        return Part(inline_data=Blob(**_drop_none(part["inline_data"])))
-    if "file_data" in part:
-        # Projected from a v1 `image`/`file` block carrying a URI.
-        return Part(file_data=FileData(**_drop_none(part["file_data"])))
-    if "executable_code" in part:
-        # Projected from a v1 `server_tool_call` (code_interpreter) block.
-        return Part(
-            executable_code=ExecutableCode(**_drop_none(part["executable_code"]))
-        )
-    if "code_execution_result" in part:
-        # Projected from a v1 `server_tool_result` (code_execution_result) block.
-        return Part(
-            code_execution_result=CodeExecutionResult(
-                **_drop_none(part["code_execution_result"])
-            )
-        )
-    if set(part) <= {"text", "thought_signature"} and isinstance(part.get("text"), str):
-        # Projected from a v1 `text` block, optionally carrying a signature.
-        return Part(
-            text=part["text"],
-            thought_signature=_decode_signature(part.get("thought_signature")),
-        )
-    return None
+    if not set(part).intersection(Part.model_fields):
+        return None
+    return Part.model_validate(part)
 
 
 def _merge_http_options(base: HttpOptions | None, override: HttpOptions) -> HttpOptions:
@@ -828,11 +787,14 @@ def _convert_to_parts(
                         # text when possible; otherwise drop the block.
                         summary = part.get("summary")
                         if isinstance(summary, list):
-                            reasoning_text = "".join(
-                                item.get("text", "")
+                            summary_texts = [
+                                text.strip()
                                 for item in summary
                                 if isinstance(item, dict)
-                            )
+                                and isinstance((text := item.get("text")), str)
+                                and text.strip()
+                            ]
+                            reasoning_text = " ".join(summary_texts)
                         if not reasoning_text:
                             continue
                     parts.append(
@@ -1088,44 +1050,6 @@ def _convert_to_parts_lenient(
     return parts
 
 
-def _is_foreign_provider(message: AIMessage) -> bool:
-    """Whether `message` came from a provider whose blocks Gemini cannot consume.
-
-    A message with no `model_provider` is *not* foreign: hand-built messages and
-    checkpoints serialized before core stamped the field may hold Google's own
-    block shapes, and reading them as foreign would discard genuine signatures.
-    Contrast `_may_hold_foreign_blocks`, which deliberately answers the opposite
-    way for that case.
-
-    Args:
-        message: The message to classify.
-
-    Returns:
-        `True` if the message records a provider other than Google's.
-    """
-    model_provider = message.response_metadata.get("model_provider")
-    return model_provider is not None and model_provider not in _NATIVE_MODEL_PROVIDERS
-
-
-def _may_hold_foreign_blocks(message: AIMessage) -> bool:
-    """Whether conversion failures for `message` should be dropped rather than raised.
-
-    Answers `True` where `_is_foreign_provider` answers `False` for a message with
-    no `model_provider`: such a message is read as native (to preserve signatures)
-    but cannot be *trusted* to be native, so a conversion failure is dropped rather
-    than turned into an error the caller cannot act on.
-
-    Args:
-        message: The message to classify.
-
-    Returns:
-        `True` if the message is not known to have come from Google.
-    """
-    return message.response_metadata.get("model_provider") not in (
-        _NATIVE_MODEL_PROVIDERS
-    )
-
-
 def _as_gemini_media_block(block: Mapping[str, Any]) -> dict[str, Any]:
     """Re-tag a raw Gemini `file_data` block as a `media` block.
 
@@ -1250,7 +1174,10 @@ def _prepare_content_for_tool_call_message(message: AIMessage) -> list[Any]:
         wrapped in a list (empty string yields an empty list, per the empty-part
         rule near the top of this module).
     """
-    is_foreign = _is_foreign_provider(message)
+    provider_kind = _classify_model_provider(
+        message.response_metadata.get("model_provider")
+    )
+    is_foreign = provider_kind == "foreign"
     # Only foreign messages are read from `content_blocks`: they need core's
     # standardization to shapes `_convert_to_parts` understands, and anything
     # core cannot standardize is safe to drop because it is not Google's.
@@ -1308,6 +1235,52 @@ def _prepare_content_for_tool_call_message(message: AIMessage) -> list[Any]:
     return filtered
 
 
+def _convert_ai_message_content(
+    message: AIMessage,
+    model: str | None,
+    *,
+    exclude_function_calls: bool,
+) -> list[Part]:
+    """Convert an AI message's non-authoritative content to Gemini parts.
+
+    `message.tool_calls` is the authoritative function-call representation. V1
+    content is first projected to Gemini-compatible dictionaries; other content
+    uses the provider-aware normalization path when function calls must be removed.
+
+    Args:
+        message: The AI message to convert.
+        model: The target model name, used for version-specific media behavior.
+        exclude_function_calls: Whether function-call blocks should be omitted
+            because they will be rebuilt from `message.tool_calls`.
+
+    Returns:
+        Converted Gemini parts.
+    """
+    provider_kind = _classify_model_provider(
+        message.response_metadata.get("model_provider")
+    )
+    if message.response_metadata.get("output_version") == "v1":
+        content: list[Any] = _convert_from_v1_to_generativelanguage_v1beta(
+            cast("list[types.ContentBlock]", message.content),
+            message.response_metadata.get("model_provider"),
+        )
+        if exclude_function_calls:
+            content = [
+                block for block in content if not _is_redundant_v1beta_part(block)
+            ]
+    elif exclude_function_calls:
+        content = _prepare_content_for_tool_call_message(message)
+    else:
+        content = (
+            [message.content] if isinstance(message.content, str) else message.content
+        )
+
+    convert = (
+        _convert_to_parts if provider_kind == "native" else _convert_to_parts_lenient
+    )
+    return convert(content, model=model)
+
+
 def _parse_chat_history(
     input_messages: Sequence[BaseMessage],
     convert_system_message_to_human: bool = False,
@@ -1337,27 +1310,6 @@ def _parse_chat_history(
             DeprecationWarning,
             stacklevel=2,
         )
-    input_messages = list(input_messages)  # Make a mutable copy
-
-    # Case where content was serialized to v1 format
-    for idx, message in enumerate(input_messages):
-        if (
-            isinstance(message, AIMessage)
-            and message.response_metadata.get("output_version") == "v1"
-        ):
-            # Unpack known v1 content to v1beta format for the request
-            #
-            # Old content types and any previously serialized messages passed back in to
-            # history will skip this, but hit and processed in `_convert_to_parts`
-            input_messages[idx] = message.model_copy(
-                update={
-                    "content": _convert_from_v1_to_generativelanguage_v1beta(
-                        cast("list[types.ContentBlock]", message.content),
-                        message.response_metadata.get("model_provider"),
-                    )
-                }
-            )
-
     formatted_messages: list[Content] = []
 
     system_instruction: Content | None = None
@@ -1383,57 +1335,21 @@ def _parse_chat_history(
         if isinstance(message, AIMessage):
             role = "model"
             if message.tool_calls:
-                ai_message_parts = []
-
                 # First, convert all non-function-call content (text, thinking,
                 # reasoning, media, etc.) through the unified conversion path.
                 # When include_thoughts=True, thinking blocks need to be preserved
                 # when passing messages back to the API.
-                if message.response_metadata.get("output_version") == "v1":
-                    # Content was already converted to v1beta dicts above by
-                    # `_convert_from_v1_to_generativelanguage_v1beta`, so these
-                    # blocks carry no `type` key and need their own filter rather
-                    # than `_prepare_content_for_tool_call_message`.
-                    #
-                    # `_compat` drops unconvertible foreign block types, but it
-                    # does not validate converted media payloads: another
-                    # provider's malformed `image`/`file` base64 still reaches
-                    # `Blob` here, so foreign v1 messages keep the tolerant
-                    # per-block dropping of the non-v1 branch. Native v1 content
-                    # stays strict -- a conversion failure there is malformed
-                    # input that must not be silently rewritten.
-                    v1_blocks = [
-                        block
-                        for block in message.content
-                        if not _is_redundant_v1beta_part(block)
-                    ]
-                    convert = (
-                        _convert_to_parts_lenient
-                        if _may_hold_foreign_blocks(message)
-                        else _convert_to_parts
-                    )
-                    ai_message_parts.extend(convert(v1_blocks, model=model))
-                else:
-                    # Only another provider's blocks may fail to convert; a block
-                    # from a message known to be Google's is malformed input, and
-                    # must surface rather than silently change the request.
-                    convert = (
-                        _convert_to_parts_lenient
-                        if _may_hold_foreign_blocks(message)
-                        else _convert_to_parts
-                    )
-                    ai_message_parts.extend(
-                        convert(
-                            _prepare_content_for_tool_call_message(message),
-                            model=model,
-                        )
-                    )
+                ai_message_parts = _convert_ai_message_content(
+                    message,
+                    model,
+                    exclude_function_calls=True,
+                )
 
                 # Then, add function call parts
                 function_call_sigs: dict[Any, str] = message.additional_kwargs.get(
                     _FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY, {}
                 )
-                for tool_call_idx, tool_call in enumerate(message.tool_calls):
+                for tool_call in message.tool_calls:
                     function_call = FunctionCall(
                         name=tool_call["name"],
                         args=tool_call["args"],
@@ -1470,8 +1386,11 @@ def _parse_chat_history(
                 )
                 parts = [Part(function_call=function_call)]
             elif message.response_metadata.get("output_version") == "v1":
-                # Already converted to v1beta format above
-                parts = message.content  # type: ignore[assignment]
+                parts = _convert_ai_message_content(
+                    message,
+                    model,
+                    exclude_function_calls=False,
+                )
             else:
                 # Prepare request content parts from message.content field
                 parts = _convert_to_parts(message.content, model=model)

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -327,28 +327,13 @@ def _base64_to_bytes(input_str: str) -> bytes:
     return base64.b64decode(input_str.encode("utf-8"))
 
 
-# THE EMPTY-PART RULE, referenced throughout this module: the Gemini API rejects a
-# part that carries no payload, and on thinking-enabled turns the thought signature
-# *is* the payload it requires to be echoed back. A signature-only block is
-# therefore kept; a genuinely empty one is not.
-# (`ChatGoogleGenerativeAI._filter_messages` deliberately sends an empty text part
-# for Vertex AI, which is a separate, endpoint-specific allowance.)
+# Gemini rejects empty parts, but a thought signature is itself a replayable payload.
 
 
 def _decode_signature(sig: Any) -> bytes | None:
-    """Decode a thought signature to the raw bytes the Gemini API expects.
+    """Decode a serialized thought signature to Gemini's byte representation.
 
-    Signatures cross process boundaries base64-encoded (that is how they survive
-    JSON serialization in a checkpoint) but reach the API as bytes.
-
-    Args:
-        sig: A base64-encoded `str`, raw `bytes`, or any other value.
-
-    Returns:
-        The signature as bytes, or `None` if there is no usable signature.
-
-    Raises:
-        binascii.Error: If `sig` is a `str` that is not valid base64.
+    Checkpoints store signatures as base64 strings, while the SDK accepts bytes.
     """
     if isinstance(sig, str):
         return base64.b64decode(sig) or None
@@ -358,18 +343,7 @@ def _decode_signature(sig: Any) -> bytes | None:
 
 
 def _block_signature(block: Mapping[str, Any]) -> str | bytes | None:
-    """Return the thought signature carried by a content block, if any.
-
-    Signatures live under `thought_signature` on Vertex text blocks, at the top
-    level under `signature` on v0 `thinking` blocks, and under `extras` on v1
-    `reasoning` and `text` blocks.
-
-    Args:
-        block: The content block to inspect.
-
-    Returns:
-        The signature value, or `None` if the block carries none.
-    """
+    """Read a signature from its v0, v1, or Vertex location."""
     extras = block.get("extras")
     return (
         block.get("thought_signature")
@@ -379,19 +353,10 @@ def _block_signature(block: Mapping[str, Any]) -> str | bytes | None:
 
 
 def _is_redundant_v1beta_part(block: Any) -> bool:
-    """Whether an already-converted v1beta part must be dropped before conversion.
+    """Check whether a projected part duplicates a call or is truly empty.
 
-    Function calls are rebuilt from `message.tool_calls` so that they are emitted
-    exactly once. Text parts are dropped per the empty-part rule near the top of
-    this module, so a part whose text is empty but which carries a signature is
-    kept.
-
-    Args:
-        block: A block from an `AIMessage` whose content was already projected to
-            v1beta dicts by `_convert_from_v1_to_generativelanguage_v1beta`.
-
-    Returns:
-        `True` if the block must not be converted to a part.
+    Signature-only parts are intentionally retained because Gemini requires their
+    signatures to be replayed even when they contain no text.
     """
     if not isinstance(block, dict):
         return False
@@ -407,21 +372,7 @@ def _is_redundant_v1beta_part(block: Any) -> bool:
 
 
 def _v1beta_dict_to_part(part: Mapping[str, Any]) -> Part | None:
-    """Convert an already-projected `generativelanguage_v1beta` dict to a `Part`.
-
-    `_convert_from_v1_to_generativelanguage_v1beta` projects v1 content blocks to
-    plain v1beta dicts, which carry no `type` key and so are identified by which
-    keys they hold. The `_parse_chat_history` tool-call branch routes v1-converted
-    content through here.
-
-    Args:
-        part: A mapping with no `type` key, as emitted by
-            `_convert_from_v1_to_generativelanguage_v1beta`.
-
-    Returns:
-        The corresponding `Part`, or `None` if `part` is not one of the shapes that
-        function emits.
-    """
+    """Validate a type-less projected v1beta dictionary as a Gemini part."""
     if not set(part).intersection(Part.model_fields):
         return None
     return Part.model_validate(part)
@@ -1019,36 +970,16 @@ def _convert_to_parts_lenient(
     content: list[Any],
     model: str | None = None,
 ) -> list[Part]:
-    """Convert content to parts, dropping any block that fails to convert.
+    """Convert foreign content one block at a time, dropping invalid blocks.
 
-    For content that may carry another provider's blocks, where an unconvertible
-    block is an expected occurrence in a multi-provider history rather than a
-    programming error. Native content is converted with `_convert_to_parts`
-    directly, so that a failure surfaces instead of silently changing the request.
-
-    Each block is converted on its own so that one unconvertible block does not
-    discard its neighbors. Note that a whole-list attempt cannot be used as a fast
-    path here: `_convert_to_parts` fetches remote media, so retrying after a
-    failure would re-download every image preceding the failing block.
-
-    Args:
-        content: The content blocks to convert.
-        model: The model name, used for version-specific logic.
-
-    Returns:
-        The convertible blocks as parts, in their original order.
+    Per-block conversion preserves valid neighbors without retrying media downloads
+    that occurred before a failing block.
     """
     parts: list[Part] = []
     for block in content:
         try:
             parts.extend(_convert_to_parts([block], model=model))
         except (ValueError, ChatGoogleGenerativeAIError) as exc:
-            # `ValueError` covers both the unrecognized-part-type error and the
-            # `pydantic.ValidationError`/`binascii.Error` raised by a malformed
-            # payload; `ChatGoogleGenerativeAIError` covers a block that is
-            # neither a string nor a mapping. The cause is logged because it is
-            # not always "Gemini has no equivalent" -- it may be an actionable
-            # message from media loading (e.g. a rejected local file path).
             logger.warning(
                 "Dropping content block that cannot be represented as a Gemini "
                 "part (type: %s): %s",
@@ -1059,17 +990,7 @@ def _convert_to_parts_lenient(
 
 
 def _as_gemini_media_block(block: Mapping[str, Any]) -> dict[str, Any]:
-    """Re-tag a raw Gemini `file_data` block as a `media` block.
-
-    `_convert_to_parts` has no `file_data` branch; the `media` shape with
-    `file_uri` is the Gemini-native equivalent it converts.
-
-    Args:
-        block: A raw `file_data` block carrying a `file_uri`.
-
-    Returns:
-        The equivalent `media` block.
-    """
+    """Re-tag raw Gemini file data for the shared media converter."""
     return {
         "type": "media",
         "file_uri": block["file_uri"],
@@ -1078,18 +999,7 @@ def _as_gemini_media_block(block: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _is_rebuilt_tool_call_block(block: Mapping[str, Any]) -> bool:
-    """Whether `block` is a function call that is rebuilt from `message.tool_calls`.
-
-    `_convert_to_parts` has no `tool_call` branch, so leaving these in would raise;
-    they would also duplicate every call. Foreign messages reach the filter via
-    `content_blocks`, which can include these blocks.
-
-    Args:
-        block: The content block to test.
-
-    Returns:
-        `True` if the block must be dropped.
-    """
+    """Check whether a block is rebuilt from `message.tool_calls`."""
     return block.get("type") in (
         "tool_call",
         "tool_call_chunk",
@@ -1101,14 +1011,7 @@ def _is_rebuilt_tool_call_block(block: Mapping[str, Any]) -> bool:
 def _function_call_signatures_from_content(
     message: AIMessage,
 ) -> dict[int, str | bytes]:
-    """Extract legacy function-call signature sidecars from message content.
-
-    Args:
-        message: AI message whose tool calls are being rebuilt.
-
-    Returns:
-        Signature values keyed by their corresponding tool-call index.
-    """
+    """Index legacy function-call signature sidecars by tool call."""
     if _classify_model_provider(
         message.response_metadata.get("model_provider")
     ) == "foreign" or not isinstance(message.content, list):
@@ -1137,17 +1040,10 @@ def _function_call_signatures_from_content(
 def _is_unsupported_foreign_server_tool(
     block: Mapping[str, Any], code_interpreter_call_ids: Container[str]
 ) -> bool:
-    """Whether `block` is another provider's server tool that Gemini cannot replay.
+    """Check whether a foreign server-tool block has a Gemini equivalent.
 
-    Code interpreter calls map onto Gemini's `executable_code`; nothing else does.
-    A result is kept only when its call was kept, so no orphan result is sent.
-
-    Args:
-        block: The content block to test.
-        code_interpreter_call_ids: Ids of the code-interpreter calls being kept.
-
-    Returns:
-        `True` if the block must be dropped.
+    Code-interpreter calls map to executable code; their results are retained only
+    when the corresponding call was retained.
     """
     block_type = block.get("type")
     if block_type == "server_tool_call":
@@ -1158,18 +1054,10 @@ def _is_unsupported_foreign_server_tool(
 
 
 def _strip_foreign_signature(block: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Return `block` without any thought signature another provider attached.
+    """Return a block without another provider's thought signature.
 
-    Signatures from other providers are not meaningful to Google. Stripping must
-    happen before the empty-block check: a block whose only payload is a foreign
-    signature would otherwise survive on the strength of that signature and then
-    emit an empty part. See the empty-part rule near the top of this module.
-
-    Args:
-        block: The content block to strip.
-
-    Returns:
-        `block` unchanged if it carries no signature, otherwise a stripped copy.
+    This runs before empty-block filtering so a signature-only foreign block does
+    not become an invalid empty Gemini part after its signature is removed.
     """
     extras = block.get("extras")
     extras_has_signature = isinstance(extras, dict) and "signature" in extras
@@ -1189,15 +1077,7 @@ def _strip_foreign_signature(block: Mapping[str, Any]) -> Mapping[str, Any]:
 
 
 def _is_empty_content_block(block: Mapping[str, Any]) -> bool:
-    """Whether `block` is a text/thought block with no payload at all.
-
-    Args:
-        block: The content block to test.
-
-    Returns:
-        `True` if the block carries neither text nor a thought signature, and so
-        must be dropped per the empty-part rule near the top of this module.
-    """
+    """Check whether a text or thought block has no replayable payload."""
     if block.get("type") not in ("text", "thinking", "reasoning"):
         return False
     has_text = (
@@ -1210,14 +1090,7 @@ def _is_empty_content_block(block: Mapping[str, Any]) -> bool:
 
 
 def _content_block_file_uri(block: Any) -> Any:
-    """Return the file URI carried by any supported content-block shape.
-
-    Args:
-        block: Raw, standardized, or projected content block.
-
-    Returns:
-        The block's file URI or `None` when it has no file reference.
-    """
+    """Return the URI carried by any supported file block shape."""
     if not isinstance(block, Mapping):
         return None
     file_data = block.get("file_data")
@@ -1241,15 +1114,7 @@ def _content_block_file_uri(block: Any) -> Any:
 def _drop_unsupported_file_references(
     content: list[Any], *, use_vertexai: bool
 ) -> list[Any]:
-    """Drop history file references that the target backend cannot consume.
-
-    Args:
-        content: Prepared AI-message content blocks.
-        use_vertexai: Whether the target is the Vertex AI backend.
-
-    Returns:
-        Content without backend-specific file references unsupported by the target.
-    """
+    """Drop file references unsupported by the target backend."""
     filtered: list[Any] = []
     for block in content:
         file_uri = _content_block_file_uri(block)
@@ -1266,44 +1131,20 @@ def _drop_unsupported_file_references(
 def _prepare_ai_message_content(
     message: AIMessage, *, exclude_function_calls: bool
 ) -> list[Any]:
-    """Prepare non-v1 `AIMessage` content for provider-aware conversion.
+    """Normalize non-v1 AI content for provider-aware conversion.
 
-    When function calls are rebuilt from `message.tool_calls`, strips their valid
-    and invalid content blocks. Normalizes another provider's blocks regardless of
-    whether the message has tool calls, so foreign signatures never reach Gemini.
-    Foreign code-interpreter calls are retained; their results only when matched.
-
-    Args:
-        message: The `AIMessage` whose content should be prepared.
-        exclude_function_calls: Whether function-call blocks should be omitted
-            because they will be rebuilt from `message.tool_calls`.
-
-    Returns:
-        The content to convert as a list, with provider-native blocks normalized as
-        needed, function-call blocks optionally removed, another provider's
-        signatures stripped, unreplayable foreign server tool blocks dropped, and
-        text/thought blocks that carry neither text nor a signature dropped. String
-        content is wrapped in a list (empty string yields an empty list, per the
-        empty-part rule near the top of this module).
+    Foreign messages use LangChain's standardized blocks. Native messages retain
+    their raw blocks because core may wrap valid Gemini media as `non_standard`.
     """
     provider_kind = _classify_model_provider(
         message.response_metadata.get("model_provider")
     )
     is_foreign = provider_kind == "foreign"
-    # Only foreign messages are read from `content_blocks`: they need core's
-    # standardization to shapes `_convert_to_parts` understands, and anything
-    # core cannot standardize is safe to drop because it is not Google's.
-    # Native and unstamped messages are read from raw `content`: core projects
-    # Google's own `thinking` and `media` blocks to `non_standard`, which would
-    # discard genuine signatures and silently drop media blocks mixed with
-    # native function calls. Raw `function_call`/`file_data` blocks are
-    # normalized individually below.
+    # Core standardizes foreign blocks, but can wrap native Gemini blocks as
+    # `non_standard`, so native and unstamped messages use their raw content.
     content = message.content_blocks if is_foreign else message.content
 
     if not isinstance(content, list):
-        # A bare string is returned as a single-element list so that callers never
-        # have to re-handle the scalar case (iterating a `str` would yield one part
-        # per character). Empty text carries no information and is dropped.
         return [content] if content else []
 
     code_interpreter_call_ids: set[str] = set()
@@ -1337,11 +1178,8 @@ def _prepare_ai_message_content(
             )
             continue
         if exclude_function_calls and block_type == "function_call":
-            # Raw Gemini function call: the equivalent part is rebuilt from
-            # `message.tool_calls`, so the block must not be converted twice.
             continue
         if block_type == "file_data" and "file_uri" in block:
-            # Raw Gemini file reference: re-tag so `_convert_to_parts` handles it.
             filtered.append(_as_gemini_media_block(block))
             continue
         candidate: Mapping[str, Any] = block
@@ -1362,21 +1200,10 @@ def _convert_ai_message_content(
     exclude_function_calls: bool,
     use_vertexai: bool,
 ) -> list[Part]:
-    """Convert an AI message's non-authoritative content to Gemini parts.
+    """Convert AI content while treating `message.tool_calls` as authoritative.
 
-    `message.tool_calls` is the authoritative function-call representation. V1
-    content is first projected to Gemini-compatible dictionaries; other content
-    uses the provider-aware normalization path when function calls must be removed.
-
-    Args:
-        message: The AI message to convert.
-        model: The target model name, used for version-specific media behavior.
-        exclude_function_calls: Whether function-call blocks should be omitted
-            because they will be rebuilt from `message.tool_calls`.
-        use_vertexai: Whether the target is the Vertex AI backend.
-
-    Returns:
-        Converted Gemini parts.
+    Native content is validated strictly; foreign and provider-less content is
+    converted leniently so unsupported provider-specific blocks do not abort replay.
     """
     provider_kind = _classify_model_provider(
         message.response_metadata.get("model_provider")

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -979,20 +979,22 @@ def _prepare_content_for_tool_call_message(
         message: The `AIMessage` whose content should be prepared.
 
     Returns:
-        The message content, with `tool_call`/`tool_call_chunk` blocks removed
-        and unrepresentable reasoning blocks dropped.
+        The normalized message content, with `tool_call`/`tool_call_chunk` blocks
+        removed and unrepresentable reasoning blocks dropped.
     """
-    if not isinstance(message.content, list):
-        if isinstance(message.content, str) and not message.content:
+    model_provider = message.response_metadata.get("model_provider")
+    is_foreign = model_provider is not None and model_provider != "google_genai"
+    content = message.content_blocks if is_foreign else message.content
+
+    if not isinstance(content, list):
+        if isinstance(content, str) and not content:
             # Normalize empty text to no content; it carries no information and
             # the Gemini API rejects empty parts.
             return []
-        return message.content
+        return content
 
-    model_provider = message.response_metadata.get("model_provider")
-    is_foreign = model_provider is not None and model_provider != "google_genai"
     filtered: list[Any] = []
-    for block in message.content:
+    for block in content:
         if not isinstance(block, dict):
             if isinstance(block, str) and not block:
                 # Skip empty text; it carries no information and the Gemini API
@@ -1031,10 +1033,16 @@ def _prepare_content_for_tool_call_message(
             )
         ):
             # Signatures from other providers are not meaningful to Google.
-            block = {k: v for k, v in block.items() if k != "signature"}
-            extras = block.get("extras")
+            sanitized_block: dict[str, Any] = {
+                k: v for k, v in block.items() if k != "signature"
+            }
+            extras = sanitized_block.get("extras")
             if isinstance(extras, dict) and "signature" in extras:
-                block["extras"] = {k: v for k, v in extras.items() if k != "signature"}
+                sanitized_block["extras"] = {
+                    k: v for k, v in extras.items() if k != "signature"
+                }
+            filtered.append(sanitized_block)
+            continue
         filtered.append(block)
     return filtered
 

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -987,7 +987,8 @@ def _prepare_content_for_tool_call_message(
 
     Strips valid and invalid function-call content blocks (valid calls are rebuilt
     from `message.tool_calls`) and normalizes foreign-provider reasoning blocks so
-    conversion never crashes on shapes this package did not produce.
+    conversion never crashes on shapes this package did not produce. Foreign server
+    tools are retained only for matched code-interpreter call/result pairs.
 
     Args:
         message: The `AIMessage` whose content should be prepared.
@@ -1007,6 +1008,17 @@ def _prepare_content_for_tool_call_message(
             return []
         return content
 
+    code_interpreter_call_ids: set[str] = set()
+    if is_foreign:
+        code_interpreter_call_ids = {
+            block["id"]
+            for block in content
+            if isinstance(block, dict)
+            and block.get("type") == "server_tool_call"
+            and block.get("name") == "code_interpreter"
+            and isinstance(block.get("id"), str)
+        }
+
     filtered: list[Any] = []
     for block in content:
         if not isinstance(block, dict):
@@ -1022,6 +1034,15 @@ def _prepare_content_for_tool_call_message(
             # Function-call parts are emitted from `message.tool_calls`; the
             # v1 converter also translates these blocks, so including them here
             # would duplicate each function call.
+            continue
+        if is_foreign and block_type == "server_tool_call":
+            if block.get("name") != "code_interpreter":
+                continue
+        if (
+            is_foreign
+            and block_type == "server_tool_result"
+            and block.get("tool_call_id") not in code_interpreter_call_ids
+        ):
             continue
         if block_type == "text" and not block.get("text"):
             # Skip empty text blocks; they carry no information and the Gemini

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1253,24 +1253,28 @@ def _drop_unsupported_file_references(
     return filtered
 
 
-def _prepare_content_for_tool_call_message(message: AIMessage) -> list[Any]:
-    """Prepare `AIMessage` content for conversion when the message has tool calls.
+def _prepare_ai_message_content(
+    message: AIMessage, *, exclude_function_calls: bool
+) -> list[Any]:
+    """Prepare non-v1 `AIMessage` content for provider-aware conversion.
 
-    Strips valid and invalid function-call content blocks (valid calls are rebuilt
-    from `message.tool_calls`) and normalizes another provider's blocks so that
-    conversion does not raise on shapes this package did not produce. Foreign
-    code-interpreter calls are retained; their results only when matched.
+    When function calls are rebuilt from `message.tool_calls`, strips their valid
+    and invalid content blocks. Normalizes another provider's blocks regardless of
+    whether the message has tool calls, so foreign signatures never reach Gemini.
+    Foreign code-interpreter calls are retained; their results only when matched.
 
     Args:
         message: The `AIMessage` whose content should be prepared.
+        exclude_function_calls: Whether function-call blocks should be omitted
+            because they will be rebuilt from `message.tool_calls`.
 
     Returns:
         The content to convert as a list, with provider-native blocks normalized as
-        needed, function-call blocks removed, another provider's signatures
-        stripped, unreplayable foreign server tool blocks dropped, and text/thought
-        blocks that carry neither text nor a signature dropped. String content is
-        wrapped in a list (empty string yields an empty list, per the empty-part
-        rule near the top of this module).
+        needed, function-call blocks optionally removed, another provider's
+        signatures stripped, unreplayable foreign server tool blocks dropped, and
+        text/thought blocks that carry neither text nor a signature dropped. String
+        content is wrapped in a list (empty string yields an empty list, per the
+        empty-part rule near the top of this module).
     """
     provider_kind = _classify_model_provider(
         message.response_metadata.get("model_provider")
@@ -1311,7 +1315,7 @@ def _prepare_content_for_tool_call_message(message: AIMessage) -> list[Any]:
             filtered.append(block)
             continue
 
-        if _is_rebuilt_tool_call_block(block):
+        if exclude_function_calls and _is_rebuilt_tool_call_block(block):
             continue
         block_type = block.get("type")
         if is_foreign and block_type == "non_standard":
@@ -1322,7 +1326,7 @@ def _prepare_content_for_tool_call_message(message: AIMessage) -> list[Any]:
                 value.get("type") if isinstance(value, Mapping) else None,
             )
             continue
-        if block_type == "function_call":
+        if exclude_function_calls and block_type == "function_call":
             # Raw Gemini function call: the equivalent part is rebuilt from
             # `message.tool_calls`, so the block must not be converted twice.
             continue
@@ -1377,8 +1381,10 @@ def _convert_ai_message_content(
             content = [
                 block for block in content if not _is_redundant_v1beta_part(block)
             ]
-    elif exclude_function_calls:
-        content = _prepare_content_for_tool_call_message(message)
+    elif exclude_function_calls or provider_kind == "foreign":
+        content = _prepare_ai_message_content(
+            message, exclude_function_calls=exclude_function_calls
+        )
     else:
         content = (
             [message.content] if isinstance(message.content, str) else message.content
@@ -1514,8 +1520,12 @@ def _parse_chat_history(
                     use_vertexai=use_vertexai,
                 )
             else:
-                # Prepare request content parts from message.content field
-                parts = _convert_to_parts(message.content, model=model)
+                parts = _convert_ai_message_content(
+                    message,
+                    model,
+                    exclude_function_calls=False,
+                    use_vertexai=use_vertexai,
+                )
         elif isinstance(message, HumanMessage):
             role = "user"
             parts = _convert_to_parts(message.content, model=model)

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -11,7 +11,14 @@ import re
 import uuid
 import warnings
 import wave
-from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
+from collections.abc import (
+    AsyncIterator,
+    Callable,
+    Container,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 from difflib import get_close_matches
 from operator import itemgetter
 from typing import (
@@ -122,6 +129,7 @@ from langchain_google_genai._common import (
     get_user_agent,
 )
 from langchain_google_genai._compat import (
+    _NATIVE_MODEL_PROVIDERS,
     _convert_from_v1_to_generativelanguage_v1beta,
 )
 from langchain_google_genai._function_utils import (
@@ -315,13 +323,49 @@ def _base64_to_bytes(input_str: str) -> bytes:
     return base64.b64decode(input_str.encode("utf-8"))
 
 
-#: Providers whose content blocks and thought signatures this package can consume
-#: directly. Vertex AI serves the same Gemini models, so its signatures are valid
-#: here and must not be stripped.
-_NATIVE_MODEL_PROVIDERS = frozenset({"google_genai", "google_vertexai"})
+# THE EMPTY-PART RULE, referenced throughout this module: the Gemini API rejects a
+# part that carries no payload, and on thinking-enabled turns the thought signature
+# *is* the payload it requires to be echoed back. A signature-only block is
+# therefore kept; a genuinely empty one is not.
+# (`ChatGoogleGenerativeAI._filter_messages` deliberately sends an empty text part
+# for Vertex AI, which is a separate, endpoint-specific allowance.)
 
 
-def _block_signature(block: Mapping[str, Any]) -> Any:
+def _decode_signature(sig: Any) -> bytes | None:
+    """Decode a thought signature to the raw bytes the Gemini API expects.
+
+    Signatures cross process boundaries base64-encoded (that is how they survive
+    JSON serialization in a checkpoint) but reach the API as bytes.
+
+    Args:
+        sig: A base64-encoded `str`, raw `bytes`, or any other value.
+
+    Returns:
+        The signature as bytes, or `None` if there is no usable signature.
+
+    Raises:
+        binascii.Error: If `sig` is a `str` that is not valid base64.
+    """
+    if isinstance(sig, str):
+        return base64.b64decode(sig) or None
+    if isinstance(sig, bytes):
+        return sig or None
+    return None
+
+
+def _drop_none(mapping: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return `mapping` without its `None` values, for splatting into a `Part` field.
+
+    Args:
+        mapping: The mapping to filter, or `None`.
+
+    Returns:
+        A new dict holding only the entries whose value is not `None`.
+    """
+    return {k: v for k, v in (mapping or {}).items() if v is not None}
+
+
+def _block_signature(block: Mapping[str, Any]) -> str | bytes | None:
     """Return the thought signature carried by a content block, if any.
 
     Signatures live at the top level on v0 `thinking` blocks and under `extras`
@@ -343,10 +387,9 @@ def _is_redundant_v1beta_part(block: Any) -> bool:
     """Whether an already-converted v1beta part must be dropped before conversion.
 
     Function calls are rebuilt from `message.tool_calls` so that they are emitted
-    exactly once, and the Gemini API rejects text parts that carry neither text
-    nor a thought signature. A part whose text is empty but which carries a
-    signature is kept: the signature is the payload Gemini requires to be echoed
-    back on thinking-enabled turns.
+    exactly once. Text parts are dropped per the empty-part rule near the top of
+    this module, so a part whose text is empty but which carries a signature is
+    kept.
 
     Args:
         block: A block from an `AIMessage` whose content was already projected to
@@ -366,6 +409,56 @@ def _is_redundant_v1beta_part(block: Any) -> bool:
         "thought",
         "thought_signature",
     } and not block.get("thought_signature")
+
+
+def _v1beta_dict_to_part(part: Mapping[str, Any]) -> Part | None:
+    """Convert an already-projected `generativelanguage_v1beta` dict to a `Part`.
+
+    `_convert_from_v1_to_generativelanguage_v1beta` projects v1 content blocks to
+    plain v1beta dicts, which carry no `type` key and so are identified by which
+    keys they hold. The `_parse_chat_history` tool-call branch routes v1-converted
+    content through here.
+
+    Args:
+        part: A mapping with no `type` key, as emitted by
+            `_convert_from_v1_to_generativelanguage_v1beta`.
+
+    Returns:
+        The corresponding `Part`, or `None` if `part` is not one of the shapes that
+        function emits.
+    """
+    if part.get("thought") is True and "text" in part:
+        # Projected from a v1 `reasoning` block.
+        return Part(
+            text=part["text"],
+            thought=True,
+            thought_signature=_decode_signature(part.get("thought_signature")),
+        )
+    if "inline_data" in part:
+        # Projected from a v1 `image`/`file` block carrying base64 data.
+        return Part(inline_data=Blob(**_drop_none(part["inline_data"])))
+    if "file_data" in part:
+        # Projected from a v1 `image`/`file` block carrying a URI.
+        return Part(file_data=FileData(**_drop_none(part["file_data"])))
+    if "executable_code" in part:
+        # Projected from a v1 `server_tool_call` (code_interpreter) block.
+        return Part(
+            executable_code=ExecutableCode(**_drop_none(part["executable_code"]))
+        )
+    if "code_execution_result" in part:
+        # Projected from a v1 `server_tool_result` (code_execution_result) block.
+        return Part(
+            code_execution_result=CodeExecutionResult(
+                **_drop_none(part["code_execution_result"])
+            )
+        )
+    if set(part) <= {"text", "thought_signature"} and isinstance(part.get("text"), str):
+        # Projected from a v1 `text` block, optionally carrying a signature.
+        return Part(
+            text=part["text"],
+            thought_signature=_decode_signature(part.get("thought_signature")),
+        )
+    return None
 
 
 def _merge_http_options(base: HttpOptions | None, override: HttpOptions) -> HttpOptions:
@@ -535,40 +628,15 @@ def _convert_to_parts(
         if isinstance(part, str):
             parts.append(Part(text=part))
         elif isinstance(part, Mapping):
-            if part.get("thought") is True and "text" in part:
-                # `thought` part produced by
-                # `_convert_from_v1_to_generativelanguage_v1beta` when unpacking a
-                # v1 `reasoning` block (the `_parse_chat_history` tool-call branch
-                # routes v1-converted content through here).
-                thought_sig = None
-                sig = part.get("thought_signature")
-                if isinstance(sig, str):
-                    thought_sig = base64.b64decode(sig)
-                elif isinstance(sig, bytes):
-                    thought_sig = sig
-                parts.append(
-                    Part(
-                        text=part["text"],
-                        thought=True,
-                        thought_signature=thought_sig,
-                    )
-                )
-            elif "type" in part:
+            if "type" in part:
                 if part["type"] == "text":
                     # Either old dict-style CC text block or new TextContentBlock
-                    # Check if there's a signature attached to this text block
-                    thought_sig = None
-                    if "extras" in part and isinstance(part["extras"], dict):
-                        sig = part["extras"].get("signature")
-                        if sig and isinstance(sig, str):
-                            # Decode base64-encoded signature back to bytes
-                            thought_sig = base64.b64decode(sig)
-                    if thought_sig:
-                        parts.append(
-                            Part(text=part["text"], thought_signature=thought_sig)
+                    parts.append(
+                        Part(
+                            text=part["text"],
+                            thought_signature=_decode_signature(_block_signature(part)),
                         )
-                    else:
-                        parts.append(Part(text=part["text"]))
+                    )
                 elif part.get("type") == "file" and "file_id" in part:
                     # Handle FileContentBlock with file_id (uploaded file reference)
                     mime_type = part.get("mime_type", "application/octet-stream")
@@ -743,27 +811,16 @@ def _convert_to_parts(
                     parts.append(Part(**media_part_kwargs))
                 elif part["type"] == "thinking":
                     # Pre-existing thinking block format that we continue to store as
-                    thought_sig = None
-                    if "signature" in part:
-                        sig = part["signature"]
-                        if sig and isinstance(sig, str):
-                            # Decode base64-encoded signature back to bytes
-                            thought_sig = base64.b64decode(sig)
                     parts.append(
                         Part(
                             text=part["thinking"],
                             thought=True,
-                            thought_signature=thought_sig,
+                            thought_signature=_decode_signature(_block_signature(part)),
                         )
                     )
                 elif part["type"] == "reasoning":
                     # ReasoningContentBlock (when output_version = "v1")
-                    extras = part.get("extras", {}) or {}
-                    sig = extras.get("signature")
-                    thought_sig = None
-                    if sig and isinstance(sig, str):
-                        # Decode base64-encoded signature back to bytes
-                        thought_sig = base64.b64decode(sig)
+                    thought_sig = _decode_signature(_block_signature(part))
                     reasoning_text = part.get("reasoning")
                     if reasoning_text is None:
                         # Foreign-provider reasoning block without a `reasoning`
@@ -881,53 +938,8 @@ def _convert_to_parts(
                 else:
                     msg = f"Unrecognized message part type: {part['type']}."
                     raise ValueError(msg)
-            elif "inline_data" in part or "file_data" in part:
-                # `inline_data`/`file_data` part produced by
-                # `_convert_from_v1_to_generativelanguage_v1beta` when unpacking
-                # v1 image/file content blocks (the `_parse_chat_history`
-                # tool-call branch routes v1-converted content through here).
-                media_data = part.get("inline_data") or part.get("file_data")
-                data_kwargs: dict[str, Any] = {
-                    k: v for k, v in (media_data or {}).items() if v is not None
-                }
-                if "inline_data" in part:
-                    parts.append(Part(inline_data=Blob(**data_kwargs)))
-                else:
-                    parts.append(Part(file_data=FileData(**data_kwargs)))
-            elif "executable_code" in part:
-                # Same already-converted v1beta shape, for `server_tool_call`
-                # (code_interpreter) blocks.
-                exec_kwargs: dict[str, Any] = {
-                    k: v
-                    for k, v in (part.get("executable_code") or {}).items()
-                    if v is not None
-                }
-                parts.append(Part(executable_code=ExecutableCode(**exec_kwargs)))
-            elif "code_execution_result" in part:
-                # Same already-converted v1beta shape, for `server_tool_result`
-                # (code_execution_result) blocks.
-                result_kwargs: dict[str, Any] = {
-                    k: v
-                    for k, v in (part.get("code_execution_result") or {}).items()
-                    if v is not None
-                }
-                parts.append(
-                    Part(code_execution_result=CodeExecutionResult(**result_kwargs))
-                )
-            elif set(part) <= {"text", "thought_signature"} and isinstance(
-                part.get("text"), str
-            ):
-                # `text` part produced by
-                # `_convert_from_v1_to_generativelanguage_v1beta` when unpacking
-                # v1 content blocks (no `type` key). The `_parse_chat_history`
-                # tool-call branch routes v1-converted content through here.
-                thought_sig = None
-                sig = part.get("thought_signature")
-                if isinstance(sig, str):
-                    thought_sig = base64.b64decode(sig)
-                elif isinstance(sig, bytes):
-                    thought_sig = sig
-                parts.append(Part(text=part["text"], thought_signature=thought_sig))
+            elif (v1beta_part := _v1beta_dict_to_part(part)) is not None:
+                parts.append(v1beta_part)
             else:
                 # Yolo. The input message content doesn't have a `type` key
                 logger.warning(
@@ -1033,104 +1045,245 @@ DUMMY_THOUGHT_SIGNATURE = _base64_to_bytes(
 )
 
 
-def _convert_to_parts_dropping_unconvertible(
+def _convert_to_parts_lenient(
     content: list[Any],
     model: str | None = None,
-    *,
-    drop_unconvertible: bool = True,
 ) -> list[Part]:
-    """Convert content to parts, dropping blocks that have no Gemini equivalent.
+    """Convert content to parts, dropping any block that fails to convert.
+
+    For content that may carry another provider's blocks, where an unconvertible
+    block is an expected occurrence in a multi-provider history rather than a
+    programming error. Native content is converted with `_convert_to_parts`
+    directly, so that a failure surfaces instead of silently changing the request.
+
+    Each block is converted on its own so that one unconvertible block does not
+    discard its neighbors. Note that a whole-list attempt cannot be used as a fast
+    path here: `_convert_to_parts` fetches remote media, so retrying after a
+    failure would re-download every image preceding the failing block.
 
     Args:
         content: The content blocks to convert.
         model: The model name, used for version-specific logic.
-        drop_unconvertible: Whether a block that fails to convert is dropped with a
-            warning (`True`, for content that may carry another provider's blocks,
-            where such a block is an expected occurrence rather than a programming
-            error) or raises `ValueError` (`False`, for native content, where a
-            conversion failure means malformed input that must not be silently
-            turned into a different request).
 
     Returns:
         The convertible blocks as parts, in their original order.
-
-    Raises:
-        ValueError: If `drop_unconvertible` is `False` and a block fails to
-            convert.
     """
-    # A batch that converts cleanly is the common case. When the batch raises,
-    # retry per block so that one unconvertible block does not discard the
-    # rest; in strict mode the failing block re-raises on its own retry.
-    try:
-        return _convert_to_parts(content, model=model)
-    except ValueError:
-        if not drop_unconvertible:
-            raise
-        parts: list[Part] = []
-        for block in content:
-            try:
-                parts.extend(_convert_to_parts([block], model=model))
-            except ValueError:
-                logger.warning(
-                    "Dropping content block that cannot be represented as a "
-                    "Gemini part (type: %s).",
-                    block.get("type") if isinstance(block, Mapping) else type(block),
-                )
-        return parts
+    parts: list[Part] = []
+    for block in content:
+        try:
+            parts.extend(_convert_to_parts([block], model=model))
+        except (ValueError, ChatGoogleGenerativeAIError) as exc:
+            # `ValueError` covers both the unrecognized-part-type error and the
+            # `pydantic.ValidationError`/`binascii.Error` raised by a malformed
+            # payload; `ChatGoogleGenerativeAIError` covers a block that is
+            # neither a string nor a mapping. The cause is logged because it is
+            # not always "Gemini has no equivalent" -- it may be an actionable
+            # message from media loading (e.g. a rejected local file path).
+            logger.warning(
+                "Dropping content block that cannot be represented as a Gemini "
+                "part (type: %s): %s",
+                block.get("type") if isinstance(block, Mapping) else type(block),
+                exc,
+            )
+    return parts
 
 
-def _prepare_content_for_tool_call_message(
-    message: AIMessage,
-) -> str | list[Any]:
+def _is_foreign_provider(message: AIMessage) -> bool:
+    """Whether `message` came from a provider whose blocks Gemini cannot consume.
+
+    A message with no `model_provider` is *not* foreign: hand-built messages and
+    checkpoints serialized before core stamped the field may hold Google's own
+    block shapes, and reading them as foreign would discard genuine signatures.
+    Contrast `_may_hold_foreign_blocks`, which deliberately answers the opposite
+    way for that case.
+
+    Args:
+        message: The message to classify.
+
+    Returns:
+        `True` if the message records a provider other than Google's.
+    """
+    model_provider = message.response_metadata.get("model_provider")
+    return model_provider is not None and model_provider not in _NATIVE_MODEL_PROVIDERS
+
+
+def _may_hold_foreign_blocks(message: AIMessage) -> bool:
+    """Whether conversion failures for `message` should be dropped rather than raised.
+
+    Answers `True` where `_is_foreign_provider` answers `False` for a message with
+    no `model_provider`: such a message is read as native (to preserve signatures)
+    but cannot be *trusted* to be native, so a conversion failure is dropped rather
+    than turned into an error the caller cannot act on.
+
+    Args:
+        message: The message to classify.
+
+    Returns:
+        `True` if the message is not known to have come from Google.
+    """
+    return message.response_metadata.get("model_provider") not in (
+        _NATIVE_MODEL_PROVIDERS
+    )
+
+
+def _has_provider_native_blocks(message: AIMessage) -> bool:
+    """Whether native `message` content holds raw Gemini block shapes.
+
+    Args:
+        message: The message to inspect.
+
+    Returns:
+        `True` if the content carries `function_call`/`file_data` blocks, which the
+        provider translator normalizes to standard tool-call and file blocks.
+    """
+    return isinstance(message.content, list) and any(
+        isinstance(block, dict) and block.get("type") in ("function_call", "file_data")
+        for block in message.content
+    )
+
+
+def _is_rebuilt_tool_call_block(block: Mapping[str, Any]) -> bool:
+    """Whether `block` is a function call that is rebuilt from `message.tool_calls`.
+
+    `_convert_to_parts` has no `tool_call` branch, so leaving these in would raise;
+    they would also duplicate every call. Foreign messages reach the filter via
+    `content_blocks`, which can include these blocks.
+
+    Args:
+        block: The content block to test.
+
+    Returns:
+        `True` if the block must be dropped.
+    """
+    return block.get("type") in ("tool_call", "tool_call_chunk", "invalid_tool_call")
+
+
+def _is_unsupported_foreign_server_tool(
+    block: Mapping[str, Any], code_interpreter_call_ids: Container[str]
+) -> bool:
+    """Whether `block` is another provider's server tool that Gemini cannot replay.
+
+    Code interpreter calls map onto Gemini's `executable_code`; nothing else does.
+    A result is kept only when its call was kept, so no orphan result is sent.
+
+    Args:
+        block: The content block to test.
+        code_interpreter_call_ids: Ids of the code-interpreter calls being kept.
+
+    Returns:
+        `True` if the block must be dropped.
+    """
+    block_type = block.get("type")
+    if block_type == "server_tool_call":
+        return block.get("name") != "code_interpreter"
+    if block_type == "server_tool_result":
+        return block.get("tool_call_id") not in code_interpreter_call_ids
+    return False
+
+
+def _strip_foreign_signature(block: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return `block` without any thought signature another provider attached.
+
+    Signatures from other providers are not meaningful to Google. Stripping must
+    happen before the empty-block check: a block whose only payload is a foreign
+    signature would otherwise survive on the strength of that signature and then
+    emit an empty part. See the empty-part rule near the top of this module.
+
+    Args:
+        block: The content block to strip.
+
+    Returns:
+        `block` unchanged if it carries no signature, otherwise a stripped copy.
+    """
+    extras = block.get("extras")
+    extras_has_signature = isinstance(extras, dict) and "signature" in extras
+    if "signature" not in block and not extras_has_signature:
+        return block
+    stripped: dict[str, Any] = {k: v for k, v in block.items() if k != "signature"}
+    if extras_has_signature:
+        stripped["extras"] = {
+            k: v for k, v in cast("dict[str, Any]", extras).items() if k != "signature"
+        }
+    return stripped
+
+
+def _is_empty_content_block(block: Mapping[str, Any]) -> bool:
+    """Whether `block` is a text/thought block with no payload at all.
+
+    Args:
+        block: The content block to test.
+
+    Returns:
+        `True` if the block carries neither text nor a thought signature, and so
+        must be dropped per the empty-part rule near the top of this module.
+    """
+    if block.get("type") not in ("text", "thinking", "reasoning"):
+        return False
+    has_text = (
+        block.get("text")
+        or block.get("thinking")
+        or block.get("reasoning")
+        or block.get("summary")
+    )
+    return not has_text and not _block_signature(block)
+
+
+def _as_gemini_file_block(block: Mapping[str, Any]) -> dict[str, Any]:
+    """Re-tag a standard file URL block as a Gemini file reference.
+
+    The native block translator represents Gemini `file_data` as a standard file
+    URL. Preserve the provider-owned URI as a file reference rather than trying to
+    download it as public HTTP content.
+
+    Args:
+        block: A `file` block carrying a `url`.
+
+    Returns:
+        The equivalent `media` block.
+    """
+    return {
+        "type": "media",
+        "file_uri": block["url"],
+        "mime_type": block.get("mime_type", "application/octet-stream"),
+    }
+
+
+def _prepare_content_for_tool_call_message(message: AIMessage) -> list[Any]:
     """Prepare `AIMessage` content for conversion when the message has tool calls.
 
     Strips valid and invalid function-call content blocks (valid calls are rebuilt
     from `message.tool_calls`) and normalizes another provider's blocks so that
-    conversion never crashes on shapes this package did not produce. Foreign server
-    tools are retained only for matched code-interpreter call/result pairs.
+    conversion does not raise on shapes this package did not produce. Foreign
+    code-interpreter calls are retained; their results only when matched.
 
     Args:
         message: The `AIMessage` whose content should be prepared.
 
     Returns:
-        The content to convert, with provider-native blocks normalized as needed,
-        function-call blocks removed, another provider's signatures stripped,
-        unmatched foreign server tool blocks dropped, and text/thought blocks that
-        carry neither text nor a signature dropped.
+        The content to convert as a list, with provider-native blocks normalized as
+        needed, function-call blocks removed, another provider's signatures
+        stripped, unreplayable foreign server tool blocks dropped, and text/thought
+        blocks that carry neither text nor a signature dropped. String content is
+        wrapped in a list (empty string yields an empty list, per the empty-part
+        rule near the top of this module).
     """
-    model_provider = message.response_metadata.get("model_provider")
-    is_foreign = (
-        model_provider is not None and model_provider not in _NATIVE_MODEL_PROVIDERS
+    is_foreign = _is_foreign_provider(message)
+    is_native = message.response_metadata.get("model_provider") in (
+        _NATIVE_MODEL_PROVIDERS
     )
-    is_native = model_provider in _NATIVE_MODEL_PROVIDERS
-    has_provider_native_blocks = (
-        is_native
-        and isinstance(message.content, list)
-        and any(
-            isinstance(block, dict)
-            and block.get("type") in ("function_call", "file_data")
-            for block in message.content
-        )
-    )
-    # Messages with no `model_provider` (hand-built messages, checkpoints serialized
-    # before core stamped the field) may hold either shape. Read `content` rather
-    # than `content_blocks` for those: core projects Google's own `thinking` and
-    # `media` blocks to `non_standard`, which would discard genuine signatures.
-    # Native Gemini `function_call` and `file_data` blocks are the exception: the
-    # provider translator normalizes them to standard tool-call and file blocks.
-    # `_convert_to_parts_dropping_unconvertible` handles any foreign block instead.
-    content = (
-        message.content_blocks
-        if is_foreign or has_provider_native_blocks
-        else message.content
-    )
+    # Read `content` rather than `content_blocks` for native and unstamped
+    # messages: core projects Google's own `thinking` and `media` blocks to
+    # `non_standard`, which would discard genuine signatures. Native Gemini
+    # `function_call` and `file_data` blocks are the exception -- the provider
+    # translator normalizes those to standard tool-call and file blocks.
+    read_blocks = is_foreign or (is_native and _has_provider_native_blocks(message))
+    content = message.content_blocks if read_blocks else message.content
 
     if not isinstance(content, list):
-        if isinstance(content, str) and not content:
-            # Normalize empty text to no content; it carries no information and
-            # the Gemini API rejects empty parts.
-            return []
-        return content
+        # A bare string is returned as a single-element list so that callers never
+        # have to re-handle the scalar case (iterating a `str` would yield one part
+        # per character). Empty text carries no information and is dropped.
+        return [content] if content else []
 
     code_interpreter_call_ids: set[str] = set()
     if is_foreign:
@@ -1147,70 +1300,23 @@ def _prepare_content_for_tool_call_message(
     for block in content:
         if not isinstance(block, dict):
             if isinstance(block, str) and not block:
-                # Skip empty text; it carries no information and the Gemini API
-                # rejects empty parts.
                 continue
             filtered.append(block)
             continue
 
-        block_type = block.get("type")
-        if block_type in ("tool_call", "tool_call_chunk", "invalid_tool_call"):
-            # Function calls are rebuilt from `message.tool_calls` below.
-            # `_convert_to_parts` has no `tool_call` branch, so leaving these in
-            # would raise; they would also duplicate every call. Foreign messages
-            # reach here via `content_blocks`, which does include these blocks.
+        if _is_rebuilt_tool_call_block(block):
             continue
-        if is_native and block_type == "file" and "url" in block:
-            # The native block translator represents Gemini `file_data` as a
-            # standard file URL. Preserve the provider-owned URI as a file reference
-            # rather than trying to download it as public HTTP content.
-            filtered.append(
-                {
-                    "type": "media",
-                    "file_uri": block["url"],
-                    "mime_type": block.get("mime_type", "application/octet-stream"),
-                }
-            )
+        if is_native and block.get("type") == "file" and "url" in block:
+            filtered.append(_as_gemini_file_block(block))
             continue
-        if is_foreign and block_type == "server_tool_call":
-            if block.get("name") != "code_interpreter":
+        candidate: Mapping[str, Any] = block
+        if is_foreign:
+            if _is_unsupported_foreign_server_tool(block, code_interpreter_call_ids):
                 continue
-        if (
-            is_foreign
-            and block_type == "server_tool_result"
-            and block.get("tool_call_id") not in code_interpreter_call_ids
-        ):
+            candidate = _strip_foreign_signature(block)
+        if _is_empty_content_block(candidate):
             continue
-        # Signatures from other providers are not meaningful to Google. Strip
-        # them before the emptiness check below: a block whose only payload is a
-        # foreign signature (e.g. an empty `text` block with `extras.signature`)
-        # would otherwise pass the check on the strength of that signature and
-        # then emit an empty part, which the Gemini API rejects.
-        if is_foreign and block_type in ("thinking", "text", "reasoning"):
-            stripped_block: dict[str, Any] = {
-                k: v for k, v in block.items() if k != "signature"
-            }
-            extras = stripped_block.get("extras")
-            if isinstance(extras, dict) and "signature" in extras:
-                stripped_block["extras"] = {
-                    k: v for k, v in extras.items() if k != "signature"
-                }
-            block = stripped_block
-        # Blocks with no text are dropped because the Gemini API rejects empty
-        # parts -- unless they carry a thought signature, which is itself the
-        # payload Gemini requires to be echoed back on thinking-enabled turns.
-        if (
-            block_type in ("text", "thinking", "reasoning")
-            and not (
-                block.get("text")
-                or block.get("thinking")
-                or block.get("reasoning")
-                or block.get("summary")
-            )
-            and not _block_signature(block)
-        ):
-            continue
-        filtered.append(block)
+        filtered.append(candidate)
     return filtered
 
 
@@ -1308,33 +1414,30 @@ def _parse_chat_history(
                     # per-block dropping of the non-v1 branch. Native v1 content
                     # stays strict -- a conversion failure there is malformed
                     # input that must not be silently rewritten.
-                    model_provider = message.response_metadata.get("model_provider")
-                    ai_message_parts.extend(
-                        _convert_to_parts_dropping_unconvertible(
-                            [
-                                block
-                                for block in message.content
-                                if not _is_redundant_v1beta_part(block)
-                            ],
-                            model=model,
-                            drop_unconvertible=(
-                                model_provider is None
-                                or model_provider not in _NATIVE_MODEL_PROVIDERS
-                            ),
-                        )
+                    v1_blocks = [
+                        block
+                        for block in message.content
+                        if not _is_redundant_v1beta_part(block)
+                    ]
+                    convert = (
+                        _convert_to_parts_lenient
+                        if _may_hold_foreign_blocks(message)
+                        else _convert_to_parts
                     )
+                    ai_message_parts.extend(convert(v1_blocks, model=model))
                 else:
-                    model_provider = message.response_metadata.get("model_provider")
+                    # Only another provider's blocks may fail to convert; a block
+                    # from a message known to be Google's is malformed input, and
+                    # must surface rather than silently change the request.
+                    convert = (
+                        _convert_to_parts_lenient
+                        if _may_hold_foreign_blocks(message)
+                        else _convert_to_parts
+                    )
                     ai_message_parts.extend(
-                        _convert_to_parts_dropping_unconvertible(
-                            _prepare_content_for_tool_call_message(message),  # type: ignore[arg-type]
+                        convert(
+                            _prepare_content_for_tool_call_message(message),
                             model=model,
-                            # Only another provider's blocks may fail to convert;
-                            # a native block that fails is malformed input.
-                            drop_unconvertible=(
-                                model_provider is None
-                                or model_provider not in _NATIVE_MODEL_PROVIDERS
-                            ),
                         )
                     )
 

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -155,6 +155,9 @@ _FunctionDeclarationType = FunctionDeclaration | dict[str, Any] | Callable[..., 
 _FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY = (
     "__gemini_function_call_thought_signatures__"
 )
+_GEMINI_NATIVE_NON_STANDARD_TYPES = frozenset(
+    {"media", "thinking", "executable_code", "code_execution_result"}
+)
 
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
 
@@ -887,20 +890,21 @@ def _convert_to_parts(
                     )
                     parts.append(code_execution_result_part)
                 elif part["type"] == "non_standard":
-                    # Provider-specific payload that LangChain core could not map
-                    # to a standard content block (e.g. Anthropic's
-                    # `redacted_thinking`). Such payloads are only meaningful to
-                    # the provider that produced them, so there is nothing Gemini
-                    # can do with them. Drop rather than raise: an unconvertible
-                    # block from another provider is an expected occurrence in a
-                    # multi-provider history, not a programming error.
-                    logger.warning(
-                        "Dropping non-standard content block that cannot be "
-                        "represented as a Gemini part (inner type: %s).",
-                        (part.get("value") or {}).get("type")
-                        if isinstance(part.get("value"), Mapping)
-                        else None,
-                    )
+                    value = part.get("value")
+                    if (
+                        isinstance(value, Mapping)
+                        and value.get("type") in _GEMINI_NATIVE_NON_STANDARD_TYPES
+                    ):
+                        # Core wraps Gemini-native blocks it cannot standardize.
+                        # Unwrap only known shapes; malformed native values must
+                        # still raise rather than silently changing the request.
+                        parts.extend(_convert_to_parts([dict(value)], model=model))
+                    else:
+                        logger.warning(
+                            "Dropping non-standard content block that cannot be "
+                            "represented as a Gemini part (inner type: %s).",
+                            value.get("type") if isinstance(value, Mapping) else None,
+                        )
                 else:
                     msg = f"Unrecognized message part type: {part['type']}."
                     raise ValueError(msg)
@@ -1310,6 +1314,14 @@ def _prepare_content_for_tool_call_message(message: AIMessage) -> list[Any]:
         if _is_rebuilt_tool_call_block(block):
             continue
         block_type = block.get("type")
+        if is_foreign and block_type == "non_standard":
+            value = block.get("value")
+            logger.warning(
+                "Dropping non-standard content block that cannot be represented "
+                "as a Gemini part (inner type: %s).",
+                value.get("type") if isinstance(value, Mapping) else None,
+            )
+            continue
         if block_type == "function_call":
             # Raw Gemini function call: the equivalent part is rebuilt from
             # `message.tool_calls`, so the block must not be converted twice.

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -810,6 +810,21 @@ def _convert_to_parts(
                         )
                     )
                     parts.append(code_execution_result_part)
+                elif part["type"] == "non_standard":
+                    # Provider-specific payload that LangChain core could not map
+                    # to a standard content block (e.g. Anthropic's
+                    # `redacted_thinking`). Such payloads are only meaningful to
+                    # the provider that produced them, so there is nothing Gemini
+                    # can do with them. Drop rather than raise: an unconvertible
+                    # block from another provider is an expected occurrence in a
+                    # multi-provider history, not a programming error.
+                    logger.warning(
+                        "Dropping non-standard content block that cannot be "
+                        "represented as a Gemini part (inner type: %s).",
+                        (part.get("value") or {}).get("type")
+                        if isinstance(part.get("value"), Mapping)
+                        else None,
+                    )
                 else:
                     msg = f"Unrecognized message part type: {part['type']}."
                     raise ValueError(msg)

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -528,6 +528,8 @@ def _validate_video_metadata(video_metadata: object) -> None:
 def _convert_to_parts(
     raw_content: str | Sequence[str | dict],
     model: str | None = None,
+    *,
+    allow_v1beta_dicts: bool = False,
 ) -> list[Part]:
     """Converts LangChain message content into `generativelanguage_v1beta` parts.
 
@@ -535,6 +537,14 @@ def _convert_to_parts(
 
     Handles both legacy (pre-v1) dict-based content blocks and v1 `ContentBlock`
     objects.
+
+    Args:
+        raw_content: Message content to convert.
+        model: Model name used for version-specific conversion behavior.
+        allow_v1beta_dicts: Whether to validate type-less projected v1beta mappings.
+
+    Returns:
+        Gemini parts representing the message content.
     """
     content = [raw_content] if isinstance(raw_content, str) else raw_content
     image_loader = ImageBytesLoader()
@@ -849,7 +859,13 @@ def _convert_to_parts(
                         # Core wraps Gemini-native blocks it cannot standardize.
                         # Unwrap only known shapes; malformed native values must
                         # still raise rather than silently changing the request.
-                        parts.extend(_convert_to_parts([dict(value)], model=model))
+                        parts.extend(
+                            _convert_to_parts(
+                                [dict(value)],
+                                model=model,
+                                allow_v1beta_dicts=allow_v1beta_dicts,
+                            )
+                        )
                     else:
                         logger.warning(
                             "Dropping non-standard content block that cannot be "
@@ -859,7 +875,10 @@ def _convert_to_parts(
                 else:
                     msg = f"Unrecognized message part type: {part['type']}."
                     raise ValueError(msg)
-            elif (v1beta_part := _v1beta_dict_to_part(part)) is not None:
+            elif (
+                allow_v1beta_dicts
+                and (v1beta_part := _v1beta_dict_to_part(part)) is not None
+            ):
                 parts.append(v1beta_part)
             else:
                 # Yolo. The input message content doesn't have a `type` key
@@ -969,16 +988,32 @@ DUMMY_THOUGHT_SIGNATURE = _base64_to_bytes(
 def _convert_to_parts_lenient(
     content: list[Any],
     model: str | None = None,
+    *,
+    allow_v1beta_dicts: bool = False,
 ) -> list[Part]:
     """Convert foreign content one block at a time, dropping invalid blocks.
 
     Per-block conversion preserves valid neighbors without retrying media downloads
     that occurred before a failing block.
+
+    Args:
+        content: Message content blocks to convert.
+        model: Model name used for version-specific conversion behavior.
+        allow_v1beta_dicts: Whether to validate type-less projected v1beta mappings.
+
+    Returns:
+        Valid Gemini parts from the supplied content.
     """
     parts: list[Part] = []
     for block in content:
         try:
-            parts.extend(_convert_to_parts([block], model=model))
+            parts.extend(
+                _convert_to_parts(
+                    [block],
+                    model=model,
+                    allow_v1beta_dicts=allow_v1beta_dicts,
+                )
+            )
         except (ValueError, ChatGoogleGenerativeAIError) as exc:
             logger.warning(
                 "Dropping content block that cannot be represented as a Gemini "
@@ -1208,7 +1243,8 @@ def _convert_ai_message_content(
     provider_kind = _classify_model_provider(
         message.response_metadata.get("model_provider")
     )
-    if message.response_metadata.get("output_version") == "v1":
+    is_v1_content = message.response_metadata.get("output_version") == "v1"
+    if is_v1_content:
         content: list[Any] = _convert_from_v1_to_generativelanguage_v1beta(
             cast("list[types.ContentBlock]", message.content),
             message.response_metadata.get("model_provider"),
@@ -1231,7 +1267,11 @@ def _convert_ai_message_content(
     convert = (
         _convert_to_parts if provider_kind == "native" else _convert_to_parts_lenient
     )
-    return convert(content, model=model)
+    return convert(
+        content,
+        model=model,
+        allow_v1beta_dicts=is_v1_content,
+    )
 
 
 def _parse_chat_history(

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1086,7 +1086,43 @@ def _is_rebuilt_tool_call_block(block: Mapping[str, Any]) -> bool:
     Returns:
         `True` if the block must be dropped.
     """
-    return block.get("type") in ("tool_call", "tool_call_chunk", "invalid_tool_call")
+    return block.get("type") in (
+        "tool_call",
+        "tool_call_chunk",
+        "invalid_tool_call",
+        "function_call_signature",
+    )
+
+
+def _function_call_signatures_from_content(
+    message: AIMessage,
+) -> dict[int, str | bytes]:
+    """Extract legacy function-call signature sidecars from message content.
+
+    Args:
+        message: AI message whose tool calls are being rebuilt.
+
+    Returns:
+        Signature values keyed by their corresponding tool-call index.
+    """
+    if _classify_model_provider(
+        message.response_metadata.get("model_provider")
+    ) == "foreign" or not isinstance(message.content, list):
+        return {}
+    signatures: dict[int, str | bytes] = {}
+    for content_index, block in enumerate(message.content):
+        if (
+            not isinstance(block, Mapping)
+            or block.get("type") != "function_call_signature"
+        ):
+            continue
+        signature = block.get("signature")
+        if not isinstance(signature, (str, bytes)) or not signature:
+            continue
+        tool_call_index = block.get("index", content_index)
+        if isinstance(tool_call_index, int):
+            signatures[tool_call_index] = signature
+    return signatures
 
 
 def _is_unsupported_foreign_server_tool(
@@ -1412,21 +1448,28 @@ def _parse_chat_history(
                 )
 
                 # Then, add function call parts
-                function_call_sigs: dict[Any, str] = message.additional_kwargs.get(
-                    _FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY, {}
+                function_call_sigs: dict[Any, str | bytes] = (
+                    message.additional_kwargs.get(
+                        _FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY, {}
+                    )
                 )
-                for tool_call in message.tool_calls:
+                indexed_function_call_sigs = _function_call_signatures_from_content(
+                    message
+                )
+                for tool_call_index, tool_call in enumerate(message.tool_calls):
                     function_call = FunctionCall(
                         name=tool_call["name"],
                         args=tool_call["args"],
                     )
                     # Check if there's a signature for this function call
-                    sig = function_call_sigs.get(tool_call.get("id"))
+                    sig = function_call_sigs.get(
+                        tool_call.get("id")
+                    ) or indexed_function_call_sigs.get(tool_call_index)
                     if sig:
                         ai_message_parts.append(
                             Part(
                                 function_call=function_call,
-                                thought_signature=_base64_to_bytes(sig),
+                                thought_signature=_decode_signature(sig),
                             )
                         )
                     else:

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1152,6 +1152,21 @@ def _prepare_content_for_tool_call_message(
             and block.get("tool_call_id") not in code_interpreter_call_ids
         ):
             continue
+        # Signatures from other providers are not meaningful to Google. Strip
+        # them before the emptiness check below: a block whose only payload is a
+        # foreign signature (e.g. an empty `text` block with `extras.signature`)
+        # would otherwise pass the check on the strength of that signature and
+        # then emit an empty part, which the Gemini API rejects.
+        if is_foreign and block_type in ("thinking", "text", "reasoning"):
+            stripped_block: dict[str, Any] = {
+                k: v for k, v in block.items() if k != "signature"
+            }
+            extras = stripped_block.get("extras")
+            if isinstance(extras, dict) and "signature" in extras:
+                stripped_block["extras"] = {
+                    k: v for k, v in extras.items() if k != "signature"
+                }
+            block = stripped_block
         # Blocks with no text are dropped because the Gemini API rejects empty
         # parts -- unless they carry a thought signature, which is itself the
         # payload Gemini requires to be echoed back on thinking-enabled turns.
@@ -1165,20 +1180,6 @@ def _prepare_content_for_tool_call_message(
             )
             and not _block_signature(block)
         ):
-            continue
-        # Signatures from other providers are not meaningful to Google. Strip them
-        # from reasoning blocks whether the block carries reasoning text or a
-        # summary.
-        if is_foreign and block_type in ("thinking", "text", "reasoning"):
-            sanitized_block: dict[str, Any] = {
-                k: v for k, v in block.items() if k != "signature"
-            }
-            extras = sanitized_block.get("extras")
-            if isinstance(extras, dict) and "signature" in extras:
-                sanitized_block["extras"] = {
-                    k: v for k, v in extras.items() if k != "signature"
-                }
-            filtered.append(sanitized_block)
             continue
         filtered.append(block)
     return filtered

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -482,7 +482,25 @@ def _convert_to_parts(
         if isinstance(part, str):
             parts.append(Part(text=part))
         elif isinstance(part, Mapping):
-            if "type" in part:
+            if part.get("thought") is True and "text" in part:
+                # `thought` part produced by
+                # `_convert_from_v1_to_generativelanguage_v1beta` when unpacking a
+                # v1 `reasoning` block (the `_parse_chat_history` tool-call branch
+                # routes v1-converted content through here).
+                thought_sig = None
+                sig = part.get("thought_signature")
+                if isinstance(sig, str):
+                    thought_sig = base64.b64decode(sig)
+                elif isinstance(sig, bytes):
+                    thought_sig = sig
+                parts.append(
+                    Part(
+                        text=part["text"],
+                        thought=True,
+                        thought_signature=thought_sig,
+                    )
+                )
+            elif "type" in part:
                 if part["type"] == "text":
                     # Either old dict-style CC text block or new TextContentBlock
                     # Check if there's a signature attached to this text block
@@ -693,9 +711,23 @@ def _convert_to_parts(
                     if sig and isinstance(sig, str):
                         # Decode base64-encoded signature back to bytes
                         thought_sig = base64.b64decode(sig)
+                    reasoning_text = part.get("reasoning")
+                    if reasoning_text is None:
+                        # Foreign-provider reasoning block without a `reasoning`
+                        # key (e.g. OpenAI's `summary` shape). Extract summary
+                        # text when possible; otherwise drop the block.
+                        summary = part.get("summary")
+                        if isinstance(summary, list):
+                            reasoning_text = "".join(
+                                item.get("text", "")
+                                for item in summary
+                                if isinstance(item, dict)
+                            )
+                        else:
+                            continue
                     parts.append(
                         Part(
-                            text=part["reasoning"],
+                            text=reasoning_text,
                             thought=True,
                             thought_signature=thought_sig,
                         )
@@ -781,6 +813,20 @@ def _convert_to_parts(
                 else:
                     msg = f"Unrecognized message part type: {part['type']}."
                     raise ValueError(msg)
+            elif set(part) <= {"text", "thought_signature"} and isinstance(
+                part.get("text"), str
+            ):
+                # `text` part produced by
+                # `_convert_from_v1_to_generativelanguage_v1beta` when unpacking
+                # v1 content blocks (no `type` key). The `_parse_chat_history`
+                # tool-call branch routes v1-converted content through here.
+                thought_sig = None
+                sig = part.get("thought_signature")
+                if isinstance(sig, str):
+                    thought_sig = base64.b64decode(sig)
+                elif isinstance(sig, bytes):
+                    thought_sig = sig
+                parts.append(Part(text=part["text"], thought_signature=thought_sig))
             else:
                 # Yolo. The input message content doesn't have a `type` key
                 logger.warning(
@@ -886,6 +932,71 @@ DUMMY_THOUGHT_SIGNATURE = _base64_to_bytes(
 )
 
 
+def _prepare_content_for_tool_call_message(
+    message: AIMessage,
+) -> str | list[Any]:
+    """Prepare `AIMessage` content for conversion when the message has tool calls.
+
+    Strips content blocks that are rebuilt from `message.tool_calls` instead
+    (function calls must be emitted exactly once) and normalizes foreign-provider
+    reasoning blocks so conversion never crashes on shapes this package did not
+    produce.
+
+    Args:
+        message: The `AIMessage` whose content should be prepared.
+
+    Returns:
+        The message content, with `tool_call`/`tool_call_chunk` blocks removed
+        and unrepresentable reasoning blocks dropped.
+    """
+    if not isinstance(message.content, list):
+        if isinstance(message.content, str) and not message.content:
+            # Normalize empty text to no content; it carries no information and
+            # the Gemini API rejects empty parts.
+            return []
+        return message.content
+
+    model_provider = message.response_metadata.get("model_provider")
+    is_foreign = model_provider is not None and model_provider != "google_genai"
+    filtered: list[Any] = []
+    for block in message.content:
+        if not isinstance(block, dict):
+            if isinstance(block, str) and not block:
+                # Skip empty text; it carries no information and the Gemini API
+                # rejects empty parts.
+                continue
+            filtered.append(block)
+            continue
+
+        block_type = block.get("type")
+        if block_type in ("tool_call", "tool_call_chunk"):
+            # Function-call parts are emitted from `message.tool_calls`; the
+            # v1 converter also translates these blocks, so including them here
+            # would duplicate each function call.
+            continue
+        if block_type == "reasoning" and "reasoning" not in block and not is_foreign:
+            # Reasoning block in a shape `_convert_to_parts` cannot represent
+            # (e.g. OpenAI's `summary` blocks on a message without provider
+            # metadata). Drop rather than crash. Foreign-provider messages get
+            # no filtering here so summary text can still be converted below.
+            continue
+        if is_foreign and (
+            block_type in ("thinking", "text")
+            or (
+                # A foreign reasoning block's signature is unusable by Google;
+                # strip it whether the block carries reasoning text or a summary.
+                block_type == "reasoning"
+            )
+        ):
+            # Signatures from other providers are not meaningful to Google.
+            block = {k: v for k, v in block.items() if k != "signature"}
+            extras = block.get("extras")
+            if isinstance(extras, dict) and "signature" in extras:
+                block["extras"] = {k: v for k, v in extras.items() if k != "signature"}
+        filtered.append(block)
+    return filtered
+
+
 def _parse_chat_history(
     input_messages: Sequence[BaseMessage],
     convert_system_message_to_human: bool = False,
@@ -963,42 +1074,34 @@ def _parse_chat_history(
             if message.tool_calls:
                 ai_message_parts = []
 
-                # First, include thinking blocks from content if present.
+                # First, convert all non-function-call content (text, thinking,
+                # reasoning, media, etc.) through the unified conversion path.
                 # When include_thoughts=True, thinking blocks need to be preserved
                 # when passing messages back to the API.
-                if isinstance(message.content, list):
-                    for content_block in message.content:
-                        if isinstance(content_block, dict):
-                            block_type = content_block.get("type")
-                            if block_type == "thinking":
-                                # v0 output_format thinking block
-                                thought_sig = None
-                                if "signature" in content_block:
-                                    sig = content_block["signature"]
-                                    if sig and isinstance(sig, str):
-                                        thought_sig = base64.b64decode(sig)
-                                ai_message_parts.append(
-                                    Part(
-                                        text=content_block["thinking"],
-                                        thought=True,
-                                        thought_signature=thought_sig,
-                                    )
+                if message.response_metadata.get("output_version") == "v1":
+                    # Content was already converted to v1beta dicts above by
+                    # `_convert_from_v1_to_generativelanguage_v1beta`. Keep
+                    # non-function-call blocks (function calls are rebuilt from
+                    # `message.tool_calls` below so they are emitted exactly once).
+                    ai_message_parts.extend(
+                        _convert_to_parts(
+                            [
+                                block
+                                for block in message.content
+                                if not (
+                                    isinstance(block, dict) and "function_call" in block
                                 )
-                            elif block_type == "reasoning":
-                                # v1 output_format reasoning block
-                                # (Stored in extras, and different type key)
-                                extras = content_block.get("extras", {}) or {}
-                                sig = extras.get("signature")
-                                thought_sig = None
-                                if sig and isinstance(sig, str):
-                                    thought_sig = base64.b64decode(sig)
-                                ai_message_parts.append(
-                                    Part(
-                                        text=content_block["reasoning"],
-                                        thought=True,
-                                        thought_signature=thought_sig,
-                                    )
-                                )
+                            ],
+                            model=model,
+                        )
+                    )
+                else:
+                    ai_message_parts.extend(
+                        _convert_to_parts(
+                            _prepare_content_for_tool_call_message(message),
+                            model=model,
+                        )
+                    )
 
                 # Then, add function call parts
                 function_call_sigs: dict[Any, str] = message.additional_kwargs.get(

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -131,6 +131,7 @@ from langchain_google_genai._common import (
 from langchain_google_genai._compat import (
     _classify_model_provider,
     _convert_from_v1_to_generativelanguage_v1beta,
+    _is_file_uri_supported,
 )
 from langchain_google_genai._function_utils import (
     _tool_choice_to_tool_config,
@@ -1163,6 +1164,55 @@ def _is_empty_content_block(block: Mapping[str, Any]) -> bool:
     return not has_text and not _block_signature(block)
 
 
+def _content_block_file_uri(block: Any) -> Any:
+    """Return the file URI carried by any supported content-block shape.
+
+    Args:
+        block: Raw, standardized, or projected content block.
+
+    Returns:
+        The block's file URI or `None` when it has no file reference.
+    """
+    if not isinstance(block, Mapping):
+        return None
+    file_data = block.get("file_data")
+    if isinstance(file_data, Mapping):
+        return file_data.get("file_uri")
+    block_type = block.get("type")
+    if block_type in ("file_data", "media"):
+        return block.get("file_uri")
+    if block_type == "file":
+        return block.get("file_id") or block.get("url")
+    if block_type == "image":
+        return block.get("url")
+    return None
+
+
+def _drop_unsupported_file_references(
+    content: list[Any], *, use_vertexai: bool
+) -> list[Any]:
+    """Drop history file references that the target backend cannot consume.
+
+    Args:
+        content: Prepared AI-message content blocks.
+        use_vertexai: Whether the target is the Vertex AI backend.
+
+    Returns:
+        Content without backend-specific file references unsupported by the target.
+    """
+    filtered: list[Any] = []
+    for block in content:
+        file_uri = _content_block_file_uri(block)
+        if not _is_file_uri_supported(file_uri, use_vertexai=use_vertexai):
+            logger.warning(
+                "Dropping Google Cloud Storage file URI from chat history because "
+                "the target Gemini Developer API does not support gs:// references."
+            )
+            continue
+        filtered.append(block)
+    return filtered
+
+
 def _prepare_content_for_tool_call_message(message: AIMessage) -> list[Any]:
     """Prepare `AIMessage` content for conversion when the message has tool calls.
 
@@ -1248,6 +1298,7 @@ def _convert_ai_message_content(
     model: str | None,
     *,
     exclude_function_calls: bool,
+    use_vertexai: bool,
 ) -> list[Part]:
     """Convert an AI message's non-authoritative content to Gemini parts.
 
@@ -1260,6 +1311,7 @@ def _convert_ai_message_content(
         model: The target model name, used for version-specific media behavior.
         exclude_function_calls: Whether function-call blocks should be omitted
             because they will be rebuilt from `message.tool_calls`.
+        use_vertexai: Whether the target is the Vertex AI backend.
 
     Returns:
         Converted Gemini parts.
@@ -1271,6 +1323,7 @@ def _convert_ai_message_content(
         content: list[Any] = _convert_from_v1_to_generativelanguage_v1beta(
             cast("list[types.ContentBlock]", message.content),
             message.response_metadata.get("model_provider"),
+            use_vertexai=use_vertexai,
         )
         if exclude_function_calls:
             content = [
@@ -1283,6 +1336,7 @@ def _convert_ai_message_content(
             [message.content] if isinstance(message.content, str) else message.content
         )
 
+    content = _drop_unsupported_file_references(content, use_vertexai=use_vertexai)
     convert = (
         _convert_to_parts if provider_kind == "native" else _convert_to_parts_lenient
     )
@@ -1293,6 +1347,8 @@ def _parse_chat_history(
     input_messages: Sequence[BaseMessage],
     convert_system_message_to_human: bool = False,
     model: str | None = None,
+    *,
+    use_vertexai: bool = False,
 ) -> tuple[Content | None, list[Content]]:
     """Parses sequence of `BaseMessage` into system instruction and formatted messages.
 
@@ -1302,6 +1358,7 @@ def _parse_chat_history(
 
             Whether to convert the first system message into a `HumanMessage`.
         model: The model name, used for version-specific logic.
+        use_vertexai: Whether the target is the Vertex AI backend.
 
     Returns:
         A tuple containing:
@@ -1351,6 +1408,7 @@ def _parse_chat_history(
                     message,
                     model,
                     exclude_function_calls=True,
+                    use_vertexai=use_vertexai,
                 )
 
                 # Then, add function call parts
@@ -1398,6 +1456,7 @@ def _parse_chat_history(
                     message,
                     model,
                     exclude_function_calls=False,
+                    use_vertexai=use_vertexai,
                 )
             else:
                 # Prepare request content parts from message.content field
@@ -3510,6 +3569,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             filtered_messages,
             convert_system_message_to_human=self.convert_system_message_to_human,
             model=self.model,
+            use_vertexai=self._use_vertexai,  # type: ignore[attr-defined]
         )
         if (
             _uses_fixed_sampling_and_disallows_prefill(self.model)

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1058,12 +1058,14 @@ def _convert_to_parts_dropping_unconvertible(
         ValueError: If `drop_unconvertible` is `False` and a block fails to
             convert.
     """
-    if not drop_unconvertible:
-        return _convert_to_parts(content, model=model)
+    # A batch that converts cleanly is the common case. When the batch raises,
+    # retry per block so that one unconvertible block does not discard the
+    # rest; in strict mode the failing block re-raises on its own retry.
     try:
         return _convert_to_parts(content, model=model)
     except ValueError:
-        # Retry per block so that one unconvertible block does not discard the rest.
+        if not drop_unconvertible:
+            raise
         parts: list[Part] = []
         for block in content:
             try:
@@ -1271,6 +1273,15 @@ def _parse_chat_history(
                     # `_convert_from_v1_to_generativelanguage_v1beta`, so these
                     # blocks carry no `type` key and need their own filter rather
                     # than `_prepare_content_for_tool_call_message`.
+                    #
+                    # `_compat` drops unconvertible foreign block types, but it
+                    # does not validate converted media payloads: another
+                    # provider's malformed `image`/`file` base64 still reaches
+                    # `Blob` here, so foreign v1 messages keep the tolerant
+                    # per-block dropping of the non-v1 branch. Native v1 content
+                    # stays strict -- a conversion failure there is malformed
+                    # input that must not be silently rewritten.
+                    model_provider = message.response_metadata.get("model_provider")
                     ai_message_parts.extend(
                         _convert_to_parts_dropping_unconvertible(
                             [
@@ -1279,11 +1290,10 @@ def _parse_chat_history(
                                 if not _is_redundant_v1beta_part(block)
                             ],
                             model=model,
-                            # v1 conversion in `_compat` already dropped
-                            # unconvertible blocks from other providers; what
-                            # remains is representable, so a failure here means
-                            # malformed content and must surface.
-                            drop_unconvertible=False,
+                            drop_unconvertible=(
+                                model_provider is None
+                                or model_provider not in _NATIVE_MODEL_PROVIDERS
+                            ),
                         )
                     )
                 else:

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1114,7 +1114,8 @@ def _function_call_signatures_from_content(
     ) == "foreign" or not isinstance(message.content, list):
         return {}
     signatures: dict[int, str | bytes] = {}
-    for content_index, block in enumerate(message.content):
+    signature_ordinal = 0
+    for block in message.content:
         if (
             not isinstance(block, Mapping)
             or block.get("type") != "function_call_signature"
@@ -1123,7 +1124,11 @@ def _function_call_signatures_from_content(
         signature = block.get("signature")
         if not isinstance(signature, (str, bytes)) or not signature:
             continue
-        tool_call_index = block.get("index", content_index)
+        # Early signature sidecars did not include an index and were appended after
+        # other content. Their position in the full content list therefore does not
+        # identify the corresponding entry in `message.tool_calls`.
+        tool_call_index = block.get("index", signature_ordinal)
+        signature_ordinal += 1
         if isinstance(tool_call_index, int):
             signatures[tool_call_index] = signature
     return signatures

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1230,6 +1230,11 @@ def _content_block_file_uri(block: Any) -> Any:
         return block.get("file_id") or block.get("url")
     if block_type == "image":
         return block.get("url")
+    if block_type == "image_url":
+        image_url = block.get("image_url")
+        if isinstance(image_url, Mapping):
+            return image_url.get("url")
+        return image_url
     return None
 
 

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -1034,22 +1034,32 @@ DUMMY_THOUGHT_SIGNATURE = _base64_to_bytes(
 
 
 def _convert_to_parts_dropping_unconvertible(
-    content: list[Any], model: str | None = None
+    content: list[Any],
+    model: str | None = None,
+    *,
+    drop_unconvertible: bool = True,
 ) -> list[Part]:
     """Convert content to parts, dropping blocks that have no Gemini equivalent.
-
-    Used for `AIMessage`s that may carry another provider's content blocks. Such a
-    block is an expected occurrence in a multi-provider history rather than a
-    programming error, so it is dropped with a warning instead of raising. Blocks
-    that do convert are unaffected.
 
     Args:
         content: The content blocks to convert.
         model: The model name, used for version-specific logic.
+        drop_unconvertible: Whether a block that fails to convert is dropped with a
+            warning (`True`, for content that may carry another provider's blocks,
+            where such a block is an expected occurrence rather than a programming
+            error) or raises `ValueError` (`False`, for native content, where a
+            conversion failure means malformed input that must not be silently
+            turned into a different request).
 
     Returns:
         The convertible blocks as parts, in their original order.
+
+    Raises:
+        ValueError: If `drop_unconvertible` is `False` and a block fails to
+            convert.
     """
+    if not drop_unconvertible:
+        return _convert_to_parts(content, model=model)
     try:
         return _convert_to_parts(content, model=model)
     except ValueError:
@@ -1268,13 +1278,25 @@ def _parse_chat_history(
                                 if not _is_redundant_v1beta_part(block)
                             ],
                             model=model,
+                            # v1 conversion in `_compat` already dropped
+                            # unconvertible blocks from other providers; what
+                            # remains is representable, so a failure here means
+                            # malformed content and must surface.
+                            drop_unconvertible=False,
                         )
                     )
                 else:
+                    model_provider = message.response_metadata.get("model_provider")
                     ai_message_parts.extend(
                         _convert_to_parts_dropping_unconvertible(
                             _prepare_content_for_tool_call_message(message),  # type: ignore[arg-type]
                             model=model,
+                            # Only another provider's blocks may fail to convert;
+                            # a native block that fails is malformed input.
+                            drop_unconvertible=(
+                                model_provider is None
+                                or model_provider not in _NATIVE_MODEL_PROVIDERS
+                            ),
                         )
                     )
 

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -356,8 +356,9 @@ def _decode_signature(sig: Any) -> bytes | None:
 def _block_signature(block: Mapping[str, Any]) -> str | bytes | None:
     """Return the thought signature carried by a content block, if any.
 
-    Signatures live at the top level on v0 `thinking` blocks and under `extras`
-    on v1 `reasoning` and `text` blocks.
+    Signatures live under `thought_signature` on Vertex text blocks, at the top
+    level under `signature` on v0 `thinking` blocks, and under `extras` on v1
+    `reasoning` and `text` blocks.
 
     Args:
         block: The content block to inspect.
@@ -366,8 +367,10 @@ def _block_signature(block: Mapping[str, Any]) -> str | bytes | None:
         The signature value, or `None` if the block carries none.
     """
     extras = block.get("extras")
-    return block.get("signature") or (
-        extras.get("signature") if isinstance(extras, Mapping) else None
+    return (
+        block.get("thought_signature")
+        or block.get("signature")
+        or (extras.get("signature") if isinstance(extras, Mapping) else None)
     )
 
 
@@ -1124,9 +1127,14 @@ def _strip_foreign_signature(block: Mapping[str, Any]) -> Mapping[str, Any]:
     """
     extras = block.get("extras")
     extras_has_signature = isinstance(extras, dict) and "signature" in extras
-    if "signature" not in block and not extras_has_signature:
+    if (
+        not {"signature", "thought_signature"}.intersection(block)
+        and not extras_has_signature
+    ):
         return block
-    stripped: dict[str, Any] = {k: v for k, v in block.items() if k != "signature"}
+    stripped: dict[str, Any] = {
+        k: v for k, v in block.items() if k not in ("signature", "thought_signature")
+    }
     if extras_has_signature:
         stripped["extras"] = {
             k: v for k, v in cast("dict[str, Any]", extras).items() if k != "signature"

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -723,7 +723,7 @@ def _convert_to_parts(
                                 for item in summary
                                 if isinstance(item, dict)
                             )
-                        else:
+                        if not reasoning_text:
                             continue
                     parts.append(
                         Part(
@@ -813,6 +813,39 @@ def _convert_to_parts(
                 else:
                     msg = f"Unrecognized message part type: {part['type']}."
                     raise ValueError(msg)
+            elif "inline_data" in part or "file_data" in part:
+                # `inline_data`/`file_data` part produced by
+                # `_convert_from_v1_to_generativelanguage_v1beta` when unpacking
+                # v1 image/file content blocks (the `_parse_chat_history`
+                # tool-call branch routes v1-converted content through here).
+                media_data = part.get("inline_data") or part.get("file_data")
+                data_kwargs: dict[str, Any] = {
+                    k: v for k, v in (media_data or {}).items() if v is not None
+                }
+                if "inline_data" in part:
+                    parts.append(Part(inline_data=Blob(**data_kwargs)))
+                else:
+                    parts.append(Part(file_data=FileData(**data_kwargs)))
+            elif "executable_code" in part:
+                # Same already-converted v1beta shape, for `server_tool_call`
+                # (code_interpreter) blocks.
+                exec_kwargs: dict[str, Any] = {
+                    k: v
+                    for k, v in (part.get("executable_code") or {}).items()
+                    if v is not None
+                }
+                parts.append(Part(executable_code=ExecutableCode(**exec_kwargs)))
+            elif "code_execution_result" in part:
+                # Same already-converted v1beta shape, for `server_tool_result`
+                # (code_execution_result) blocks.
+                result_kwargs: dict[str, Any] = {
+                    k: v
+                    for k, v in (part.get("code_execution_result") or {}).items()
+                    if v is not None
+                }
+                parts.append(
+                    Part(code_execution_result=CodeExecutionResult(**result_kwargs))
+                )
             elif set(part) <= {"text", "thought_signature"} and isinstance(
                 part.get("text"), str
             ):
@@ -974,6 +1007,15 @@ def _prepare_content_for_tool_call_message(
             # v1 converter also translates these blocks, so including them here
             # would duplicate each function call.
             continue
+        if block_type == "text" and not block.get("text"):
+            # Skip empty text blocks; they carry no information and the Gemini
+            # API rejects empty parts.
+            continue
+        if block_type in ("thinking", "reasoning") and not (
+            block.get("thinking") or block.get("reasoning") or block.get("summary")
+        ):
+            # Skip empty thought blocks; the Gemini API rejects empty parts.
+            continue
         if block_type == "reasoning" and "reasoning" not in block and not is_foreign:
             # Reasoning block in a shape `_convert_to_parts` cannot represent
             # (e.g. OpenAI's `summary` blocks on a message without provider
@@ -1082,14 +1124,23 @@ def _parse_chat_history(
                     # Content was already converted to v1beta dicts above by
                     # `_convert_from_v1_to_generativelanguage_v1beta`. Keep
                     # non-function-call blocks (function calls are rebuilt from
-                    # `message.tool_calls` below so they are emitted exactly once).
+                    # `message.tool_calls` below so they are emitted exactly once)
+                    # and drop empty text blocks (the Gemini API rejects empty
+                    # parts).
                     ai_message_parts.extend(
                         _convert_to_parts(
                             [
                                 block
                                 for block in message.content
                                 if not (
-                                    isinstance(block, dict) and "function_call" in block
+                                    isinstance(block, dict)
+                                    and (
+                                        "function_call" in block
+                                        or (
+                                            set(block) <= {"text", "thought_signature"}
+                                            and not block.get("text")
+                                        )
+                                    )
                                 )
                             ],
                             model=model,

--- a/libs/genai/langchain_google_genai/utils.py
+++ b/libs/genai/langchain_google_genai/utils.py
@@ -155,7 +155,11 @@ def create_context_cache(
         raise ValueError(msg)
 
     # Parse messages into system instruction and content
-    system_instruction, contents = _parse_chat_history(messages, model=model.model)
+    system_instruction, contents = _parse_chat_history(
+        messages,
+        model=model.model,
+        use_vertexai=model._use_vertexai,  # type: ignore[attr-defined]
+    )
 
     # Convert tools to Tool objects if provided
     tool_list = None

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -78,7 +78,6 @@ from langchain_google_genai.chat_models import (
     GoogleContextOverflowError,
     _convert_to_parts,
     _convert_tool_message_to_parts,
-    _decode_signature,
     _get_ai_message_tool_messages_parts,
     _handle_client_error,
     _handle_server_error,
@@ -3085,13 +3084,8 @@ def test_signature_round_trip_conversion() -> None:
     with patch.object(
         llm.client.models, "generate_content", return_value=mock_response
     ):
-        # First call - get response with signatures
         result = llm.invoke("Test message")
-
-        # Verify signatures were extracted
         assert isinstance(result.content, list)
-
-        # Find blocks with signatures
         sig_blocks = []
         for block in result.content:
             if isinstance(block, dict):
@@ -3104,7 +3098,6 @@ def test_signature_round_trip_conversion() -> None:
             f"Expected signature blocks, got content: {result.content}"
         )
 
-        # Now simulate passing this result back in a conversation
         with patch(
             "langchain_google_genai.chat_models._convert_from_v1_to_generativelanguage_v1beta"
         ) as mock_convert:
@@ -3114,14 +3107,11 @@ def test_signature_round_trip_conversion() -> None:
 
             mock_convert.side_effect = real_convert
 
-            # Create conversation with the signature-containing message
             conversation = [
                 HumanMessage(content="First message"),
-                result,  # This contains signatures
+                result,
                 HumanMessage(content="Follow up"),
             ]
-
-            # Set up mock for the follow-up response
             follow_up_response = GenerateContentResponse(
                 candidates=[
                     Candidate(content=Content(parts=[Part(text="Follow up response")]))
@@ -3133,10 +3123,7 @@ def test_signature_round_trip_conversion() -> None:
             ):
                 follow_up = llm.invoke(conversation)
 
-            # Verify conversion was called
             assert mock_convert.call_count >= 1
-
-            # Find calls with signatures
             calls_with_signatures = []
             for call in mock_convert.call_args_list:
                 content_blocks, model_provider = call[0]
@@ -3158,17 +3145,12 @@ def test_signature_round_trip_conversion() -> None:
                 "Expected at least one call to convert signatures"
             )
 
-            # Verify follow-up succeeded
             assert isinstance(follow_up, AIMessage)
             assert follow_up.content is not None
 
 
 def test_parse_response_candidate_adds_index_to_signature() -> None:
-    """Test _parse_response_candidate adds index to function_call_signature blocks."""
-    # Mock a candidate with thinking and function call with signature
     part1 = Part(text="Thinking...", thought=True)
-
-    # Signature must be bytes
     sig = b"mysig"
     part2 = Part(
         function_call=FunctionCall(name="tool", args={}), thought_signature=sig
@@ -3185,12 +3167,8 @@ def test_parse_response_candidate_adds_index_to_signature() -> None:
 
 
 def test_parse_chat_history_uses_index_for_signature() -> None:
-    """Test _parse_chat_history uses the index field to map signatures to tool calls."""
     sig_bytes = b"dummy_signature"
     sig_b64 = base64.b64encode(sig_bytes).decode("ascii")
-
-    # Content with thinking block (index 0) and signature block (index 1)
-    # The signature block points to tool call index 0
     content = [{"type": "thinking", "thinking": "I should use the tool."}]
 
     tool_calls = [{"name": "my_tool", "args": {"param": "value"}, "id": "call_1"}]
@@ -3203,56 +3181,70 @@ def test_parse_chat_history_uses_index_for_signature() -> None:
         },
     )
 
-    # Parse the history
     _, formatted_messages = _parse_chat_history([message])
-
-    # Check the result
     model_content = formatted_messages[0]
     assert model_content.role == "model"
     assert model_content.parts is not None
     assert len(model_content.parts) == 2
 
-    # First part should be the thinking text (thinking blocks come first)
     thinking_part = model_content.parts[0]
     assert thinking_part.thought is True
     assert thinking_part.text == "I should use the tool."
 
-    # Second part should be the function call with signature
     function_part = model_content.parts[1]
     assert function_part.function_call is not None
     assert function_part.function_call.name == "my_tool"
     assert function_part.thought_signature == sig_bytes
 
 
-def test_parse_chat_history_tool_calls_preserves_string_content() -> None:
-    """AIMessage with string content + tool calls keeps the text.
-
-    Regression test for https://github.com/langchain-ai/langchain-google/issues/1706.
-    """
+@pytest.mark.parametrize(
+    ("content", "expected_text", "expected_thought", "expected_signature"),
+    [
+        pytest.param(
+            "Let me look that up.",
+            "Let me look that up.",
+            None,
+            None,
+            id="string",
+        ),
+        pytest.param(
+            [{"type": "text", "text": "One moment."}],
+            "One moment.",
+            None,
+            None,
+            id="text-block",
+        ),
+        pytest.param(
+            [{"type": "thinking", "thinking": "Thinking.", "signature": "c2ln"}],
+            "Thinking.",
+            True,
+            b"sig",
+            id="v0-thinking",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "reasoning",
+                    "reasoning": "Thinking.",
+                    "extras": {"signature": "c2ln"},
+                }
+            ],
+            "Thinking.",
+            True,
+            b"sig",
+            id="v1-reasoning",
+        ),
+    ],
+)
+def test_parse_chat_history_tool_calls_preserves_content(
+    content: str | list[str | dict[Any, Any]],
+    expected_text: str,
+    expected_thought: bool | None,
+    expected_signature: bytes | None,
+) -> None:
+    """Preserve assistant content beside tool calls (regression for #1706)."""
     message = AIMessage(
-        content="Let me look that up.",
-        tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "call_1"}],
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    model_content = formatted_messages[0]
-    assert model_content.role == "model"
-    parts = model_content.parts
-    assert parts is not None
-    assert len(parts) == 2
-    assert parts[0].text == "Let me look that up."
-    assert parts[1].function_call is not None
-    assert parts[1].function_call.name == "search"
-
-
-def test_parse_chat_history_tool_calls_preserves_text_block_content() -> None:
-    """AIMessage with a text content block + tool calls keeps the text.
-
-    Regression test for https://github.com/langchain-ai/langchain-google/issues/1706.
-    """
-    message = AIMessage(
-        content=[{"type": "text", "text": "One moment."}],
+        content=content,
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
     )
 
@@ -3261,63 +3253,14 @@ def test_parse_chat_history_tool_calls_preserves_text_block_content() -> None:
     parts = formatted_messages[0].parts
     assert parts is not None
     assert len(parts) == 2
-    assert parts[0].text == "One moment."
-    assert parts[1].function_call is not None
-
-
-def test_parse_chat_history_tool_calls_preserves_thinking_block() -> None:
-    """v0 `thinking` blocks are kept as thought parts alongside tool calls."""
-    sig_bytes = b"thinking_signature"
-    sig_b64 = base64.b64encode(sig_bytes).decode("ascii")
-    message = AIMessage(
-        content=[
-            {"type": "thinking", "thinking": "Let me think.", "signature": sig_b64}
-        ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 2
-    assert parts[0].thought is True
-    assert parts[0].text == "Let me think."
-    assert parts[0].thought_signature == sig_bytes
-    assert parts[1].function_call is not None
-
-
-def test_parse_chat_history_tool_calls_preserves_v1_reasoning_block() -> None:
-    """v1 `reasoning` blocks are kept as thought parts alongside tool calls."""
-    sig_bytes = b"reasoning_signature"
-    sig_b64 = base64.b64encode(sig_bytes).decode("ascii")
-    message = AIMessage(
-        content=[
-            {
-                "type": "reasoning",
-                "reasoning": "I should search.",
-                "extras": {"signature": sig_b64},
-            }
-        ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 2
-    assert parts[0].thought is True
-    assert parts[0].text == "I should search."
-    assert parts[0].thought_signature == sig_bytes
+    assert parts[0].text == expected_text
+    assert parts[0].thought is expected_thought
+    assert parts[0].thought_signature == expected_signature
     assert parts[1].function_call is not None
 
 
 def test_parse_chat_history_tool_calls_v1_content_blocks_round_trip() -> None:
-    """Native thinking + tool call AIMessage projected through v1 content blocks.
-
-    Regression test for https://github.com/langchain-ai/langchain-google/issues/1964.
-    """
+    """Preserve signed reasoning through v1 projection (regression for #1964)."""
     sig_bytes = b"thinking_signature"
     sig_b64 = base64.b64encode(sig_bytes).decode("ascii")
     message = AIMessage(
@@ -3327,7 +3270,6 @@ def test_parse_chat_history_tool_calls_v1_content_blocks_round_trip() -> None:
         tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "call_1"}],
         response_metadata={"model_provider": "google_genai"},
     )
-    # Project through v1 content blocks as when `output_version="v1"` is used
     v1_message = message.model_copy(
         update={
             "content": message.content_blocks,
@@ -3337,7 +3279,6 @@ def test_parse_chat_history_tool_calls_v1_content_blocks_round_trip() -> None:
             },
         }
     )
-    # Sanity check: the projection produced a reasoning block and a tool_call block
     assert v1_message.content[0]["type"] == "reasoning"  # type: ignore[index]
     assert any(
         isinstance(block, dict) and block.get("type") == "tool_call"
@@ -3348,7 +3289,6 @@ def test_parse_chat_history_tool_calls_v1_content_blocks_round_trip() -> None:
 
     parts = formatted_messages[0].parts
     assert parts is not None
-    # Exactly one thought part and exactly one function call part (no duplicates)
     assert len(parts) == 2
     thought_parts = [part for part in parts if part.thought]
     function_call_parts = [part for part in parts if part.function_call]
@@ -3362,7 +3302,6 @@ def test_parse_chat_history_tool_calls_v1_content_blocks_round_trip() -> None:
 
 
 def test_parse_chat_history_tool_calls_normalizes_anthropic_tool_use() -> None:
-    """Anthropic `tool_use` content is normalized before Google conversion."""
     message = AIMessage(
         content=[
             {"type": "text", "text": "Let me look that up."},
@@ -3389,7 +3328,6 @@ def test_parse_chat_history_tool_calls_normalizes_anthropic_tool_use() -> None:
 
 
 def test_parse_chat_history_tool_calls_drops_invalid_foreign_calls() -> None:
-    """Malformed foreign calls do not prevent valid calls from being replayed."""
     message = AIMessage(
         content=[
             {
@@ -3429,7 +3367,6 @@ def test_parse_chat_history_tool_calls_drops_invalid_foreign_calls() -> None:
 
 
 def test_parse_chat_history_tool_calls_drops_foreign_web_search_pair() -> None:
-    """Foreign server-tool results are not cast as Gemini code results."""
     message = AIMessage(
         content=[
             {
@@ -3465,7 +3402,6 @@ def test_parse_chat_history_tool_calls_drops_foreign_web_search_pair() -> None:
 
 
 def test_parse_chat_history_tool_calls_keeps_foreign_code_interpreter_pair() -> None:
-    """Matched foreign code-interpreter calls and results remain compatible."""
     message = AIMessage(
         content=[
             {
@@ -3500,20 +3436,38 @@ def test_parse_chat_history_tool_calls_keeps_foreign_code_interpreter_pair() -> 
     assert parts[2].function_call.name == "lookup"
 
 
-def test_parse_chat_history_tool_calls_non_standard_block_dropped(
+@pytest.mark.parametrize(
+    ("output_version", "content"),
+    [
+        pytest.param(
+            None,
+            [{"type": "redacted_thinking", "data": "encrypted"}],
+            id="v0",
+        ),
+        pytest.param(
+            "v1",
+            [
+                {
+                    "type": "non_standard",
+                    "value": {"type": "redacted_thinking", "data": "encrypted"},
+                }
+            ],
+            id="v1",
+        ),
+    ],
+)
+def test_parse_chat_history_tool_calls_drops_foreign_non_standard_block(
+    output_version: str | None,
+    content: list[str | dict[Any, Any]],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Provider payloads core cannot standardize are dropped, not raised on.
-
-    LangChain core wraps content it has no standard block for (e.g. Anthropic's
-    `redacted_thinking`) in a `non_standard` block. Gemini cannot represent
-    another provider's opaque payload, so it must be skipped with a warning
-    rather than aborting the whole request.
-    """
+    response_metadata = {"model_provider": "anthropic"}
+    if output_version is not None:
+        response_metadata["output_version"] = output_version
     message = AIMessage(
-        content=[{"type": "redacted_thinking", "data": "encrypted"}],
+        content=content,
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": "anthropic"},
+        response_metadata=response_metadata,
     )
 
     with caplog.at_level(logging.WARNING):
@@ -3521,14 +3475,12 @@ def test_parse_chat_history_tool_calls_non_standard_block_dropped(
 
     parts = formatted_messages[0].parts
     assert parts is not None
-    # Only the function call survives; the opaque payload is dropped
     assert len(parts) == 1
     assert parts[0].function_call is not None
-    assert "non-standard content block" in caplog.text
+    assert "Dropping" in caplog.text
 
 
 def test_parse_chat_history_without_tool_calls_drops_foreign_non_standard() -> None:
-    """Foreign provider payloads are filtered even without function calls."""
     signature = base64.b64encode(b"anthropic_signature").decode("ascii")
     message = AIMessage(
         content=[
@@ -3554,49 +3506,34 @@ def test_parse_chat_history_without_tool_calls_drops_foreign_non_standard() -> N
     assert parts[0].thought_signature is None
 
 
-def test_parse_chat_history_tool_calls_v1_non_standard_block_dropped() -> None:
-    """Serialized v1 provider payloads are dropped before Gemini conversion."""
-    message = AIMessage(
-        content=[
-            {
-                "type": "non_standard",
-                "value": {"type": "redacted_thinking", "data": "encrypted"},
-            }
-        ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={
-            "model_provider": "anthropic",
-            "output_version": "v1",
-        },
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 1
-    assert parts[0].function_call is not None
-
-
-def test_parse_chat_history_tool_calls_v1_foreign_malformed_media_dropped(
+@pytest.mark.parametrize(
+    ("output_version", "content"),
+    [
+        pytest.param(
+            None,
+            [{"type": "media", "mime_type": "image/png", "data": "invalid!!"}],
+            id="v0",
+        ),
+        pytest.param(
+            "v1",
+            [{"type": "image", "mime_type": "image/png", "base64": "invalid!!"}],
+            id="v1",
+        ),
+    ],
+)
+def test_parse_chat_history_drops_malformed_foreign_media(
+    output_version: str | None,
+    content: list[str | dict[Any, Any]],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A foreign v1 media block with malformed base64 is dropped, not raised on.
-
-    `_compat` converts the block to an `inline_data` v1beta dict without
-    validating the base64 payload, so the failure only surfaces when the dict is
-    converted to a `Blob`. Foreign v1 messages keep the tolerant per-block
-    behavior of the non-v1 branch; the valid tool call must still be replayed.
-    """
+    """Drop malformed foreign media without losing an otherwise valid tool call."""
+    response_metadata = {"model_provider": "openai"}
+    if output_version is not None:
+        response_metadata["output_version"] = output_version
     message = AIMessage(
-        content=[
-            {"type": "image", "base64": "not valid base64!!", "mime_type": "image/png"}
-        ],
+        content=content,
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={
-            "model_provider": "openai",
-            "output_version": "v1",
-        },
+        response_metadata=response_metadata,
     )
 
     with caplog.at_level(logging.WARNING):
@@ -3606,26 +3543,36 @@ def test_parse_chat_history_tool_calls_v1_foreign_malformed_media_dropped(
     assert parts is not None
     assert len(parts) == 1
     assert parts[0].function_call is not None
-    assert parts[0].function_call.name == "search"
-    assert "Dropping content block that cannot" in caplog.text
+    assert "Dropping" in caplog.text
 
 
-def test_parse_chat_history_tool_calls_v1_native_malformed_media_raises() -> None:
-    """A native v1 media block with malformed base64 must not be silently dropped.
-
-    Unlike foreign content, a malformed `google_genai` block is bad input, not an
-    expected foreign shape; dropping it would turn the request into a different
-    valid request without telling the caller.
-    """
+@pytest.mark.parametrize(
+    ("output_version", "content"),
+    [
+        pytest.param(
+            None,
+            [{"type": "media", "mime_type": "image/png", "data": "invalid!!"}],
+            id="v0",
+        ),
+        pytest.param(
+            "v1",
+            [{"type": "image", "mime_type": "image/png", "base64": "invalid!!"}],
+            id="v1",
+        ),
+    ],
+)
+def test_parse_chat_history_rejects_malformed_native_media(
+    output_version: str | None,
+    content: list[str | dict[Any, Any]],
+) -> None:
+    """Keep native replay strict so invalid input cannot silently change a request."""
+    response_metadata = {"model_provider": "google_genai"}
+    if output_version is not None:
+        response_metadata["output_version"] = output_version
     message = AIMessage(
-        content=[
-            {"type": "image", "base64": "not valid base64!!", "mime_type": "image/png"}
-        ],
+        content=content,
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={
-            "model_provider": "google_genai",
-            "output_version": "v1",
-        },
+        response_metadata=response_metadata,
     )
 
     with pytest.raises(ValueError, match="valid base64"):
@@ -3633,13 +3580,11 @@ def test_parse_chat_history_tool_calls_v1_native_malformed_media_raises() -> Non
 
 
 def test_convert_to_parts_still_raises_on_unknown_type() -> None:
-    """Dropping `non_standard` must not weaken the guard on malformed blocks."""
     with pytest.raises(ValueError, match="Unrecognized message part type: bogus"):
         _convert_to_parts([{"type": "bogus"}])
 
 
 def test_parse_chat_history_preserves_human_non_standard_media() -> None:
-    """Core-wrapped Gemini media on a human message is unwrapped and sent."""
     message = HumanMessage(
         content_blocks=[
             {
@@ -3664,7 +3609,6 @@ def test_parse_chat_history_preserves_human_non_standard_media() -> None:
 
 
 def test_parse_chat_history_preserves_native_ai_non_standard_media() -> None:
-    """Native AI media is unwrapped even without v1 output metadata."""
     message = AIMessage(
         content=[
             {
@@ -3690,7 +3634,6 @@ def test_parse_chat_history_preserves_native_ai_non_standard_media() -> None:
 
 
 def test_parse_chat_history_tool_calls_drops_foreign_non_standard_media() -> None:
-    """Provider-aware filtering still rejects another provider's opaque media."""
     message = AIMessage(
         content=[
             {
@@ -3715,10 +3658,7 @@ def test_parse_chat_history_tool_calls_drops_foreign_non_standard_media() -> Non
 def test_parse_chat_history_tool_calls_foreign_reasoning_block(
     output_version: str | None,
 ) -> None:
-    """OpenAI-style `summary` reasoning blocks don't crash history parsing.
-
-    Regression test for https://github.com/langchain-ai/langchain-google/issues/1603.
-    """
+    """Replay OpenAI summary reasoning safely (regression for #1603)."""
     response_metadata = {"model_provider": "openai"}
     if output_version:
         response_metadata["output_version"] = output_version
@@ -3737,7 +3677,6 @@ def test_parse_chat_history_tool_calls_foreign_reasoning_block(
 
     parts = formatted_messages[0].parts
     assert parts is not None
-    # The reasoning text is converted from the summary; the function call is kept
     assert len(parts) == 2
     assert parts[0].thought is True
     assert parts[0].text == "I should search."
@@ -3746,14 +3685,6 @@ def test_parse_chat_history_tool_calls_foreign_reasoning_block(
 
 
 def test_convert_to_parts_openai_summary_reasoning_without_metadata() -> None:
-    """The exact repro from the issue: no provider metadata and no tool calls.
-
-    This is the only input shape that exercises the `summary` extraction fallback
-    in `_convert_to_parts`; a message tagged `model_provider="openai"` is
-    normalized by core to a `reasoning` key before conversion runs.
-
-    Regression test for https://github.com/langchain-ai/langchain-google/issues/1603.
-    """
     message = AIMessage(
         content=[
             {
@@ -3780,19 +3711,12 @@ def test_convert_to_parts_openai_summary_reasoning_without_metadata() -> None:
 
 
 def test_convert_to_parts_reasoning_summary_not_a_list_is_dropped() -> None:
-    """A `summary` that yields no text is dropped rather than raising."""
     assert _convert_to_parts([{"type": "reasoning", "summary": "notalist"}]) == []
 
 
 def test_parse_chat_history_tool_calls_unknown_provider_drops_foreign_block(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A foreign block on a metadata-less message is dropped, not raised on.
-
-    Messages lacking `model_provider` (hand-built, or checkpoints serialized before
-    core stamped the field) must not turn a previously-ignored block into a hard
-    request failure.
-    """
     message = AIMessage(
         content=[
             {"type": "text", "text": "Let me look that up."},
@@ -3806,7 +3730,6 @@ def test_parse_chat_history_tool_calls_unknown_provider_drops_foreign_block(
 
     parts = formatted_messages[0].parts
     assert parts is not None
-    # Text survives, the unconvertible block is dropped, the call is emitted once
     assert len(parts) == 2
     assert parts[0].text == "Let me look that up."
     assert parts[1].function_call is not None
@@ -3814,132 +3737,64 @@ def test_parse_chat_history_tool_calls_unknown_provider_drops_foreign_block(
     assert "Dropping content block that cannot" in caplog.text
 
 
-def test_parse_chat_history_tool_calls_native_invalid_media_raises() -> None:
-    """A native block that fails validation must not be silently dropped.
-
-    A malformed media block on a `google_genai` message is bad input, not an
-    expected foreign shape; dropping it would turn the request into a different
-    valid request without telling the caller.
-    """
-    message = AIMessage(
-        content=[
-            {"type": "media", "mime_type": "image/png", "data": "not valid base64!!"},
+@pytest.mark.parametrize(
+    ("model_provider", "output_version", "content", "expected"),
+    [
+        *[
+            pytest.param(
+                provider,
+                None,
+                [{"type": "thinking", "thinking": "Thinking.", "signature": "c2ln"}],
+                [("Thinking.", True)],
+                id=f"{provider}-v0-thinking",
+            )
+            for provider in ("google_genai", "google_vertexai")
         ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": "google_genai"},
-    )
-
-    with pytest.raises(ValueError, match="valid base64"):
-        _parse_chat_history([message])
-
-
-def test_parse_chat_history_tool_calls_foreign_malformed_media_still_dropped(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Another provider's malformed block is dropped, not raised on.
-
-    Only native content regains strict validation; multi-provider histories keep
-    the tolerant behavior since unconvertible foreign blocks are expected.
-    """
-    message = AIMessage(
-        content=[
-            {"type": "media", "mime_type": "image/png", "data": "not valid base64!!"},
+        *[
+            pytest.param(
+                provider,
+                "v1",
+                [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "Thinking.",
+                        "extras": {"signature": "c2ln"},
+                    },
+                    {
+                        "type": "text",
+                        "text": "Answer.",
+                        "extras": {"signature": "c2ln"},
+                    },
+                ],
+                [("Thinking.", True), ("Answer.", None)],
+                id=f"{provider}-v1-content",
+            )
+            for provider in ("google_genai", "google_vertexai")
         ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": "openai"},
-    )
-
-    with caplog.at_level(logging.WARNING):
-        _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 1
-    assert parts[0].function_call is not None
-    # Core projects an unknown provider's `media` block to `non_standard`; the
-    # tolerant path drops it with a warning instead of failing the request.
-    assert "Dropping non-standard content block" in caplog.text
-
-
-@pytest.mark.parametrize("model_provider", ["google_genai", "google_vertexai"])
-def test_parse_chat_history_tool_calls_native_v0_signature_preserved(
+        *[
+            pytest.param(
+                "google_vertexai",
+                output_version,
+                [{"type": "text", "text": "Answer.", "thought_signature": "c2ln"}],
+                [("Answer.", None)],
+                id=f"vertex-text-{output_version or 'v0'}",
+            )
+            for output_version in (None, "v1")
+        ],
+    ],
+)
+def test_parse_chat_history_preserves_native_signatures(
     model_provider: str,
-) -> None:
-    """Vertex AI serves the same Gemini models, so its signatures stay valid."""
-    signature = base64.b64encode(b"vertex_sig").decode("ascii")
-    message = AIMessage(
-        content=[{"type": "thinking", "thinking": "Thinking.", "signature": signature}],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": model_provider},
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 2
-    assert parts[0].thought is True
-    assert parts[0].thought_signature == b"vertex_sig"
-
-
-@pytest.mark.parametrize("model_provider", ["google_genai", "google_vertexai"])
-def test_parse_chat_history_tool_calls_native_v1_signature_preserved(
-    model_provider: str,
-) -> None:
-    """Both native providers keep reasoning text and signatures on the v1 path.
-
-    Regression guard: `_compat` used to gate v1 signature handling on
-    `google_genai` alone, so a Vertex AI turn lost its reasoning block entirely
-    and had its text signature stripped. The signature then fell through to
-    `DUMMY_THOUGHT_SIGNATURE`, silently degrading thinking continuity.
-    """
-    signature = base64.b64encode(b"vertex_sig").decode("ascii")
-    message = AIMessage(
-        content=[
-            {
-                "type": "reasoning",
-                "reasoning": "Thinking.",
-                "extras": {"signature": signature},
-            },
-            {"type": "text", "text": "Answer.", "extras": {"signature": signature}},
-        ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={
-            "model_provider": model_provider,
-            "output_version": "v1",
-        },
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 3
-    assert parts[0].thought is True
-    assert parts[0].text == "Thinking."
-    assert parts[0].thought_signature == b"vertex_sig"
-    assert parts[1].text == "Answer."
-    assert parts[1].thought_signature == b"vertex_sig"
-    assert parts[2].function_call is not None
-
-
-@pytest.mark.parametrize("output_version", [None, "v1"])
-def test_parse_chat_history_vertex_text_thought_signature_preserved(
     output_version: str | None,
+    content: list[str | dict[Any, Any]],
+    expected: list[tuple[str, bool | None]],
 ) -> None:
-    """Vertex's top-level text signature survives both history paths."""
-    signature = base64.b64encode(b"vertex_sig").decode("ascii")
-    response_metadata = {"model_provider": "google_vertexai"}
+    """Treat Vertex and Developer API signatures as the same native format."""
+    response_metadata = {"model_provider": model_provider}
     if output_version is not None:
         response_metadata["output_version"] = output_version
     message = AIMessage(
-        content=[
-            {
-                "type": "text",
-                "text": "Answer.",
-                "thought_signature": signature,
-            }
-        ],
+        content=content,
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
         response_metadata=response_metadata,
     )
@@ -3948,16 +3803,15 @@ def test_parse_chat_history_vertex_text_thought_signature_preserved(
 
     parts = formatted_messages[0].parts
     assert parts is not None
-    assert len(parts) == 2
-    assert parts[0].text == "Answer."
-    assert parts[0].thought_signature == b"vertex_sig"
-    assert parts[1].function_call is not None
+    assert len(parts) == len(expected) + 1
+    assert [(part.text, part.thought) for part in parts[:-1]] == expected
+    assert all(part.thought_signature == b"sig" for part in parts[:-1])
+    assert parts[-1].function_call is not None
 
 
 def test_parse_chat_history_tool_calls_v1_unknown_provider_preserves_signature() -> (
     None
 ):
-    """Older v1 checkpoints keep native signatures without provider metadata."""
     signature = base64.b64encode(b"checkpoint_sig").decode("ascii")
     message = AIMessage(
         content=[
@@ -3985,7 +3839,6 @@ def test_parse_chat_history_tool_calls_v1_unknown_provider_preserves_signature()
 def test_parse_chat_history_tool_calls_summary_reasoning_kept_without_metadata() -> (
     None
 ):
-    """A metadata-less `summary` reasoning block is converted, not dropped."""
     message = AIMessage(
         content=[
             {
@@ -4006,26 +3859,50 @@ def test_parse_chat_history_tool_calls_summary_reasoning_kept_without_metadata()
 
 
 @pytest.mark.parametrize(
-    "block",
+    ("block", "response_metadata", "expected_signature"),
     [
-        {"type": "thinking", "thinking": "", "signature": "c2ln"},
-        {"type": "reasoning", "reasoning": "", "extras": {"signature": "c2ln"}},
-        {"type": "text", "text": "", "extras": {"signature": "c2ln"}},
+        pytest.param(
+            {"type": "thinking", "thinking": "", "signature": "c2ln"},
+            {},
+            b"sig",
+            id="v0-thinking",
+        ),
+        pytest.param(
+            {"type": "reasoning", "reasoning": "", "extras": {"signature": "c2ln"}},
+            {},
+            b"sig",
+            id="v0-reasoning",
+        ),
+        pytest.param(
+            {"type": "text", "text": "", "extras": {"signature": "c2ln"}},
+            {},
+            b"sig",
+            id="v0-text",
+        ),
+        pytest.param(
+            {"type": "reasoning", "reasoning": "", "extras": {"signature": "c2ln"}},
+            {"model_provider": "google_genai", "output_version": "v1"},
+            b"sig",
+            id="v1-signed",
+        ),
+        pytest.param(
+            {"type": "reasoning", "reasoning": ""},
+            {"model_provider": "google_genai", "output_version": "v1"},
+            None,
+            id="v1-unsigned",
+        ),
     ],
 )
-def test_parse_chat_history_tool_calls_keeps_signature_only_blocks(
+def test_parse_chat_history_handles_empty_thought_blocks(
     block: dict[str, Any],
+    response_metadata: dict[str, Any],
+    expected_signature: bytes | None,
 ) -> None:
-    """An empty block carrying a signature must survive.
-
-    Gemini emits signature-bearing blocks with empty text and requires the
-    signature to be echoed back, so emptiness alone must not trigger a drop --
-    otherwise the signature is lost and the Gemini 3 enforcement pass silently
-    substitutes `DUMMY_THOUGHT_SIGNATURE` for the whole turn.
-    """
+    """Retain signature-only thoughts while dropping genuinely empty thoughts."""
     message = AIMessage(
         content=[block],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata=response_metadata,
     )
 
     _, formatted_messages = _parse_chat_history(
@@ -4034,72 +3911,47 @@ def test_parse_chat_history_tool_calls_keeps_signature_only_blocks(
 
     parts = formatted_messages[0].parts
     assert parts is not None
-    assert len(parts) == 2
-    # The real signature survives on the thought part rather than being dropped
-    # and back-filled with the dummy
-    assert parts[0].thought_signature == b"sig"
-    assert parts[0].thought_signature != DUMMY_THOUGHT_SIGNATURE
-    assert parts[1].function_call is not None
+    content_parts = [part for part in parts if part.function_call is None]
+    if expected_signature is None:
+        assert content_parts == []
+    else:
+        assert len(content_parts) == 1
+        assert content_parts[0].thought_signature == expected_signature
+        assert content_parts[0].thought_signature != DUMMY_THOUGHT_SIGNATURE
+    assert len([part for part in parts if part.function_call is not None]) == 1
 
 
-def test_parse_chat_history_tool_calls_v1_keeps_signature_only_thought() -> None:
-    """The v1 path keeps a signature-bearing empty thought, matching the v0 path."""
-    signature = base64.b64encode(b"sig").decode("ascii")
+@pytest.mark.parametrize(
+    ("block", "expected_text", "expected_thought"),
+    [
+        pytest.param(
+            {"type": "text", "text": "Looking it up."},
+            "Looking it up.",
+            None,
+            id="text",
+        ),
+        pytest.param(
+            {"type": "reasoning", "reasoning": "I should search."},
+            "I should search.",
+            True,
+            id="reasoning",
+        ),
+        pytest.param(
+            {"type": "text", "text": ""},
+            None,
+            None,
+            id="signature-only",
+        ),
+    ],
+)
+def test_parse_chat_history_strips_foreign_signatures(
+    block: dict[str, Any],
+    expected_text: str | None,
+    expected_thought: bool | None,
+) -> None:
+    block["extras"] = {"signature": "b3BlbmFpX3NpZw=="}
     message = AIMessage(
-        content=[
-            {"type": "reasoning", "reasoning": "", "extras": {"signature": signature}},
-            {"type": "tool_call", "name": "search", "args": {}, "id": "call_1"},
-        ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={
-            "model_provider": "google_genai",
-            "output_version": "v1",
-        },
-    )
-
-    _, formatted_messages = _parse_chat_history(
-        [message], model="gemini-3.1-pro-preview"
-    )
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 2
-    assert parts[0].thought is True
-    assert parts[0].thought_signature == b"sig"
-    assert parts[1].function_call is not None
-
-
-def test_parse_chat_history_tool_calls_v1_drops_unsigned_empty_thought() -> None:
-    """An empty thought with no signature is still dropped on the v1 path."""
-    message = AIMessage(
-        content=[{"thought": True, "text": ""}, {"function_call": {"name": "search"}}],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={
-            "model_provider": "google_genai",
-            "output_version": "v1",
-        },
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 1
-    assert parts[0].function_call is not None
-
-
-def test_parse_chat_history_tool_calls_foreign_text_signature_stripped() -> None:
-    """A foreign `text` block's signature is stripped, not just reasoning blocks."""
-    message = AIMessage(
-        content=[
-            {
-                "type": "text",
-                "text": "Looking it up.",
-                "extras": {
-                    "signature": base64.b64encode(b"openai_sig").decode("ascii")
-                },
-            }
-        ],
+        content=[block],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
         response_metadata={"model_provider": "openai"},
     )
@@ -4108,41 +3960,18 @@ def test_parse_chat_history_tool_calls_foreign_text_signature_stripped() -> None
 
     parts = formatted_messages[0].parts
     assert parts is not None
-    assert parts[0].text == "Looking it up."
-    assert parts[0].thought_signature is None
-
-
-def test_parse_chat_history_tool_calls_foreign_signature_only_block_dropped() -> None:
-    """A foreign block whose only payload is a signature must not emit an empty part.
-
-    The emptiness check must run after foreign signatures are stripped: the
-    signature makes the block look non-empty, but once stripped nothing remains,
-    and the Gemini API rejects the resulting empty text part.
-    """
-    message = AIMessage(
-        content=[
-            {
-                "type": "text",
-                "text": "",
-                "extras": {
-                    "signature": base64.b64encode(b"openai_sig").decode("ascii")
-                },
-            }
-        ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": "openai"},
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 1
-    assert parts[0].function_call is not None
+    content_parts = [part for part in parts if part.function_call is None]
+    if expected_text is None:
+        assert content_parts == []
+    else:
+        assert len(content_parts) == 1
+        assert content_parts[0].text == expected_text
+        assert content_parts[0].thought is expected_thought
+        assert content_parts[0].thought_signature is None
+    assert len([part for part in parts if part.function_call is not None]) == 1
 
 
 def test_parse_chat_history_tool_calls_strips_tool_call_chunk_blocks() -> None:
-    """A `tool_call_chunk` block must not duplicate the rebuilt function call."""
     message = AIMessage(
         content=[
             {
@@ -4164,22 +3993,26 @@ def test_parse_chat_history_tool_calls_strips_tool_call_chunk_blocks() -> None:
 
 
 @pytest.mark.parametrize("output_version", [None, "v1"])
+@pytest.mark.parametrize("index", [0, None], ids=["indexed", "unindexed"])
 def test_parse_chat_history_consumes_legacy_function_call_signature(
     output_version: str | None,
+    index: int | None,
 ) -> None:
-    """Legacy signature sidecars are attached to rebuilt function calls."""
+    """Map indexed and early unindexed signature sidecars to rebuilt calls."""
     signature = base64.b64encode(b"legacy_sig").decode("ascii")
     response_metadata = {"model_provider": "google_vertexai"}
     if output_version is not None:
         response_metadata["output_version"] = output_version
+    signature_block: dict[str, Any] = {
+        "type": "function_call_signature",
+        "signature": signature,
+    }
+    if index is not None:
+        signature_block["index"] = index
     message = AIMessage(
         content=[
             {"type": "text", "text": "Calling a tool."},
-            {
-                "type": "function_call_signature",
-                "signature": signature,
-                "index": 0,
-            },
+            signature_block,
         ],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
         response_metadata=response_metadata,
@@ -4195,32 +4028,6 @@ def test_parse_chat_history_consumes_legacy_function_call_signature(
     assert parts[1].thought_signature == b"legacy_sig"
 
 
-@pytest.mark.parametrize("output_version", [None, "v1"])
-def test_parse_chat_history_maps_unindexed_legacy_function_call_signature(
-    output_version: str | None,
-) -> None:
-    """Unindexed legacy sidecars use signature order, not content position."""
-    signature = base64.b64encode(b"unindexed_legacy_sig").decode("ascii")
-    response_metadata = {"model_provider": "google_vertexai"}
-    if output_version is not None:
-        response_metadata["output_version"] = output_version
-    message = AIMessage(
-        content=[
-            {"type": "text", "text": "Calling a tool."},
-            {"type": "function_call_signature", "signature": signature},
-        ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata=response_metadata,
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert parts[1].function_call is not None
-    assert parts[1].thought_signature == b"unindexed_legacy_sig"
-
-
 @pytest.mark.parametrize(
     ("model_provider", "file_uri"),
     [
@@ -4231,7 +4038,6 @@ def test_parse_chat_history_maps_unindexed_legacy_function_call_signature(
 def test_parse_chat_history_tool_calls_normalizes_native_blocks(
     model_provider: str, file_uri: str
 ) -> None:
-    """Provider-native file and function-call blocks replay without duplication."""
     message = AIMessage(
         content=[
             {
@@ -4265,37 +4071,29 @@ def test_parse_chat_history_tool_calls_normalizes_native_blocks(
     assert parts[1].function_call.args == {"q": "x"}
 
 
-def test_parse_chat_history_drops_vertex_gcs_for_gemini_backend() -> None:
-    """The source being Vertex does not make its GCS URI valid for Gemini API."""
-    message = AIMessage(
-        content=[
+@pytest.mark.parametrize(
+    "block",
+    [
+        pytest.param(
             {
                 "type": "file_data",
                 "file_uri": "gs://bucket/document.pdf",
                 "mime_type": "application/pdf",
-            }
-        ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": "google_vertexai"},
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 1
-    assert parts[0].function_call is not None
-
-
-def test_parse_chat_history_drops_nested_vertex_gcs_for_gemini_backend() -> None:
-    """Nested Chat Completions image URLs receive the same backend filtering."""
+            },
+            id="file-data",
+        ),
+        pytest.param(
+            {"type": "image_url", "image_url": {"url": "gs://bucket/image.png"}},
+            id="nested-image-url",
+        ),
+    ],
+)
+def test_parse_chat_history_drops_vertex_gcs_for_gemini_backend(
+    block: dict[str, Any],
+) -> None:
+    """Filter Vertex-only GCS references according to the destination backend."""
     message = AIMessage(
-        content=[
-            {
-                "type": "image_url",
-                "image_url": {"url": "gs://bucket/image.png"},
-            }
-        ],
+        content=[block],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
         response_metadata={"model_provider": "google_vertexai"},
     )
@@ -4312,7 +4110,6 @@ def test_parse_chat_history_drops_nested_vertex_gcs_for_gemini_backend() -> None
 def test_prepare_request_checks_target_backend_for_vertex_gcs_history(
     vertexai: bool,
 ) -> None:
-    """Vertex GCS references replay only when the target is also Vertex AI."""
     llm = ChatGoogleGenerativeAI(
         model=MODEL_NAME,
         api_key=FAKE_API_KEY,
@@ -4354,51 +4151,21 @@ def test_prepare_request_checks_target_backend_for_vertex_gcs_history(
     assert len([part for part in parts if part.function_call is not None]) == 1
 
 
-def test_parse_chat_history_tool_calls_preserves_native_media_block() -> None:
-    """A native `media` block mixed with a raw `function_call` is not dropped.
-
-    Core's google translator has no `media` case, so projecting the message
-    through `content_blocks` would turn the block into `non_standard` and lose it.
-    Reading raw `content` and normalizing only the function-call block preserves
-    the media part.
-    """
-    message = AIMessage(
-        content=[
+@pytest.mark.parametrize(
+    ("block", "output_version", "expected_uri", "expected_mime_type"),
+    [
+        pytest.param(
             {
                 "type": "media",
-                "file_uri": "https://generativelanguage.googleapis.com/v1beta/files/abc",
+                "file_uri": "files/native-audio",
                 "mime_type": "audio/mpeg",
             },
-            {
-                "type": "function_call",
-                "name": "transcribe",
-                "args": {},
-                "id": "call_1",
-            },
-        ],
-        tool_calls=[{"name": "transcribe", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": "google_genai"},
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 2
-    assert parts[0].file_data is not None
-    assert (
-        parts[0].file_data.file_uri
-        == "https://generativelanguage.googleapis.com/v1beta/files/abc"
-    )
-    assert parts[0].file_data.mime_type == "audio/mpeg"
-    assert parts[1].function_call is not None
-    assert parts[1].function_call.name == "transcribe"
-
-
-def test_parse_chat_history_tool_calls_v1_preserves_native_media_block() -> None:
-    """V1 projection does not discard a native block wrapped as `non_standard`."""
-    message = AIMessage(
-        content=[
+            None,
+            "files/native-audio",
+            "audio/mpeg",
+            id="v0-media",
+        ),
+        pytest.param(
             {
                 "type": "non_standard",
                 "value": {
@@ -4407,13 +4174,39 @@ def test_parse_chat_history_tool_calls_v1_preserves_native_media_block() -> None
                     "mime_type": "audio/mpeg",
                 },
             },
-            {"type": "tool_call", "name": "transcribe", "args": {}, "id": "call_1"},
+            "v1",
+            "files/native-audio",
+            "audio/mpeg",
+            id="v1-non-standard-media",
+        ),
+        pytest.param(
+            {"type": "file", "file_id": "files/abc", "mime_type": "application/pdf"},
+            "v1",
+            "files/abc",
+            "application/pdf",
+            id="v1-file-id",
+        ),
+    ],
+)
+def test_parse_chat_history_replays_native_file_blocks(
+    block: dict[str, Any],
+    output_version: str | None,
+    expected_uri: str,
+    expected_mime_type: str,
+) -> None:
+    """Replay native file shapes that core may otherwise wrap as non-standard."""
+    response_metadata = {"model_provider": "google_genai"}
+    call_block_type = "function_call"
+    if output_version is not None:
+        response_metadata["output_version"] = output_version
+        call_block_type = "tool_call"
+    message = AIMessage(
+        content=[
+            block,
+            {"type": call_block_type, "name": "search", "args": {}, "id": "call_1"},
         ],
-        tool_calls=[{"name": "transcribe", "args": {}, "id": "call_1"}],
-        response_metadata={
-            "model_provider": "google_genai",
-            "output_version": "v1",
-        },
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata=response_metadata,
     )
 
     _, formatted_messages = _parse_chat_history([message])
@@ -4422,40 +4215,12 @@ def test_parse_chat_history_tool_calls_v1_preserves_native_media_block() -> None
     assert parts is not None
     assert len(parts) == 2
     assert parts[0].file_data is not None
-    assert parts[0].file_data.file_uri == "files/native-audio"
-    assert parts[0].file_data.mime_type == "audio/mpeg"
+    assert parts[0].file_data.file_uri == expected_uri
+    assert parts[0].file_data.mime_type == expected_mime_type
     assert parts[1].function_call is not None
 
 
-def test_parse_chat_history_tool_calls_v1_file_id_becomes_file_data() -> None:
-    """A v1 `file` block carrying a `file_id` converts to a `file_data` part."""
-    message = AIMessage(
-        content=[
-            {
-                "type": "file",
-                "file_id": "files/abc",
-                "mime_type": "application/pdf",
-            },
-            {"type": "tool_call", "name": "search", "args": {}, "id": "call_1"},
-        ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={
-            "model_provider": "google_genai",
-            "output_version": "v1",
-        },
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert parts[0].file_data is not None
-    assert parts[0].file_data.file_uri == "files/abc"
-    assert parts[0].file_data.mime_type == "application/pdf"
-
-
 def test_parse_chat_history_tool_calls_v1_foreign_file_id_dropped() -> None:
-    """A provider-scoped foreign file ID must not be replayed to Gemini."""
     message = AIMessage(
         content=[
             {
@@ -4482,7 +4247,6 @@ def test_parse_chat_history_tool_calls_v1_foreign_file_id_dropped() -> None:
 
 
 def test_parse_chat_history_tool_calls_v1_text_signature_decoded() -> None:
-    """A signature on a v1 `text` block round-trips as decoded bytes."""
     signature = base64.b64encode(b"text_sig").decode("ascii")
     message = AIMessage(
         content=[
@@ -4504,36 +4268,39 @@ def test_parse_chat_history_tool_calls_v1_text_signature_decoded() -> None:
     assert parts[0].thought_signature == b"text_sig"
 
 
-def test_convert_from_v1_keeps_base64_media_undecoded() -> None:
-    """`Blob` base64-decodes a `str`, so the converter must not pre-encode it.
-
-    Pre-encoding produced double-base64-encoded bytes on the wire.
-    """
-    converted = _convert_from_v1_to_generativelanguage_v1beta(
-        [{"type": "image", "base64": "aGVsbG8=", "mime_type": "image/png"}],
-        "google_genai",
-    )
-
-    assert converted == [
-        {"inline_data": {"mime_type": "image/png", "data": "aGVsbG8="}}
-    ]
-    assert Blob(**converted[0]["inline_data"]).data == b"hello"
-
-
-def test_parse_chat_history_tool_calls_foreign_signatures_not_leaked() -> None:
-    """Signatures from other providers are stripped before sending to Google."""
+@pytest.mark.parametrize(
+    ("block", "expected_mime_type", "expected_data"),
+    [
+        pytest.param(
+            {"type": "image", "base64": "aGVsbG8=", "mime_type": "image/png"},
+            "image/png",
+            b"hello",
+            id="image",
+        ),
+        pytest.param(
+            {"type": "file", "base64": "d29ybGQ=", "mime_type": "text/plain"},
+            "text/plain",
+            b"world",
+            id="file",
+        ),
+    ],
+)
+def test_parse_chat_history_tool_calls_v1_preserves_inline_media(
+    block: dict[str, Any],
+    expected_mime_type: str,
+    expected_data: bytes,
+) -> None:
+    """Convert projected v1beta media dictionaries into real Gemini media parts."""
     message = AIMessage(
         content=[
-            {
-                "type": "reasoning",
-                "reasoning": "I should search.",
-                "extras": {
-                    "signature": base64.b64encode(b"openai_sig").decode("ascii")
-                },
-            }
+            block,
+            {"type": "tool_call", "id": "call_1", "name": "search", "args": {}},
         ],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": "openai"},
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
     )
 
     _, formatted_messages = _parse_chat_history([message])
@@ -4541,32 +4308,17 @@ def test_parse_chat_history_tool_calls_foreign_signatures_not_leaked() -> None:
     parts = formatted_messages[0].parts
     assert parts is not None
     assert len(parts) == 2
-    assert parts[0].thought is True
-    assert parts[0].text == "I should search."
-    # Signature is from another provider and must not be echoed to Google
-    assert parts[0].thought_signature is None
+    assert parts[0].inline_data is not None
+    assert parts[0].inline_data.mime_type == expected_mime_type
+    assert parts[0].inline_data.data == expected_data
+    assert parts[0].text is None
+    assert parts[1].function_call is not None
 
 
-def test_parse_chat_history_tool_calls_v1_preserves_media_and_code_parts() -> None:
-    """v1-projected media/code parts survive the tool-call branch.
-
-    `_convert_from_v1_to_generativelanguage_v1beta` produces type-less v1beta
-    dicts (`inline_data`, `file_data`, `executable_code`,
-    `code_execution_result`); they must be converted to real media/code parts
-    rather than stringified as text.
-    """
+def test_parse_chat_history_tool_calls_v1_preserves_code_execution() -> None:
+    """Keep projected code execution separate from the rebuilt function call."""
     message = AIMessage(
         content=[
-            {
-                "type": "image",
-                "base64": "aGVsbG8=",
-                "mime_type": "image/png",
-            },
-            {
-                "type": "file",
-                "base64": "d29ybGQ=",
-                "mime_type": "text/plain",
-            },
             {
                 "type": "server_tool_call",
                 "name": "code_interpreter",
@@ -4591,58 +4343,31 @@ def test_parse_chat_history_tool_calls_v1_preserves_media_and_code_parts() -> No
 
     parts = formatted_messages[0].parts
     assert parts is not None
-    assert len(parts) == 5
-    image_part = parts[0]
-    assert image_part.inline_data is not None
-    assert image_part.inline_data.mime_type == "image/png"
-    assert image_part.inline_data.data == b"hello"
-    assert image_part.text is None
-    file_part = parts[1]
-    assert file_part.inline_data is not None
-    assert file_part.inline_data.mime_type == "text/plain"
-    assert file_part.inline_data.data == b"world"
-    assert file_part.text is None
-    executable_part = parts[2]
+    assert len(parts) == 3
+    executable_part = parts[0]
     assert executable_part.executable_code is not None
     assert executable_part.executable_code.code == "print(1)"
     assert executable_part.executable_code.language == Language.PYTHON
-    result_part = parts[3]
+    result_part = parts[1]
     assert result_part.code_execution_result is not None
     assert result_part.code_execution_result.output == "1"
     assert result_part.code_execution_result.outcome == (
         CodeExecutionResultOutcome.OUTCOME_OK
     )
-    function_call_parts = [part for part in parts if part.function_call]
-    assert len(function_call_parts) == 1
+    assert parts[2].function_call is not None
 
 
-def test_parse_chat_history_tool_calls_skips_empty_text_blocks() -> None:
-    """Empty text blocks don't produce empty parts (Gemini rejects them)."""
+@pytest.mark.parametrize("output_version", [None, "v1"])
+def test_parse_chat_history_tool_calls_skips_empty_text(
+    output_version: str | None,
+) -> None:
+    response_metadata = {"model_provider": "google_genai"}
+    if output_version is not None:
+        response_metadata["output_version"] = output_version
     message = AIMessage(
         content=[{"type": "text", "text": ""}],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 1
-    assert parts[0].function_call is not None
-
-
-def test_parse_chat_history_tool_calls_skips_empty_v1_text() -> None:
-    """Empty text blocks in v1-projected messages don't produce empty parts."""
-    message = AIMessage(
-        content=[
-            {"type": "text", "text": ""},
-            {"type": "tool_call", "id": "call_1", "name": "search", "args": {}},
-        ],
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={
-            "model_provider": "google_genai",
-            "output_version": "v1",
-        },
+        response_metadata=response_metadata,
     )
 
     _, formatted_messages = _parse_chat_history([message])
@@ -4654,7 +4379,7 @@ def test_parse_chat_history_tool_calls_skips_empty_v1_text() -> None:
 
 
 def test_parse_chat_history_tool_calls_v1_no_duplicate_function_calls() -> None:
-    """v1-projected messages emit exactly one FunctionCall part per tool call."""
+    """Emit calls once when both v1 content and `tool_calls` contain them."""
     message = AIMessage(
         content="Searching now.",
         tool_calls=[
@@ -4672,8 +4397,6 @@ def test_parse_chat_history_tool_calls_v1_no_duplicate_function_calls() -> None:
             },
         }
     )
-    # Content blocks carry the tool calls AND `message.tool_calls` is set; the
-    # function calls must still be emitted exactly once each.
     assert any(
         isinstance(block, dict) and block.get("type") == "tool_call"
         for block in v1_message.content
@@ -4689,7 +4412,6 @@ def test_parse_chat_history_tool_calls_v1_no_duplicate_function_calls() -> None:
     assert function_call_parts[1].function_call is not None
     assert function_call_parts[0].function_call.args == {"q": "a"}
     assert function_call_parts[1].function_call.args == {"q": "b"}
-    # Text content is preserved too
     assert [part for part in parts if part.text == "Searching now."]
 
 
@@ -8009,103 +7731,7 @@ def test_context_overflow_error_backwards_compatibility() -> None:
         assert isinstance(exc_info.value, GoogleContextOverflowError)
 
 
-# --- Gap coverage for tool-call history conversion helpers --------------------
-
-
-@pytest.mark.parametrize(
-    ("sig", "expected"),
-    [
-        (base64.b64encode(b"sig").decode("ascii"), b"sig"),
-        (b"raw_bytes", b"raw_bytes"),
-        ("", None),
-        (b"", None),
-        (None, None),
-        (123, None),
-    ],
-)
-def test_decode_signature(sig: Any, expected: bytes | None) -> None:
-    """Both wire shapes decode, and every empty form normalizes to `None`.
-
-    The empty-string case matters: returning `b""` instead of `None` would emit a
-    part with a zero-length signature, which is not the same as no signature.
-    """
-    assert _decode_signature(sig) == expected
-
-
-def test_convert_to_parts_decodes_bytes_thought_signature() -> None:
-    """A v1beta thought part may carry raw bytes rather than base64."""
-    parts = _convert_to_parts(
-        [{"thought": True, "text": "Thinking.", "thought_signature": b"raw_sig"}]
-    )
-
-    assert len(parts) == 1
-    assert parts[0].thought is True
-    assert parts[0].thought_signature == b"raw_sig"
-
-
-def test_convert_to_parts_typed_block_wins_over_thought_key() -> None:
-    """An explicit `type` takes precedence over the type-less `thought` sniffing.
-
-    Regression guard: the `thought` branch used to run before the `type` chain, so
-    a block carrying both was silently reinterpreted as a thought part.
-    """
-    parts = _convert_to_parts(
-        [{"type": "text", "text": "Not a thought.", "thought": True}]
-    )
-
-    assert len(parts) == 1
-    assert parts[0].text == "Not a thought."
-    assert parts[0].thought is not True
-
-
-def test_convert_to_parts_empty_inline_data_is_not_a_file_part() -> None:
-    """An empty-but-present `inline_data` must not fall through to `file_data`.
-
-    Regression guard: the branch resolved the payload with
-    `part.get("inline_data") or part.get("file_data")`, so a falsy `inline_data`
-    was emitted as a `file_data` part.
-    """
-    parts = _convert_to_parts([{"inline_data": {}}])
-
-    assert len(parts) == 1
-    assert parts[0].inline_data is not None
-    assert parts[0].file_data is None
-
-
-@pytest.mark.parametrize(
-    ("block", "attr"),
-    [
-        ({"inline_data": {"mime_type": None, "data": "aGk="}}, "inline_data"),
-        ({"file_data": {"mime_type": None, "file_uri": "gs://b/o"}}, "file_data"),
-        ({"executable_code": {"language": None, "code": "x=1"}}, "executable_code"),
-        (
-            {"code_execution_result": {"outcome": None, "output": "1"}},
-            "code_execution_result",
-        ),
-    ],
-)
-def test_convert_to_parts_v1beta_shapes_tolerate_none_valued_keys(
-    block: dict[str, Any], attr: str
-) -> None:
-    """A `None`-valued key converts rather than failing validation.
-
-    `_compat` fills these fields with defaults, so `None` should not occur; this
-    pins the tolerance so that a stricter `google-genai` release surfaces here
-    rather than as a dropped media block in production.
-    """
-    parts = _convert_to_parts([block])
-
-    assert len(parts) == 1
-    assert getattr(parts[0], attr) is not None
-
-
 def test_parse_chat_history_tool_calls_native_strips_tool_call_blocks() -> None:
-    """Function-call blocks are stripped even on the strict native path.
-
-    Native content is converted strictly, so a leftover `tool_call` block would
-    raise `Unrecognized message part type` rather than be dropped. The tolerant
-    path hides this, which is why this test pins a native provider.
-    """
     message = AIMessage(
         content=[
             {"type": "text", "text": "Looking it up."},
@@ -8127,12 +7753,6 @@ def test_parse_chat_history_tool_calls_native_strips_tool_call_blocks() -> None:
 
 
 def test_parse_chat_history_tool_calls_foreign_server_tool_filtered_silently() -> None:
-    """A foreign non-code-interpreter server tool is filtered before conversion.
-
-    It must be dropped by the content filter, not by `_convert_to_parts`'s
-    warn-and-skip: reaching the latter means an unexpected `UserWarning` on every
-    turn of a multi-provider conversation.
-    """
     message = AIMessage(
         content=[
             {"type": "text", "text": "Searching."},
@@ -8159,7 +7779,6 @@ def test_parse_chat_history_tool_calls_foreign_server_tool_filtered_silently() -
 
 
 def test_parse_chat_history_tool_calls_keeps_bare_string_content_blocks() -> None:
-    """Non-dict list entries pass through; empty strings are dropped."""
     message = AIMessage(
         content=["Hello.", "", {"type": "text", "text": "World."}],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
@@ -8174,38 +7793,9 @@ def test_parse_chat_history_tool_calls_keeps_bare_string_content_blocks() -> Non
     assert parts[2].function_call is not None
 
 
-def test_convert_to_parts_joins_multi_segment_summary() -> None:
-    """Every `summary` segment is concatenated, and non-dict entries are skipped.
-
-    Guards against silently truncating a multi-segment reasoning summary to its
-    first element.
-    """
-    parts = _convert_to_parts(
-        [
-            {
-                "type": "reasoning",
-                "summary": [
-                    {"type": "summary_text", "text": "First."},
-                    "not a dict",
-                    {"type": "summary_text", "text": "Second."},
-                ],
-            }
-        ]
-    )
-
-    assert len(parts) == 1
-    assert parts[0].text == "First. Second."
-    assert parts[0].thought is True
-
-
 def test_lenient_conversion_logs_the_underlying_cause(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The dropped block's actual error is reported, not just "no equivalent".
-
-    Media loading raises actionable errors (e.g. a rejected local file path) that
-    the tolerant path would otherwise discard.
-    """
     message = AIMessage(
         content=[
             {"type": "text", "text": "Here it is."},
@@ -8221,46 +7811,5 @@ def test_lenient_conversion_logs_the_underlying_cause(
     assert parts is not None
     assert parts[0].text == "Here it is."
     assert "Dropping content block that cannot" in caplog.text
-    # The actionable cause reaches the log, not just "Gemini has no equivalent".
-    # Media loading rejects unusable sources with remediation text; discarding it
-    # would tell the caller only that Gemini cannot represent an image, which is
-    # both false and unfixable-sounding.
     assert "./secrets/local.png" in caplog.text
     assert "Media string must be one of" in caplog.text
-
-
-@pytest.mark.parametrize(
-    ("content", "model_provider", "expected_fragment"),
-    [
-        (
-            [{"type": "brand_new_core_block"}],
-            "google_genai",
-            "no Gemini equivalent",
-        ),
-        (
-            [{"type": "non_standard", "value": {"type": "redacted_thinking"}}],
-            "anthropic",
-            "non-standard v1 content block",
-        ),
-        (["not a mapping"], "google_genai", "not a typed mapping"),
-    ],
-)
-def test_convert_from_v1_logs_dropped_blocks(
-    content: list[Any],
-    model_provider: str,
-    expected_fragment: str,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Every v1 drop is diagnosable.
-
-    The v1 tool-call path converts native content strictly on the assumption that
-    `_compat` already removed anything unrepresentable, so a silent drop here is
-    the only trace of lost content.
-    """
-    with caplog.at_level(logging.WARNING):
-        result = _convert_from_v1_to_generativelanguage_v1beta(
-            cast("Any", content), model_provider
-        )
-
-    assert result == []
-    assert expected_fragment in caplog.text

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+import logging
 import os
 import warnings
 from collections.abc import AsyncIterator, Callable, Iterator
@@ -3383,6 +3384,39 @@ def test_parse_chat_history_tool_calls_normalizes_anthropic_tool_use() -> None:
     assert parts[1].function_call is not None
     assert parts[1].function_call.name == "search"
     assert parts[1].function_call.args == {"q": "x"}
+
+
+def test_parse_chat_history_tool_calls_non_standard_block_dropped(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Provider payloads core cannot standardize are dropped, not raised on.
+
+    LangChain core wraps content it has no standard block for (e.g. Anthropic's
+    `redacted_thinking`) in a `non_standard` block. Gemini cannot represent
+    another provider's opaque payload, so it must be skipped with a warning
+    rather than aborting the whole request.
+    """
+    message = AIMessage(
+        content=[{"type": "redacted_thinking", "data": "encrypted"}],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "anthropic"},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    # Only the function call survives; the opaque payload is dropped
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+    assert "non-standard content block" in caplog.text
+
+
+def test_convert_to_parts_still_raises_on_unknown_type() -> None:
+    """Dropping `non_standard` must not weaken the guard on malformed blocks."""
+    with pytest.raises(ValueError, match="Unrecognized message part type: bogus"):
+        _convert_to_parts([{"type": "bogus"}])
 
 
 def test_parse_chat_history_tool_calls_foreign_reasoning_block() -> None:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3653,6 +3653,53 @@ def test_parse_chat_history_tool_calls_unknown_provider_drops_foreign_block(
     assert "cannot be represented as a Gemini part" in caplog.text
 
 
+def test_parse_chat_history_tool_calls_native_invalid_media_raises() -> None:
+    """A native block that fails validation must not be silently dropped.
+
+    A malformed media block on a `google_genai` message is bad input, not an
+    expected foreign shape; dropping it would turn the request into a different
+    valid request without telling the caller.
+    """
+    message = AIMessage(
+        content=[
+            {"type": "media", "mime_type": "image/png", "data": "not valid base64!!"},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "google_genai"},
+    )
+
+    with pytest.raises(ValueError, match="valid base64"):
+        _parse_chat_history([message])
+
+
+def test_parse_chat_history_tool_calls_foreign_malformed_media_still_dropped(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Another provider's malformed block is dropped, not raised on.
+
+    Only native content regains strict validation; multi-provider histories keep
+    the tolerant behavior since unconvertible foreign blocks are expected.
+    """
+    message = AIMessage(
+        content=[
+            {"type": "media", "mime_type": "image/png", "data": "not valid base64!!"},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "openai"},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+    # Core projects an unknown provider's `media` block to `non_standard`; the
+    # tolerant path drops it with a warning instead of failing the request.
+    assert "Dropping non-standard content block" in caplog.text
+
+
 def test_parse_chat_history_tool_calls_vertexai_signature_preserved() -> None:
     """Vertex AI serves the same Gemini models, so its signatures stay valid."""
     signature = base64.b64encode(b"vertex_sig").decode("ascii")

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4287,6 +4287,27 @@ def test_parse_chat_history_drops_vertex_gcs_for_gemini_backend() -> None:
     assert parts[0].function_call is not None
 
 
+def test_parse_chat_history_drops_nested_vertex_gcs_for_gemini_backend() -> None:
+    """Nested Chat Completions image URLs receive the same backend filtering."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "image_url",
+                "image_url": {"url": "gs://bucket/image.png"},
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "google_vertexai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message], use_vertexai=False)
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+
+
 @pytest.mark.parametrize("vertexai", [False, True])
 def test_prepare_request_checks_target_backend_for_vertex_gcs_history(
     vertexai: bool,

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4022,6 +4022,33 @@ def test_parse_chat_history_tool_calls_v1_file_id_becomes_file_data() -> None:
     assert parts[0].file_data.mime_type == "application/pdf"
 
 
+def test_parse_chat_history_tool_calls_v1_foreign_file_id_dropped() -> None:
+    """A provider-scoped foreign file ID must not be replayed to Gemini."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "file",
+                "file_id": "file-openai-abc",
+                "mime_type": "application/pdf",
+            },
+            {"type": "tool_call", "name": "search", "args": {}, "id": "call_1"},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "openai",
+            "output_version": "v1",
+        },
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+    assert parts[0].function_call.name == "search"
+
+
 def test_parse_chat_history_tool_calls_v1_text_signature_decoded() -> None:
     """A signature on a v1 `text` block round-trips as decoded bytes."""
     signature = base64.b64encode(b"text_sig").decode("ascii")

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -176,7 +176,7 @@ def test_integration_initialization() -> None:
 def test_empty_ai_message_content_is_normalized_for_vertex(
     response_metadata: dict[str, str], vertexai: bool
 ) -> None:
-    """Test empty AI content lists become empty text parts for Vertex only."""
+    """Test empty AI content lists never produce a partless model turn."""
     llm = ChatGoogleGenerativeAI(
         model=MODEL_NAME,
         google_api_key=SecretStr(FAKE_API_KEY),
@@ -194,11 +194,8 @@ def test_empty_ai_message_content_is_normalized_for_vertex(
     empty_ai_content = request["contents"][1]
     assert empty_ai_content.role == "model"
     assert empty_ai_content.parts is not None
-    if vertexai:
-        assert len(empty_ai_content.parts) == 1
-        assert empty_ai_content.parts[0].text == ""
-    else:
-        assert empty_ai_content.parts == []
+    assert len(empty_ai_content.parts) == 1
+    assert empty_ai_content.parts[0].text == ""
 
 
 def test_seed_initialization() -> None:
@@ -3544,6 +3541,131 @@ def test_parse_chat_history_drops_malformed_foreign_media(
     assert len(parts) == 1
     assert parts[0].function_call is not None
     assert "Dropping" in caplog.text
+
+
+def test_parse_chat_history_falls_back_for_foreign_server_tools(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Avoid a partless model turn when every foreign server-tool block is dropped."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "server_tool_call",
+                "name": "web_search",
+                "id": "srv_1",
+                "args": {"query": "x"},
+            },
+            {
+                "type": "server_tool_result",
+                "tool_call_id": "srv_1",
+                "status": "success",
+                "output": {},
+            },
+        ],
+        response_metadata={"model_provider": "anthropic"},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        _, formatted_messages = _parse_chat_history(
+            [HumanMessage("hi"), message, HumanMessage("again")],
+            model=MODEL_NAME,
+        )
+
+    parts = formatted_messages[1].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].text == ""
+    assert "AI message at index 1" in caplog.text
+    assert "2 content block(s) were dropped" in caplog.text
+
+
+def test_parse_chat_history_falls_back_for_unsupported_vertex_gcs() -> None:
+    """Avoid a partless model turn when Developer API replay drops Vertex GCS."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "file_data",
+                "file_uri": "gs://bucket/document.pdf",
+                "mime_type": "application/pdf",
+            }
+        ],
+        response_metadata={"model_provider": "google_vertexai"},
+    )
+
+    _, formatted_messages = _parse_chat_history(
+        [HumanMessage("hi"), message, HumanMessage("again")],
+        model=MODEL_NAME,
+    )
+
+    parts = formatted_messages[1].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].text == ""
+
+
+def test_parse_chat_history_falls_back_for_unsigned_v1_reasoning() -> None:
+    """Avoid a partless model turn when v1 reasoning has no thought signature."""
+    message = AIMessage(
+        content=[{"type": "reasoning", "reasoning": "hmm"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
+    )
+
+    _, formatted_messages = _parse_chat_history(
+        [HumanMessage("hi"), message, HumanMessage("again")],
+        model=MODEL_NAME,
+    )
+
+    parts = formatted_messages[1].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].text == ""
+
+
+def test_parse_chat_history_falls_back_for_invalid_unknown_provider_media() -> None:
+    """Avoid a partless model turn when the only unknown-provider block is invalid."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "media",
+                "mime_type": "image/png",
+                "data": "not valid base64!!",
+            }
+        ]
+    )
+
+    _, formatted_messages = _parse_chat_history(
+        [HumanMessage("hi"), message, HumanMessage("again")],
+        model=MODEL_NAME,
+    )
+
+    parts = formatted_messages[1].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].text == ""
+
+
+def test_filter_messages_empty_foreign_vertex_model_turn_remains_replayable() -> None:
+    """Preserve the Vertex empty-content workaround through foreign block filtering."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        api_key=FAKE_API_KEY,
+        project="test-project",
+        vertexai=True,
+    )
+    message = AIMessage(
+        content=[],
+        response_metadata={"model_provider": "anthropic"},
+    )
+
+    request = llm._prepare_request([HumanMessage("hi"), message, HumanMessage("again")])
+
+    parts = request["contents"][1].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].text == ""
 
 
 @pytest.mark.parametrize(

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4063,6 +4063,38 @@ def test_parse_chat_history_tool_calls_strips_tool_call_chunk_blocks() -> None:
     assert len([p for p in parts if p.function_call]) == 1
 
 
+@pytest.mark.parametrize("output_version", [None, "v1"])
+def test_parse_chat_history_consumes_legacy_function_call_signature(
+    output_version: str | None,
+) -> None:
+    """Legacy signature sidecars are attached to rebuilt function calls."""
+    signature = base64.b64encode(b"legacy_sig").decode("ascii")
+    response_metadata = {"model_provider": "google_vertexai"}
+    if output_version is not None:
+        response_metadata["output_version"] = output_version
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "Calling a tool."},
+            {
+                "type": "function_call_signature",
+                "signature": signature,
+                "index": 0,
+            },
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata=response_metadata,
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].text == "Calling a tool."
+    assert parts[1].function_call is not None
+    assert parts[1].thought_signature == b"legacy_sig"
+
+
 @pytest.mark.parametrize(
     ("model_provider", "file_uri"),
     [

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3527,6 +3527,33 @@ def test_parse_chat_history_tool_calls_non_standard_block_dropped(
     assert "non-standard content block" in caplog.text
 
 
+def test_parse_chat_history_without_tool_calls_drops_foreign_non_standard() -> None:
+    """Foreign provider payloads are filtered even without function calls."""
+    signature = base64.b64encode(b"anthropic_signature").decode("ascii")
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "Visible response."},
+            {
+                "type": "non_standard",
+                "value": {
+                    "type": "thinking",
+                    "thinking": "Private reasoning.",
+                    "signature": signature,
+                },
+            },
+        ],
+        response_metadata={"model_provider": "anthropic"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].text == "Visible response."
+    assert parts[0].thought_signature is None
+
+
 def test_parse_chat_history_tool_calls_v1_non_standard_block_dropped() -> None:
     """Serialized v1 provider payloads are dropped before Gemini conversion."""
     message = AIMessage(

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3413,6 +3413,30 @@ def test_parse_chat_history_tool_calls_non_standard_block_dropped(
     assert "non-standard content block" in caplog.text
 
 
+def test_parse_chat_history_tool_calls_v1_non_standard_block_dropped() -> None:
+    """Serialized v1 provider payloads are dropped before Gemini conversion."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "non_standard",
+                "value": {"type": "redacted_thinking", "data": "encrypted"},
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "anthropic",
+            "output_version": "v1",
+        },
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+
+
 def test_convert_to_parts_still_raises_on_unknown_type() -> None:
     """Dropping `non_standard` must not weaken the guard on malformed blocks."""
     with pytest.raises(ValueError, match="Unrecognized message part type: bogus"):

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3386,6 +3386,46 @@ def test_parse_chat_history_tool_calls_normalizes_anthropic_tool_use() -> None:
     assert parts[1].function_call.args == {"q": "x"}
 
 
+def test_parse_chat_history_tool_calls_drops_invalid_foreign_calls() -> None:
+    """Malformed foreign calls do not prevent valid calls from being replayed."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "function_call",
+                "name": "search",
+                "arguments": "{}",
+                "call_id": "call_1",
+                "id": "fc_1",
+            },
+            {
+                "type": "function_call",
+                "name": "broken",
+                "arguments": "{",
+                "call_id": "call_bad",
+                "id": "fc_bad",
+            },
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        invalid_tool_calls=[
+            {
+                "name": "broken",
+                "args": "{",
+                "id": "call_bad",
+                "error": "Invalid JSON",
+            }
+        ],
+        response_metadata={"model_provider": "openai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+    assert parts[0].function_call.name == "search"
+
+
 def test_parse_chat_history_tool_calls_non_standard_block_dropped(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3437,9 +3437,7 @@ def test_parse_chat_history_tool_calls_drops_foreign_web_search_pair() -> None:
                 "action": {
                     "type": "search",
                     "query": "weather",
-                    "sources": [
-                        {"type": "url", "url": "https://example.com/weather"}
-                    ],
+                    "sources": [{"type": "url", "url": "https://example.com/weather"}],
                 },
             },
             {

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3550,6 +3550,60 @@ def test_parse_chat_history_tool_calls_v1_non_standard_block_dropped() -> None:
     assert parts[0].function_call is not None
 
 
+def test_parse_chat_history_tool_calls_v1_foreign_malformed_media_dropped(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A foreign v1 media block with malformed base64 is dropped, not raised on.
+
+    `_compat` converts the block to an `inline_data` v1beta dict without
+    validating the base64 payload, so the failure only surfaces when the dict is
+    converted to a `Blob`. Foreign v1 messages keep the tolerant per-block
+    behavior of the non-v1 branch; the valid tool call must still be replayed.
+    """
+    message = AIMessage(
+        content=[
+            {"type": "image", "base64": "not valid base64!!", "mime_type": "image/png"}
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "openai",
+            "output_version": "v1",
+        },
+    )
+
+    with caplog.at_level(logging.WARNING):
+        _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+    assert parts[0].function_call.name == "search"
+    assert "cannot be represented as a Gemini part" in caplog.text
+
+
+def test_parse_chat_history_tool_calls_v1_native_malformed_media_raises() -> None:
+    """A native v1 media block with malformed base64 must not be silently dropped.
+
+    Unlike foreign content, a malformed `google_genai` block is bad input, not an
+    expected foreign shape; dropping it would turn the request into a different
+    valid request without telling the caller.
+    """
+    message = AIMessage(
+        content=[
+            {"type": "image", "base64": "not valid base64!!", "mime_type": "image/png"}
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
+    )
+
+    with pytest.raises(ValueError, match="valid base64"):
+        _parse_chat_history([message])
+
+
 def test_convert_to_parts_still_raises_on_unknown_type() -> None:
     """Dropping `non_standard` must not weaken the guard on malformed blocks."""
     with pytest.raises(ValueError, match="Unrecognized message part type: bogus"):

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3823,6 +3823,37 @@ def test_parse_chat_history_tool_calls_native_v1_signature_preserved(
     assert parts[2].function_call is not None
 
 
+@pytest.mark.parametrize("output_version", [None, "v1"])
+def test_parse_chat_history_vertex_text_thought_signature_preserved(
+    output_version: str | None,
+) -> None:
+    """Vertex's top-level text signature survives both history paths."""
+    signature = base64.b64encode(b"vertex_sig").decode("ascii")
+    response_metadata = {"model_provider": "google_vertexai"}
+    if output_version is not None:
+        response_metadata["output_version"] = output_version
+    message = AIMessage(
+        content=[
+            {
+                "type": "text",
+                "text": "Answer.",
+                "thought_signature": signature,
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata=response_metadata,
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].text == "Answer."
+    assert parts[0].thought_signature == b"vertex_sig"
+    assert parts[1].function_call is not None
+
+
 def test_parse_chat_history_tool_calls_v1_unknown_provider_preserves_signature() -> (
     None
 ):

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4195,6 +4195,32 @@ def test_parse_chat_history_consumes_legacy_function_call_signature(
     assert parts[1].thought_signature == b"legacy_sig"
 
 
+@pytest.mark.parametrize("output_version", [None, "v1"])
+def test_parse_chat_history_maps_unindexed_legacy_function_call_signature(
+    output_version: str | None,
+) -> None:
+    """Unindexed legacy sidecars use signature order, not content position."""
+    signature = base64.b64encode(b"unindexed_legacy_sig").decode("ascii")
+    response_metadata = {"model_provider": "google_vertexai"}
+    if output_version is not None:
+        response_metadata["output_version"] = output_version
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "Calling a tool."},
+            {"type": "function_call_signature", "signature": signature},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata=response_metadata,
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert parts[1].function_call is not None
+    assert parts[1].thought_signature == b"unindexed_legacy_sig"
+
+
 @pytest.mark.parametrize(
     ("model_provider", "file_uri"),
     [

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3456,6 +3456,11 @@ def test_parse_chat_history_tool_calls_v1_preserves_media_and_code_parts() -> No
                 "mime_type": "image/png",
             },
             {
+                "type": "file",
+                "base64": "d29ybGQ=",
+                "mime_type": "text/plain",
+            },
+            {
                 "type": "server_tool_call",
                 "name": "code_interpreter",
                 "args": {"code": "print(1)", "language": "python"},
@@ -3479,17 +3484,22 @@ def test_parse_chat_history_tool_calls_v1_preserves_media_and_code_parts() -> No
 
     parts = formatted_messages[0].parts
     assert parts is not None
-    assert len(parts) == 4
+    assert len(parts) == 5
     image_part = parts[0]
     assert image_part.inline_data is not None
     assert image_part.inline_data.mime_type == "image/png"
-    assert image_part.inline_data.data == b"aGVsbG8="
+    assert image_part.inline_data.data == b"hello"
     assert image_part.text is None
-    executable_part = parts[1]
+    file_part = parts[1]
+    assert file_part.inline_data is not None
+    assert file_part.inline_data.mime_type == "text/plain"
+    assert file_part.inline_data.data == b"world"
+    assert file_part.text is None
+    executable_part = parts[2]
     assert executable_part.executable_code is not None
     assert executable_part.executable_code.code == "print(1)"
     assert executable_part.executable_code.language == Language.PYTHON
-    result_part = parts[2]
+    result_part = parts[3]
     assert result_part.code_execution_result is not None
     assert result_part.code_execution_result.output == "1"
     assert result_part.code_execution_result.outcome == (

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -78,6 +78,7 @@ from langchain_google_genai.chat_models import (
     GoogleContextOverflowError,
     _convert_to_parts,
     _convert_tool_message_to_parts,
+    _decode_signature,
     _get_ai_message_tool_messages_parts,
     _handle_client_error,
     _handle_server_error,
@@ -3579,7 +3580,7 @@ def test_parse_chat_history_tool_calls_v1_foreign_malformed_media_dropped(
     assert len(parts) == 1
     assert parts[0].function_call is not None
     assert parts[0].function_call.name == "search"
-    assert "cannot be represented as a Gemini part" in caplog.text
+    assert "Dropping content block that cannot" in caplog.text
 
 
 def test_parse_chat_history_tool_calls_v1_native_malformed_media_raises() -> None:
@@ -3704,7 +3705,7 @@ def test_parse_chat_history_tool_calls_unknown_provider_drops_foreign_block(
     assert parts[0].text == "Let me look that up."
     assert parts[1].function_call is not None
     assert parts[1].function_call.name == "search"
-    assert "cannot be represented as a Gemini part" in caplog.text
+    assert "Dropping content block that cannot" in caplog.text
 
 
 def test_parse_chat_history_tool_calls_native_invalid_media_raises() -> None:
@@ -3754,13 +3755,16 @@ def test_parse_chat_history_tool_calls_foreign_malformed_media_still_dropped(
     assert "Dropping non-standard content block" in caplog.text
 
 
-def test_parse_chat_history_tool_calls_vertexai_signature_preserved() -> None:
+@pytest.mark.parametrize("model_provider", ["google_genai", "google_vertexai"])
+def test_parse_chat_history_tool_calls_native_v0_signature_preserved(
+    model_provider: str,
+) -> None:
     """Vertex AI serves the same Gemini models, so its signatures stay valid."""
     signature = base64.b64encode(b"vertex_sig").decode("ascii")
     message = AIMessage(
         content=[{"type": "thinking", "thinking": "Thinking.", "signature": signature}],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": "google_vertexai"},
+        response_metadata={"model_provider": model_provider},
     )
 
     _, formatted_messages = _parse_chat_history([message])
@@ -3770,6 +3774,47 @@ def test_parse_chat_history_tool_calls_vertexai_signature_preserved() -> None:
     assert len(parts) == 2
     assert parts[0].thought is True
     assert parts[0].thought_signature == b"vertex_sig"
+
+
+@pytest.mark.parametrize("model_provider", ["google_genai", "google_vertexai"])
+def test_parse_chat_history_tool_calls_native_v1_signature_preserved(
+    model_provider: str,
+) -> None:
+    """Both native providers keep reasoning text and signatures on the v1 path.
+
+    Regression guard: `_compat` used to gate v1 signature handling on
+    `google_genai` alone, so a Vertex AI turn lost its reasoning block entirely
+    and had its text signature stripped. The signature then fell through to
+    `DUMMY_THOUGHT_SIGNATURE`, silently degrading thinking continuity.
+    """
+    signature = base64.b64encode(b"vertex_sig").decode("ascii")
+    message = AIMessage(
+        content=[
+            {
+                "type": "reasoning",
+                "reasoning": "Thinking.",
+                "extras": {"signature": signature},
+            },
+            {"type": "text", "text": "Answer.", "extras": {"signature": signature}},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": model_provider,
+            "output_version": "v1",
+        },
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 3
+    assert parts[0].thought is True
+    assert parts[0].text == "Thinking."
+    assert parts[0].thought_signature == b"vertex_sig"
+    assert parts[1].text == "Answer."
+    assert parts[1].thought_signature == b"vertex_sig"
+    assert parts[2].function_call is not None
 
 
 def test_parse_chat_history_tool_calls_summary_reasoning_kept_without_metadata() -> (
@@ -7575,3 +7620,271 @@ def test_context_overflow_error_backwards_compatibility() -> None:
         assert isinstance(exc_info.value, ClientError)
         assert isinstance(exc_info.value, ContextOverflowError)
         assert isinstance(exc_info.value, GoogleContextOverflowError)
+
+
+# --- Gap coverage for tool-call history conversion helpers --------------------
+
+
+@pytest.mark.parametrize(
+    ("sig", "expected"),
+    [
+        (base64.b64encode(b"sig").decode("ascii"), b"sig"),
+        (b"raw_bytes", b"raw_bytes"),
+        ("", None),
+        (b"", None),
+        (None, None),
+        (123, None),
+    ],
+)
+def test_decode_signature(sig: Any, expected: bytes | None) -> None:
+    """Both wire shapes decode, and every empty form normalizes to `None`.
+
+    The empty-string case matters: returning `b""` instead of `None` would emit a
+    part with a zero-length signature, which is not the same as no signature.
+    """
+    assert _decode_signature(sig) == expected
+
+
+def test_convert_to_parts_decodes_bytes_thought_signature() -> None:
+    """A v1beta thought part may carry raw bytes rather than base64."""
+    parts = _convert_to_parts(
+        [{"thought": True, "text": "Thinking.", "thought_signature": b"raw_sig"}]
+    )
+
+    assert len(parts) == 1
+    assert parts[0].thought is True
+    assert parts[0].thought_signature == b"raw_sig"
+
+
+def test_convert_to_parts_typed_block_wins_over_thought_key() -> None:
+    """An explicit `type` takes precedence over the type-less `thought` sniffing.
+
+    Regression guard: the `thought` branch used to run before the `type` chain, so
+    a block carrying both was silently reinterpreted as a thought part.
+    """
+    parts = _convert_to_parts(
+        [{"type": "text", "text": "Not a thought.", "thought": True}]
+    )
+
+    assert len(parts) == 1
+    assert parts[0].text == "Not a thought."
+    assert parts[0].thought is not True
+
+
+def test_convert_to_parts_empty_inline_data_is_not_a_file_part() -> None:
+    """An empty-but-present `inline_data` must not fall through to `file_data`.
+
+    Regression guard: the branch resolved the payload with
+    `part.get("inline_data") or part.get("file_data")`, so a falsy `inline_data`
+    was emitted as a `file_data` part.
+    """
+    parts = _convert_to_parts([{"inline_data": {}}])
+
+    assert len(parts) == 1
+    assert parts[0].inline_data is not None
+    assert parts[0].file_data is None
+
+
+@pytest.mark.parametrize(
+    ("block", "attr"),
+    [
+        ({"inline_data": {"mime_type": None, "data": "aGk="}}, "inline_data"),
+        ({"file_data": {"mime_type": None, "file_uri": "gs://b/o"}}, "file_data"),
+        ({"executable_code": {"language": None, "code": "x=1"}}, "executable_code"),
+        (
+            {"code_execution_result": {"outcome": None, "output": "1"}},
+            "code_execution_result",
+        ),
+    ],
+)
+def test_convert_to_parts_v1beta_shapes_tolerate_none_valued_keys(
+    block: dict[str, Any], attr: str
+) -> None:
+    """A `None`-valued key converts rather than failing validation.
+
+    `_compat` fills these fields with defaults, so `None` should not occur; this
+    pins the tolerance so that a stricter `google-genai` release surfaces here
+    rather than as a dropped media block in production.
+    """
+    parts = _convert_to_parts([block])
+
+    assert len(parts) == 1
+    assert getattr(parts[0], attr) is not None
+
+
+def test_parse_chat_history_tool_calls_native_strips_tool_call_blocks() -> None:
+    """Function-call blocks are stripped even on the strict native path.
+
+    Native content is converted strictly, so a leftover `tool_call` block would
+    raise `Unrecognized message part type` rather than be dropped. The tolerant
+    path hides this, which is why this test pins a native provider.
+    """
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "Looking it up."},
+            {"type": "tool_call", "name": "search", "args": {}, "id": "call_1"},
+            {"type": "invalid_tool_call", "name": "search", "args": "{bad"},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "google_genai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].text == "Looking it up."
+    assert parts[1].function_call is not None
+    assert parts[1].function_call.name == "search"
+
+
+def test_parse_chat_history_tool_calls_foreign_server_tool_filtered_silently() -> None:
+    """A foreign non-code-interpreter server tool is filtered before conversion.
+
+    It must be dropped by the content filter, not by `_convert_to_parts`'s
+    warn-and-skip: reaching the latter means an unexpected `UserWarning` on every
+    turn of a multi-provider conversation.
+    """
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "Searching."},
+            {
+                "type": "server_tool_call",
+                "name": "web_search",
+                "id": "srv_1",
+                "args": {"query": "x"},
+            },
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "openai"},
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].text == "Searching."
+    assert parts[1].function_call is not None
+
+
+def test_parse_chat_history_tool_calls_keeps_bare_string_content_blocks() -> None:
+    """Non-dict list entries pass through; empty strings are dropped."""
+    message = AIMessage(
+        content=["Hello.", "", {"type": "text", "text": "World."}],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "google_genai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert [part.text for part in parts[:2]] == ["Hello.", "World."]
+    assert parts[2].function_call is not None
+
+
+def test_parse_chat_history_tool_calls_string_content_is_not_split() -> None:
+    """Scalar string content becomes one text part, not one part per character."""
+    message = AIMessage(
+        content="Hi there",
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "google_genai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].text == "Hi there"
+
+
+def test_convert_to_parts_joins_multi_segment_summary() -> None:
+    """Every `summary` segment is concatenated, and non-dict entries are skipped.
+
+    Guards against silently truncating a multi-segment reasoning summary to its
+    first element.
+    """
+    parts = _convert_to_parts(
+        [
+            {
+                "type": "reasoning",
+                "summary": [
+                    {"type": "summary_text", "text": "First. "},
+                    "not a dict",
+                    {"type": "summary_text", "text": "Second."},
+                ],
+            }
+        ]
+    )
+
+    assert len(parts) == 1
+    assert parts[0].text == "First. Second."
+    assert parts[0].thought is True
+
+
+def test_lenient_conversion_logs_the_underlying_cause(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The dropped block's actual error is reported, not just "no equivalent".
+
+    Media loading raises actionable errors (e.g. a rejected local file path) that
+    the tolerant path would otherwise discard.
+    """
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "Here it is."},
+            {"type": "image_url", "image_url": {"url": "./secrets/local.png"}},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+    )
+
+    with caplog.at_level(logging.WARNING):
+        _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert parts[0].text == "Here it is."
+    assert "Dropping content block that cannot" in caplog.text
+    # The actionable cause reaches the log, not just "Gemini has no equivalent".
+    # Media loading rejects unusable sources with remediation text; discarding it
+    # would tell the caller only that Gemini cannot represent an image, which is
+    # both false and unfixable-sounding.
+    assert "./secrets/local.png" in caplog.text
+    assert "Media string must be one of" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_fragment"),
+    [
+        ([{"type": "brand_new_core_block"}], "no Gemini equivalent"),
+        (
+            [{"type": "non_standard", "value": {"type": "redacted_thinking"}}],
+            "non-standard v1 content block",
+        ),
+        ([{"type": "reasoning", "reasoning": "Unsigned."}], "no thought signature"),
+        (["not a mapping"], "not a typed mapping"),
+    ],
+)
+def test_convert_from_v1_logs_dropped_blocks(
+    content: list[Any],
+    expected_fragment: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Every v1 drop is diagnosable.
+
+    The v1 tool-call path converts native content strictly on the assumption that
+    `_compat` already removed anything unrepresentable, so a silent drop here is
+    the only trace of lost content.
+    """
+    with caplog.at_level(logging.WARNING):
+        result = _convert_from_v1_to_generativelanguage_v1beta(
+            cast("Any", content), "google_genai"
+        )
+
+    assert result == []
+    assert expected_fragment in caplog.text

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3412,6 +3412,102 @@ def test_parse_chat_history_tool_calls_foreign_signatures_not_leaked() -> None:
     assert parts[0].thought_signature is None
 
 
+def test_parse_chat_history_tool_calls_v1_preserves_media_and_code_parts() -> None:
+    """v1-projected media/code parts survive the tool-call branch.
+
+    `_convert_from_v1_to_generativelanguage_v1beta` produces type-less v1beta
+    dicts (`inline_data`, `file_data`, `executable_code`,
+    `code_execution_result`); they must be converted to real media/code parts
+    rather than stringified as text.
+    """
+    message = AIMessage(
+        content=[
+            {
+                "type": "image",
+                "base64": "aGVsbG8=",
+                "mime_type": "image/png",
+            },
+            {
+                "type": "server_tool_call",
+                "name": "code_interpreter",
+                "args": {"code": "print(1)", "language": "python"},
+                "id": "srv_1",
+            },
+            {
+                "type": "server_tool_result",
+                "extras": {"block_type": "code_execution_result", "outcome": 1},
+                "output": "1",
+            },
+            {"type": "tool_call", "id": "call_1", "name": "search", "args": {}},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 4
+    image_part = parts[0]
+    assert image_part.inline_data is not None
+    assert image_part.inline_data.mime_type == "image/png"
+    assert image_part.inline_data.data == b"aGVsbG8="
+    assert image_part.text is None
+    executable_part = parts[1]
+    assert executable_part.executable_code is not None
+    assert executable_part.executable_code.code == "print(1)"
+    assert executable_part.executable_code.language == Language.PYTHON
+    result_part = parts[2]
+    assert result_part.code_execution_result is not None
+    assert result_part.code_execution_result.output == "1"
+    assert result_part.code_execution_result.outcome == (
+        CodeExecutionResultOutcome.OUTCOME_OK
+    )
+    function_call_parts = [part for part in parts if part.function_call]
+    assert len(function_call_parts) == 1
+
+
+def test_parse_chat_history_tool_calls_skips_empty_text_blocks() -> None:
+    """Empty text blocks don't produce empty parts (Gemini rejects them)."""
+    message = AIMessage(
+        content=[{"type": "text", "text": ""}],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+
+
+def test_parse_chat_history_tool_calls_skips_empty_v1_text() -> None:
+    """Empty text blocks in v1-projected messages don't produce empty parts."""
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": ""},
+            {"type": "tool_call", "id": "call_1", "name": "search", "args": {}},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+
+
 def test_parse_chat_history_tool_calls_v1_no_duplicate_function_calls() -> None:
     """v1-projected messages emit exactly one FunctionCall part per tool call."""
     message = AIMessage(

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3706,6 +3706,149 @@ def test_convert_to_parts_still_raises_on_unknown_type() -> None:
         _convert_to_parts([{"type": "bogus"}])
 
 
+@pytest.mark.parametrize(
+    ("message_type", "content"),
+    [
+        pytest.param(
+            HumanMessage,
+            [{"text": "hi", "index": 0}],
+            id="human-index",
+        ),
+        pytest.param(
+            HumanMessage,
+            [{"text": "hi", "id": "x"}],
+            id="human-id",
+        ),
+        pytest.param(
+            SystemMessage,
+            [{"text": "hi", "index": 0}],
+            id="system-index",
+        ),
+        pytest.param(
+            SystemMessage,
+            [{"text": "hi", "id": "x"}],
+            id="system-id",
+        ),
+    ],
+)
+def test_parse_chat_history_tolerates_extra_keys_in_typeless_parts(
+    message_type: type[HumanMessage] | type[SystemMessage],
+    content: list[str | dict[Any, Any]],
+) -> None:
+    """Keep permissive typeless-dict fallback for human and system messages."""
+    system_instruction, formatted_messages = _parse_chat_history(
+        [message_type(content=content)]
+    )
+
+    if message_type is SystemMessage:
+        assert system_instruction is not None
+        parts = system_instruction.parts
+    else:
+        parts = formatted_messages[0].parts
+    assert parts is not None
+    assert parts == [Part(text=str(content[0]))]
+
+
+def test_convert_to_parts_accepts_projected_typeless_text() -> None:
+    """Keep valid projected text dictionaries on the v1beta conversion path."""
+    parts = _convert_to_parts(
+        [{"text": "hi"}],
+        allow_v1beta_dicts=True,
+    )
+
+    assert parts == [Part(text="hi")]
+
+
+def test_parse_chat_history_v1_projected_parts_round_trip() -> None:
+    """Convert every projected v1beta replay shape into a real Gemini part."""
+    projected_content = [
+        {"text": "hi", "thought_signature": "c2ln"},
+        {"inline_data": {"mime_type": "image/png", "data": "aW1hZ2U="}},
+        {
+            "file_data": {
+                "mime_type": "application/pdf",
+                "file_uri": "files/document",
+            }
+        },
+        {"thought": True, "text": "Thinking."},
+    ]
+    message = AIMessage(
+        content=[{"type": "text", "text": "source"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
+    )
+
+    with patch(
+        "langchain_google_genai.chat_models."
+        "_convert_from_v1_to_generativelanguage_v1beta",
+        return_value=projected_content,
+    ):
+        _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 4
+    assert parts[0].text == "hi"
+    assert parts[0].thought_signature == b"sig"
+    assert parts[1].inline_data == Blob(mime_type="image/png", data=b"image")
+    assert parts[2].file_data is not None
+    assert parts[2].file_data.mime_type == "application/pdf"
+    assert parts[2].file_data.file_uri == "files/document"
+    assert parts[3].thought is True
+    assert parts[3].text == "Thinking."
+
+
+def test_parse_chat_history_rejects_malformed_native_v1beta_projection() -> None:
+    """Surface invalid projected dictionaries during strict native v1 replay."""
+    message = AIMessage(
+        content=[{"type": "text", "text": "source"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
+    )
+
+    with (
+        patch(
+            "langchain_google_genai.chat_models."
+            "_convert_from_v1_to_generativelanguage_v1beta",
+            return_value=[{"text": "hi", "index": 0}],
+        ),
+        pytest.raises(ValidationError),
+    ):
+        _parse_chat_history([message])
+
+
+def test_parse_chat_history_drops_malformed_foreign_v1beta_projection(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Drop invalid projected dictionaries during lenient foreign v1 replay."""
+    message = AIMessage(
+        content=[{"type": "text", "text": "source"}],
+        response_metadata={
+            "model_provider": "openai",
+            "output_version": "v1",
+        },
+    )
+
+    with (
+        patch(
+            "langchain_google_genai.chat_models."
+            "_convert_from_v1_to_generativelanguage_v1beta",
+            return_value=[{"text": "hi", "id": "x"}],
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert parts == [Part(text="")]
+    assert "Dropping content block that cannot be represented" in caplog.text
+
+
 def test_parse_chat_history_preserves_human_non_standard_media() -> None:
     message = HumanMessage(
         content_blocks=[

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3879,17 +3879,14 @@ def test_convert_from_v1_keeps_base64_media_undecoded() -> None:
     Pre-encoding produced double-base64-encoded bytes on the wire.
     """
     converted = _convert_from_v1_to_generativelanguage_v1beta(
-        cast(
-            "list[Any]",
-            [{"type": "image", "base64": "aGVsbG8=", "mime_type": "image/png"}],
-        ),
+        [{"type": "image", "base64": "aGVsbG8=", "mime_type": "image/png"}],
         "google_genai",
     )
 
     assert converted == [
         {"inline_data": {"mime_type": "image/png", "data": "aGVsbG8="}}
     ]
-    assert Blob(**converted[0]["inline_data"]).data == b"hello"  # type: ignore[index]
+    assert Blob(**converted[0]["inline_data"]).data == b"hello"
 
 
 def test_parse_chat_history_tool_calls_foreign_signatures_not_leaked() -> None:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3221,6 +3221,235 @@ def test_parse_chat_history_uses_index_for_signature() -> None:
     assert function_part.thought_signature == sig_bytes
 
 
+def test_parse_chat_history_tool_calls_preserves_string_content() -> None:
+    """AIMessage with string content + tool calls keeps the text.
+
+    Regression test for https://github.com/langchain-ai/langchain-google/issues/1706.
+    """
+    message = AIMessage(
+        content="Let me look that up.",
+        tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "call_1"}],
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    model_content = formatted_messages[0]
+    assert model_content.role == "model"
+    parts = model_content.parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].text == "Let me look that up."
+    assert parts[1].function_call is not None
+    assert parts[1].function_call.name == "search"
+
+
+def test_parse_chat_history_tool_calls_preserves_text_block_content() -> None:
+    """AIMessage with a text content block + tool calls keeps the text.
+
+    Regression test for https://github.com/langchain-ai/langchain-google/issues/1706.
+    """
+    message = AIMessage(
+        content=[{"type": "text", "text": "One moment."}],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].text == "One moment."
+    assert parts[1].function_call is not None
+
+
+def test_parse_chat_history_tool_calls_preserves_thinking_block() -> None:
+    """v0 `thinking` blocks are kept as thought parts alongside tool calls."""
+    sig_bytes = b"thinking_signature"
+    sig_b64 = base64.b64encode(sig_bytes).decode("ascii")
+    message = AIMessage(
+        content=[
+            {"type": "thinking", "thinking": "Let me think.", "signature": sig_b64}
+        ],  # type: ignore[list-item]
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].thought is True
+    assert parts[0].text == "Let me think."
+    assert parts[0].thought_signature == sig_bytes
+    assert parts[1].function_call is not None
+
+
+def test_parse_chat_history_tool_calls_preserves_v1_reasoning_block() -> None:
+    """v1 `reasoning` blocks are kept as thought parts alongside tool calls."""
+    sig_bytes = b"reasoning_signature"
+    sig_b64 = base64.b64encode(sig_bytes).decode("ascii")
+    message = AIMessage(
+        content=[
+            {
+                "type": "reasoning",
+                "reasoning": "I should search.",
+                "extras": {"signature": sig_b64},
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].thought is True
+    assert parts[0].text == "I should search."
+    assert parts[0].thought_signature == sig_bytes
+    assert parts[1].function_call is not None
+
+
+def test_parse_chat_history_tool_calls_v1_content_blocks_round_trip() -> None:
+    """Native thinking + tool call AIMessage projected through v1 content blocks.
+
+    Regression test for https://github.com/langchain-ai/langchain-google/issues/1964.
+    """
+    sig_bytes = b"thinking_signature"
+    sig_b64 = base64.b64encode(sig_bytes).decode("ascii")
+    message = AIMessage(
+        content=[
+            {"type": "thinking", "thinking": "Let me think.", "signature": sig_b64}
+        ],  # type: ignore[list-item]
+        tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "call_1"}],
+        response_metadata={"model_provider": "google_genai"},
+    )
+    # Project through v1 content blocks as when `output_version="v1"` is used
+    v1_message = message.model_copy(
+        update={
+            "content": message.content_blocks,
+            "response_metadata": {
+                **message.response_metadata,
+                "output_version": "v1",
+            },
+        }
+    )
+    # Sanity check: the projection produced a reasoning block and a tool_call block
+    assert v1_message.content[0]["type"] == "reasoning"  # type: ignore[index, call-overload]
+    assert any(
+        isinstance(block, dict) and block.get("type") == "tool_call"
+        for block in v1_message.content  # type: ignore[union-attr]
+    )
+
+    _, formatted_messages = _parse_chat_history([v1_message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    # Exactly one thought part and exactly one function call part (no duplicates)
+    assert len(parts) == 2
+    thought_parts = [part for part in parts if part.thought]
+    function_call_parts = [part for part in parts if part.function_call]
+    assert len(thought_parts) == 1
+    assert len(function_call_parts) == 1
+    assert thought_parts[0].text == "Let me think."
+    assert thought_parts[0].thought_signature == sig_bytes
+    assert function_call_parts[0].function_call.name == "search"
+    assert function_call_parts[0].function_call.args == {"q": "x"}
+
+
+def test_parse_chat_history_tool_calls_foreign_reasoning_block() -> None:
+    """OpenAI-style `summary` reasoning blocks don't crash history parsing.
+
+    Regression test for https://github.com/langchain-ai/langchain-google/issues/1603.
+    """
+    message = AIMessage(
+        content=[
+            {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "I should search."}],
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "openai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    # The reasoning text is converted from the summary; the function call is kept
+    assert len(parts) == 2
+    assert parts[0].thought is True
+    assert parts[0].text == "I should search."
+    assert parts[0].thought_signature is None
+    assert parts[1].function_call is not None
+
+
+def test_parse_chat_history_tool_calls_foreign_signatures_not_leaked() -> None:
+    """Signatures from other providers are stripped before sending to Google."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "reasoning",
+                "reasoning": "I should search.",
+                "extras": {
+                    "signature": base64.b64encode(b"openai_sig").decode("ascii")
+                },
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "openai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].thought is True
+    assert parts[0].text == "I should search."
+    # Signature is from another provider and must not be echoed to Google
+    assert parts[0].thought_signature is None
+
+
+def test_parse_chat_history_tool_calls_v1_no_duplicate_function_calls() -> None:
+    """v1-projected messages emit exactly one FunctionCall part per tool call."""
+    message = AIMessage(
+        content="Searching now.",
+        tool_calls=[
+            {"name": "search", "args": {"q": "a"}, "id": "call_1"},
+            {"name": "search", "args": {"q": "b"}, "id": "call_2"},
+        ],
+        response_metadata={"model_provider": "google_genai"},
+    )
+    v1_message = message.model_copy(
+        update={
+            "content": message.content_blocks,
+            "response_metadata": {
+                **message.response_metadata,
+                "output_version": "v1",
+            },
+        }
+    )
+    # Content blocks carry the tool calls AND `message.tool_calls` is set; the
+    # function calls must still be emitted exactly once each.
+    assert any(
+        isinstance(block, dict) and block.get("type") == "tool_call"
+        for block in v1_message.content  # type: ignore[union-attr]
+    )
+
+    _, formatted_messages = _parse_chat_history([v1_message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    function_call_parts = [part for part in parts if part.function_call]
+    assert len(function_call_parts) == 2
+    assert function_call_parts[0].function_call.args == {"q": "a"}
+    assert function_call_parts[1].function_call.args == {"q": "b"}
+    # Text content is preserved too
+    assert [part for part in parts if part.text == "Searching now."]
+
+
 def test_system_message_only_raises_error() -> None:
     """Test that invoking with only a `SystemMessage` raises a helpful error."""
     llm = ChatGoogleGenerativeAI(

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4092,7 +4092,9 @@ def test_parse_chat_history_tool_calls_normalizes_native_blocks(
         response_metadata={"model_provider": model_provider},
     )
 
-    _, formatted_messages = _parse_chat_history([message])
+    _, formatted_messages = _parse_chat_history(
+        [message], use_vertexai=model_provider == "google_vertexai"
+    )
 
     parts = formatted_messages[0].parts
     assert parts is not None
@@ -4103,6 +4105,74 @@ def test_parse_chat_history_tool_calls_normalizes_native_blocks(
     assert parts[1].function_call is not None
     assert parts[1].function_call.name == "search"
     assert parts[1].function_call.args == {"q": "x"}
+
+
+def test_parse_chat_history_drops_vertex_gcs_for_gemini_backend() -> None:
+    """The source being Vertex does not make its GCS URI valid for Gemini API."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "file_data",
+                "file_uri": "gs://bucket/document.pdf",
+                "mime_type": "application/pdf",
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "google_vertexai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+
+
+@pytest.mark.parametrize("vertexai", [False, True])
+def test_prepare_request_checks_target_backend_for_vertex_gcs_history(
+    vertexai: bool,
+) -> None:
+    """Vertex GCS references replay only when the target is also Vertex AI."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        api_key=FAKE_API_KEY,
+        project="test-project" if vertexai else None,
+        vertexai=vertexai,
+    )
+    message = AIMessage(
+        content=[
+            {
+                "type": "image",
+                "url": "gs://bucket/image.png",
+                "mime_type": "image/png",
+            },
+            {
+                "type": "file",
+                "url": "gs://bucket/document.pdf",
+                "mime_type": "application/pdf",
+            },
+            {"type": "tool_call", "name": "search", "args": {}, "id": "call_1"},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "google_vertexai",
+            "output_version": "v1",
+        },
+    )
+
+    request = llm._prepare_request([message])
+
+    parts = request["contents"][0].parts
+    assert parts is not None
+    file_uris = [
+        part.file_data.file_uri for part in parts if part.file_data is not None
+    ]
+    expected_uris = (
+        ["gs://bucket/image.png", "gs://bucket/document.pdf"] if vertexai else []
+    )
+    assert file_uris == expected_uris
+    assert len([part for part in parts if part.function_call is not None]) == 1
 
 
 def test_parse_chat_history_tool_calls_preserves_native_media_block() -> None:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3358,6 +3358,33 @@ def test_parse_chat_history_tool_calls_v1_content_blocks_round_trip() -> None:
     assert function_call_parts[0].function_call.args == {"q": "x"}
 
 
+def test_parse_chat_history_tool_calls_normalizes_anthropic_tool_use() -> None:
+    """Anthropic `tool_use` content is normalized before Google conversion."""
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "Let me look that up."},
+            {
+                "type": "tool_use",
+                "id": "call_1",
+                "name": "search",
+                "input": {"q": "x"},
+            },
+        ],
+        tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "call_1"}],
+        response_metadata={"model_provider": "anthropic"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].text == "Let me look that up."
+    assert parts[1].function_call is not None
+    assert parts[1].function_call.name == "search"
+    assert parts[1].function_call.args == {"q": "x"}
+
+
 def test_parse_chat_history_tool_calls_foreign_reasoning_block() -> None:
     """OpenAI-style `summary` reasoning blocks don't crash history parsing.
 

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -2925,7 +2925,7 @@ def test_thought_signature_conversion() -> None:
         [reasoning_other_provider],  # type: ignore[list-item]
         "other_provider",
     )
-    assert result == []
+    assert result == [{"thought": True, "text": "thinking..."}]
 
 
 def test_compat_image_url_block() -> None:
@@ -3611,11 +3611,17 @@ def test_convert_to_parts_still_raises_on_unknown_type() -> None:
         _convert_to_parts([{"type": "bogus"}])
 
 
-def test_parse_chat_history_tool_calls_foreign_reasoning_block() -> None:
+@pytest.mark.parametrize("output_version", [None, "v1"])
+def test_parse_chat_history_tool_calls_foreign_reasoning_block(
+    output_version: str | None,
+) -> None:
     """OpenAI-style `summary` reasoning blocks don't crash history parsing.
 
     Regression test for https://github.com/langchain-ai/langchain-google/issues/1603.
     """
+    response_metadata = {"model_provider": "openai"}
+    if output_version:
+        response_metadata["output_version"] = output_version
     message = AIMessage(
         content=[
             {
@@ -3624,7 +3630,7 @@ def test_parse_chat_history_tool_calls_foreign_reasoning_block() -> None:
             }
         ],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": "openai"},
+        response_metadata=response_metadata,
     )
 
     _, formatted_messages = _parse_chat_history([message])
@@ -3815,6 +3821,34 @@ def test_parse_chat_history_tool_calls_native_v1_signature_preserved(
     assert parts[1].text == "Answer."
     assert parts[1].thought_signature == b"vertex_sig"
     assert parts[2].function_call is not None
+
+
+def test_parse_chat_history_tool_calls_v1_unknown_provider_preserves_signature() -> (
+    None
+):
+    """Older v1 checkpoints keep native signatures without provider metadata."""
+    signature = base64.b64encode(b"checkpoint_sig").decode("ascii")
+    message = AIMessage(
+        content=[
+            {
+                "type": "reasoning",
+                "reasoning": "Thinking.",
+                "extras": {"signature": signature},
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"output_version": "v1"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].thought is True
+    assert parts[0].text == "Thinking."
+    assert parts[0].thought_signature == b"checkpoint_sig"
+    assert parts[1].function_call is not None
 
 
 def test_parse_chat_history_tool_calls_summary_reasoning_kept_without_metadata() -> (
@@ -4079,6 +4113,38 @@ def test_parse_chat_history_tool_calls_preserves_native_media_block() -> None:
     assert parts[0].file_data.mime_type == "audio/mpeg"
     assert parts[1].function_call is not None
     assert parts[1].function_call.name == "transcribe"
+
+
+def test_parse_chat_history_tool_calls_v1_preserves_native_media_block() -> None:
+    """V1 projection does not discard a native block wrapped as `non_standard`."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "non_standard",
+                "value": {
+                    "type": "media",
+                    "file_uri": "files/native-audio",
+                    "mime_type": "audio/mpeg",
+                },
+            },
+            {"type": "tool_call", "name": "transcribe", "args": {}, "id": "call_1"},
+        ],
+        tool_calls=[{"name": "transcribe", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].file_data is not None
+    assert parts[0].file_data.file_uri == "files/native-audio"
+    assert parts[0].file_data.mime_type == "audio/mpeg"
+    assert parts[1].function_call is not None
 
 
 def test_parse_chat_history_tool_calls_v1_file_id_becomes_file_data() -> None:
@@ -7828,22 +7894,6 @@ def test_parse_chat_history_tool_calls_keeps_bare_string_content_blocks() -> Non
     assert parts[2].function_call is not None
 
 
-def test_parse_chat_history_tool_calls_string_content_is_not_split() -> None:
-    """Scalar string content becomes one text part, not one part per character."""
-    message = AIMessage(
-        content="Hi there",
-        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": "google_genai"},
-    )
-
-    _, formatted_messages = _parse_chat_history([message])
-
-    parts = formatted_messages[0].parts
-    assert parts is not None
-    assert len(parts) == 2
-    assert parts[0].text == "Hi there"
-
-
 def test_convert_to_parts_joins_multi_segment_summary() -> None:
     """Every `summary` segment is concatenated, and non-dict entries are skipped.
 
@@ -7855,7 +7905,7 @@ def test_convert_to_parts_joins_multi_segment_summary() -> None:
             {
                 "type": "reasoning",
                 "summary": [
-                    {"type": "summary_text", "text": "First. "},
+                    {"type": "summary_text", "text": "First."},
                     "not a dict",
                     {"type": "summary_text", "text": "Second."},
                 ],
@@ -7900,19 +7950,24 @@ def test_lenient_conversion_logs_the_underlying_cause(
 
 
 @pytest.mark.parametrize(
-    ("content", "expected_fragment"),
+    ("content", "model_provider", "expected_fragment"),
     [
-        ([{"type": "brand_new_core_block"}], "no Gemini equivalent"),
+        (
+            [{"type": "brand_new_core_block"}],
+            "google_genai",
+            "no Gemini equivalent",
+        ),
         (
             [{"type": "non_standard", "value": {"type": "redacted_thinking"}}],
+            "anthropic",
             "non-standard v1 content block",
         ),
-        ([{"type": "reasoning", "reasoning": "Unsigned."}], "no thought signature"),
-        (["not a mapping"], "not a typed mapping"),
+        (["not a mapping"], "google_genai", "not a typed mapping"),
     ],
 )
 def test_convert_from_v1_logs_dropped_blocks(
     content: list[Any],
+    model_provider: str,
     expected_fragment: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -7924,7 +7979,7 @@ def test_convert_from_v1_logs_dropped_blocks(
     """
     with caplog.at_level(logging.WARNING):
         result = _convert_from_v1_to_generativelanguage_v1beta(
-            cast("Any", content), "google_genai"
+            cast("Any", content), model_provider
         )
 
     assert result == []

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3269,7 +3269,7 @@ def test_parse_chat_history_tool_calls_preserves_thinking_block() -> None:
     message = AIMessage(
         content=[
             {"type": "thinking", "thinking": "Let me think.", "signature": sig_b64}
-        ],  # type: ignore[list-item]
+        ],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
     )
 
@@ -3320,7 +3320,7 @@ def test_parse_chat_history_tool_calls_v1_content_blocks_round_trip() -> None:
     message = AIMessage(
         content=[
             {"type": "thinking", "thinking": "Let me think.", "signature": sig_b64}
-        ],  # type: ignore[list-item]
+        ],
         tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "call_1"}],
         response_metadata={"model_provider": "google_genai"},
     )
@@ -3335,10 +3335,10 @@ def test_parse_chat_history_tool_calls_v1_content_blocks_round_trip() -> None:
         }
     )
     # Sanity check: the projection produced a reasoning block and a tool_call block
-    assert v1_message.content[0]["type"] == "reasoning"  # type: ignore[index, call-overload]
+    assert v1_message.content[0]["type"] == "reasoning"  # type: ignore[index]
     assert any(
         isinstance(block, dict) and block.get("type") == "tool_call"
-        for block in v1_message.content  # type: ignore[union-attr]
+        for block in v1_message.content
     )
 
     _, formatted_messages = _parse_chat_history([v1_message])
@@ -3353,6 +3353,7 @@ def test_parse_chat_history_tool_calls_v1_content_blocks_round_trip() -> None:
     assert len(function_call_parts) == 1
     assert thought_parts[0].text == "Let me think."
     assert thought_parts[0].thought_signature == sig_bytes
+    assert function_call_parts[0].function_call is not None
     assert function_call_parts[0].function_call.name == "search"
     assert function_call_parts[0].function_call.args == {"q": "x"}
 
@@ -3531,7 +3532,7 @@ def test_parse_chat_history_tool_calls_v1_no_duplicate_function_calls() -> None:
     # function calls must still be emitted exactly once each.
     assert any(
         isinstance(block, dict) and block.get("type") == "tool_call"
-        for block in v1_message.content  # type: ignore[union-attr]
+        for block in v1_message.content
     )
 
     _, formatted_messages = _parse_chat_history([v1_message])
@@ -3540,6 +3541,8 @@ def test_parse_chat_history_tool_calls_v1_no_duplicate_function_calls() -> None:
     assert parts is not None
     function_call_parts = [part for part in parts if part.function_call]
     assert len(function_call_parts) == 2
+    assert function_call_parts[0].function_call is not None
+    assert function_call_parts[1].function_call is not None
     assert function_call_parts[0].function_call.args == {"q": "a"}
     assert function_call_parts[1].function_call.args == {"q": "b"}
     # Text content is preserved too

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3611,6 +3611,79 @@ def test_convert_to_parts_still_raises_on_unknown_type() -> None:
         _convert_to_parts([{"type": "bogus"}])
 
 
+def test_parse_chat_history_preserves_human_non_standard_media() -> None:
+    """Core-wrapped Gemini media on a human message is unwrapped and sent."""
+    message = HumanMessage(
+        content_blocks=[
+            {
+                "type": "non_standard",
+                "value": {
+                    "type": "media",
+                    "mime_type": "image/png",
+                    "data": base64.b64encode(b"image data").decode("ascii"),
+                },
+            }
+        ]
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].inline_data is not None
+    assert parts[0].inline_data.mime_type == "image/png"
+    assert parts[0].inline_data.data == b"image data"
+
+
+def test_parse_chat_history_preserves_native_ai_non_standard_media() -> None:
+    """Native AI media is unwrapped even without v1 output metadata."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "non_standard",
+                "value": {
+                    "type": "media",
+                    "mime_type": "audio/mpeg",
+                    "file_uri": "files/native-audio",
+                },
+            }
+        ],
+        response_metadata={"model_provider": "google_genai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].file_data is not None
+    assert parts[0].file_data.mime_type == "audio/mpeg"
+    assert parts[0].file_data.file_uri == "files/native-audio"
+
+
+def test_parse_chat_history_tool_calls_drops_foreign_non_standard_media() -> None:
+    """Provider-aware filtering still rejects another provider's opaque media."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "media",
+                "mime_type": "image/png",
+                "data": base64.b64encode(b"foreign image").decode("ascii"),
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "openai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+
+
 @pytest.mark.parametrize("output_version", [None, "v1"])
 def test_parse_chat_history_tool_calls_foreign_reasoning_block(
     output_version: str | None,

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -4040,6 +4040,47 @@ def test_parse_chat_history_tool_calls_normalizes_native_blocks(
     assert parts[1].function_call.args == {"q": "x"}
 
 
+def test_parse_chat_history_tool_calls_preserves_native_media_block() -> None:
+    """A native `media` block mixed with a raw `function_call` is not dropped.
+
+    Core's google translator has no `media` case, so projecting the message
+    through `content_blocks` would turn the block into `non_standard` and lose it.
+    Reading raw `content` and normalizing only the function-call block preserves
+    the media part.
+    """
+    message = AIMessage(
+        content=[
+            {
+                "type": "media",
+                "file_uri": "https://generativelanguage.googleapis.com/v1beta/files/abc",
+                "mime_type": "audio/mpeg",
+            },
+            {
+                "type": "function_call",
+                "name": "transcribe",
+                "args": {},
+                "id": "call_1",
+            },
+        ],
+        tool_calls=[{"name": "transcribe", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "google_genai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].file_data is not None
+    assert (
+        parts[0].file_data.file_uri
+        == "https://generativelanguage.googleapis.com/v1beta/files/abc"
+    )
+    assert parts[0].file_data.mime_type == "audio/mpeg"
+    assert parts[1].function_call is not None
+    assert parts[1].function_call.name == "transcribe"
+
+
 def test_parse_chat_history_tool_calls_v1_file_id_becomes_file_data() -> None:
     """A v1 `file` block carrying a `file_id` converts to a `file_data` part."""
     message = AIMessage(

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -72,6 +72,7 @@ from langchain_google_genai._compat import (
     _convert_from_v1_to_generativelanguage_v1beta,
 )
 from langchain_google_genai.chat_models import (
+    DUMMY_THOUGHT_SIGNATURE,
     ChatGoogleGenerativeAI,
     ChatGoogleGenerativeAIError,
     GoogleContextOverflowError,
@@ -3581,6 +3582,314 @@ def test_parse_chat_history_tool_calls_foreign_reasoning_block() -> None:
     assert parts[0].text == "I should search."
     assert parts[0].thought_signature is None
     assert parts[1].function_call is not None
+
+
+def test_convert_to_parts_openai_summary_reasoning_without_metadata() -> None:
+    """The exact repro from the issue: no provider metadata and no tool calls.
+
+    This is the only input shape that exercises the `summary` extraction fallback
+    in `_convert_to_parts`; a message tagged `model_provider="openai"` is
+    normalized by core to a `reasoning` key before conversion runs.
+
+    Regression test for https://github.com/langchain-ai/langchain-google/issues/1603.
+    """
+    message = AIMessage(
+        content=[
+            {
+                "type": "reasoning",
+                "id": "rs_abc123",
+                "summary": [
+                    {"type": "summary_text", "text": "Let me think step by step..."}
+                ],
+            },
+            {"type": "text", "text": "The answer is 4."},
+        ],
+        tool_calls=[],
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].thought is True
+    assert parts[0].text == "Let me think step by step..."
+    assert parts[1].thought is not True
+    assert parts[1].text == "The answer is 4."
+
+
+def test_convert_to_parts_reasoning_summary_not_a_list_is_dropped() -> None:
+    """A `summary` that yields no text is dropped rather than raising."""
+    assert _convert_to_parts([{"type": "reasoning", "summary": "notalist"}]) == []
+
+
+def test_parse_chat_history_tool_calls_unknown_provider_drops_foreign_block(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A foreign block on a metadata-less message is dropped, not raised on.
+
+    Messages lacking `model_provider` (hand-built, or checkpoints serialized before
+    core stamped the field) must not turn a previously-ignored block into a hard
+    request failure.
+    """
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "Let me look that up."},
+            {"type": "tool_use", "id": "call_1", "name": "search", "input": {}},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+    )
+
+    with caplog.at_level(logging.WARNING):
+        _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    # Text survives, the unconvertible block is dropped, the call is emitted once
+    assert len(parts) == 2
+    assert parts[0].text == "Let me look that up."
+    assert parts[1].function_call is not None
+    assert parts[1].function_call.name == "search"
+    assert "cannot be represented as a Gemini part" in caplog.text
+
+
+def test_parse_chat_history_tool_calls_vertexai_signature_preserved() -> None:
+    """Vertex AI serves the same Gemini models, so its signatures stay valid."""
+    signature = base64.b64encode(b"vertex_sig").decode("ascii")
+    message = AIMessage(
+        content=[{"type": "thinking", "thinking": "Thinking.", "signature": signature}],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "google_vertexai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].thought is True
+    assert parts[0].thought_signature == b"vertex_sig"
+
+
+def test_parse_chat_history_tool_calls_summary_reasoning_kept_without_metadata() -> (
+    None
+):
+    """A metadata-less `summary` reasoning block is converted, not dropped."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "I should search."}],
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].thought is True
+    assert parts[0].text == "I should search."
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        {"type": "thinking", "thinking": "", "signature": "c2ln"},
+        {"type": "reasoning", "reasoning": "", "extras": {"signature": "c2ln"}},
+        {"type": "text", "text": "", "extras": {"signature": "c2ln"}},
+    ],
+)
+def test_parse_chat_history_tool_calls_keeps_signature_only_blocks(
+    block: dict[str, Any],
+) -> None:
+    """An empty block carrying a signature must survive.
+
+    Gemini emits signature-bearing blocks with empty text and requires the
+    signature to be echoed back, so emptiness alone must not trigger a drop --
+    otherwise the signature is lost and the Gemini 3 enforcement pass silently
+    substitutes `DUMMY_THOUGHT_SIGNATURE` for the whole turn.
+    """
+    message = AIMessage(
+        content=[block],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+    )
+
+    _, formatted_messages = _parse_chat_history(
+        [message], model="gemini-3.1-pro-preview"
+    )
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    # The real signature survives on the thought part rather than being dropped
+    # and back-filled with the dummy
+    assert parts[0].thought_signature == b"sig"
+    assert parts[0].thought_signature != DUMMY_THOUGHT_SIGNATURE
+    assert parts[1].function_call is not None
+
+
+def test_parse_chat_history_tool_calls_v1_keeps_signature_only_thought() -> None:
+    """The v1 path keeps a signature-bearing empty thought, matching the v0 path."""
+    signature = base64.b64encode(b"sig").decode("ascii")
+    message = AIMessage(
+        content=[
+            {"type": "reasoning", "reasoning": "", "extras": {"signature": signature}},
+            {"type": "tool_call", "name": "search", "args": {}, "id": "call_1"},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
+    )
+
+    _, formatted_messages = _parse_chat_history(
+        [message], model="gemini-3.1-pro-preview"
+    )
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].thought is True
+    assert parts[0].thought_signature == b"sig"
+    assert parts[1].function_call is not None
+
+
+def test_parse_chat_history_tool_calls_v1_drops_unsigned_empty_thought() -> None:
+    """An empty thought with no signature is still dropped on the v1 path."""
+    message = AIMessage(
+        content=[{"thought": True, "text": ""}, {"function_call": {"name": "search"}}],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+
+
+def test_parse_chat_history_tool_calls_foreign_text_signature_stripped() -> None:
+    """A foreign `text` block's signature is stripped, not just reasoning blocks."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "text",
+                "text": "Looking it up.",
+                "extras": {
+                    "signature": base64.b64encode(b"openai_sig").decode("ascii")
+                },
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "openai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert parts[0].text == "Looking it up."
+    assert parts[0].thought_signature is None
+
+
+def test_parse_chat_history_tool_calls_strips_tool_call_chunk_blocks() -> None:
+    """A `tool_call_chunk` block must not duplicate the rebuilt function call."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "tool_call_chunk",
+                "name": "search",
+                "args": "{}",
+                "id": "call_1",
+                "index": 0,
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len([p for p in parts if p.function_call]) == 1
+
+
+def test_parse_chat_history_tool_calls_v1_file_id_becomes_file_data() -> None:
+    """A v1 `file` block carrying a `file_id` converts to a `file_data` part."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "file",
+                "file_id": "files/abc",
+                "mime_type": "application/pdf",
+            },
+            {"type": "tool_call", "name": "search", "args": {}, "id": "call_1"},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert parts[0].file_data is not None
+    assert parts[0].file_data.file_uri == "files/abc"
+    assert parts[0].file_data.mime_type == "application/pdf"
+
+
+def test_parse_chat_history_tool_calls_v1_text_signature_decoded() -> None:
+    """A signature on a v1 `text` block round-trips as decoded bytes."""
+    signature = base64.b64encode(b"text_sig").decode("ascii")
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "hi", "extras": {"signature": signature}},
+            {"type": "tool_call", "name": "search", "args": {}, "id": "call_1"},
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={
+            "model_provider": "google_genai",
+            "output_version": "v1",
+        },
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert parts[0].text == "hi"
+    assert parts[0].thought_signature == b"text_sig"
+
+
+def test_convert_from_v1_keeps_base64_media_undecoded() -> None:
+    """`Blob` base64-decodes a `str`, so the converter must not pre-encode it.
+
+    Pre-encoding produced double-base64-encoded bytes on the wire.
+    """
+    converted = _convert_from_v1_to_generativelanguage_v1beta(
+        cast(
+            "list[Any]",
+            [{"type": "image", "base64": "aGVsbG8=", "mime_type": "image/png"}],
+        ),
+        "google_genai",
+    )
+
+    assert converted == [
+        {"inline_data": {"mime_type": "image/png", "data": "aGVsbG8="}}
+    ]
+    assert Blob(**converted[0]["inline_data"]).data == b"hello"  # type: ignore[index]
 
 
 def test_parse_chat_history_tool_calls_foreign_signatures_not_leaked() -> None:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3953,6 +3953,48 @@ def test_parse_chat_history_tool_calls_strips_tool_call_chunk_blocks() -> None:
     assert len([p for p in parts if p.function_call]) == 1
 
 
+@pytest.mark.parametrize(
+    ("model_provider", "file_uri"),
+    [
+        ("google_genai", "files/abc"),
+        ("google_vertexai", "gs://bucket/document.pdf"),
+    ],
+)
+def test_parse_chat_history_tool_calls_normalizes_native_blocks(
+    model_provider: str, file_uri: str
+) -> None:
+    """Provider-native file and function-call blocks replay without duplication."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "file_data",
+                "file_uri": file_uri,
+                "mime_type": "application/pdf",
+            },
+            {
+                "type": "function_call",
+                "name": "search",
+                "args": {"q": "x"},
+                "id": "call_1",
+            },
+        ],
+        tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "call_1"}],
+        response_metadata={"model_provider": model_provider},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 2
+    assert parts[0].file_data is not None
+    assert parts[0].file_data.file_uri == file_uri
+    assert parts[0].file_data.mime_type == "application/pdf"
+    assert parts[1].function_call is not None
+    assert parts[1].function_call.name == "search"
+    assert parts[1].function_call.args == {"q": "x"}
+
+
 def test_parse_chat_history_tool_calls_v1_file_id_becomes_file_data() -> None:
     """A v1 `file` block carrying a `file_id` converts to a `file_data` part."""
     message = AIMessage(

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3426,6 +3426,80 @@ def test_parse_chat_history_tool_calls_drops_invalid_foreign_calls() -> None:
     assert parts[0].function_call.name == "search"
 
 
+def test_parse_chat_history_tool_calls_drops_foreign_web_search_pair() -> None:
+    """Foreign server-tool results are not cast as Gemini code results."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "web_search_call",
+                "id": "ws_1",
+                "status": "completed",
+                "action": {
+                    "type": "search",
+                    "query": "weather",
+                    "sources": [
+                        {"type": "url", "url": "https://example.com/weather"}
+                    ],
+                },
+            },
+            {
+                "type": "function_call",
+                "name": "lookup",
+                "arguments": "{}",
+                "call_id": "call_1",
+                "id": "fc_1",
+            },
+        ],
+        tool_calls=[{"name": "lookup", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "openai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+    assert parts[0].function_call.name == "lookup"
+    assert parts[0].code_execution_result is None
+
+
+def test_parse_chat_history_tool_calls_keeps_foreign_code_interpreter_pair() -> None:
+    """Matched foreign code-interpreter calls and results remain compatible."""
+    message = AIMessage(
+        content=[
+            {
+                "type": "code_interpreter_call",
+                "id": "ci_1",
+                "code": "print(1)",
+                "outputs": ["1"],
+                "status": "completed",
+            },
+            {
+                "type": "function_call",
+                "name": "lookup",
+                "arguments": "{}",
+                "call_id": "call_1",
+                "id": "fc_1",
+            },
+        ],
+        tool_calls=[{"name": "lookup", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "openai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 3
+    assert parts[0].executable_code is not None
+    assert parts[0].executable_code.code == "print(1)"
+    assert parts[1].code_execution_result is not None
+    assert parts[1].code_execution_result.output == "['1']"
+    assert parts[2].function_call is not None
+    assert parts[2].function_call.name == "lookup"
+
+
 def test_parse_chat_history_tool_calls_non_standard_block_dropped(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3848,6 +3848,35 @@ def test_parse_chat_history_tool_calls_foreign_text_signature_stripped() -> None
     assert parts[0].thought_signature is None
 
 
+def test_parse_chat_history_tool_calls_foreign_signature_only_block_dropped() -> None:
+    """A foreign block whose only payload is a signature must not emit an empty part.
+
+    The emptiness check must run after foreign signatures are stripped: the
+    signature makes the block look non-empty, but once stripped nothing remains,
+    and the Gemini API rejects the resulting empty text part.
+    """
+    message = AIMessage(
+        content=[
+            {
+                "type": "text",
+                "text": "",
+                "extras": {
+                    "signature": base64.b64encode(b"openai_sig").decode("ascii")
+                },
+            }
+        ],
+        tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
+        response_metadata={"model_provider": "openai"},
+    )
+
+    _, formatted_messages = _parse_chat_history([message])
+
+    parts = formatted_messages[0].parts
+    assert parts is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+
+
 def test_parse_chat_history_tool_calls_strips_tool_call_chunk_blocks() -> None:
     """A `tool_call_chunk` block must not duplicate the rebuilt function call."""
     message = AIMessage(

--- a/libs/genai/tests/unit_tests/test_content_conversion.py
+++ b/libs/genai/tests/unit_tests/test_content_conversion.py
@@ -30,7 +30,8 @@ def test_decode_signature(signature: Any, expected: bytes | None) -> None:
 
 def test_convert_to_parts_decodes_bytes_thought_signature() -> None:
     parts = _convert_to_parts(
-        [{"thought": True, "text": "Thinking.", "thought_signature": b"raw_sig"}]
+        [{"thought": True, "text": "Thinking.", "thought_signature": b"raw_sig"}],
+        allow_v1beta_dicts=True,
     )
 
     assert len(parts) == 1
@@ -51,7 +52,7 @@ def test_convert_to_parts_typed_block_wins_over_thought_key() -> None:
 
 def test_convert_to_parts_empty_inline_data_is_not_a_file_part() -> None:
     """Do not reinterpret present-but-empty inline data as file data."""
-    parts = _convert_to_parts([{"inline_data": {}}])
+    parts = _convert_to_parts([{"inline_data": {}}], allow_v1beta_dicts=True)
 
     assert len(parts) == 1
     assert parts[0].inline_data is not None
@@ -73,7 +74,7 @@ def test_convert_to_parts_empty_inline_data_is_not_a_file_part() -> None:
 def test_convert_to_parts_v1beta_shapes_tolerate_none_valued_keys(
     block: dict[str, Any], attr: str
 ) -> None:
-    parts = _convert_to_parts([block])
+    parts = _convert_to_parts([block], allow_v1beta_dicts=True)
 
     assert len(parts) == 1
     assert getattr(parts[0], attr) is not None

--- a/libs/genai/tests/unit_tests/test_content_conversion.py
+++ b/libs/genai/tests/unit_tests/test_content_conversion.py
@@ -1,0 +1,143 @@
+"""Tests for converting LangChain content blocks to Gemini parts."""
+
+import base64
+import logging
+from typing import Any, cast
+
+import pytest
+from google.genai.types import Blob
+
+from langchain_google_genai._compat import (
+    _convert_from_v1_to_generativelanguage_v1beta,
+)
+from langchain_google_genai.chat_models import _convert_to_parts, _decode_signature
+
+
+@pytest.mark.parametrize(
+    ("signature", "expected"),
+    [
+        (base64.b64encode(b"sig").decode("ascii"), b"sig"),
+        (b"raw_bytes", b"raw_bytes"),
+        ("", None),
+        (b"", None),
+        (None, None),
+        (123, None),
+    ],
+)
+def test_decode_signature(signature: Any, expected: bytes | None) -> None:
+    assert _decode_signature(signature) == expected
+
+
+def test_convert_to_parts_decodes_bytes_thought_signature() -> None:
+    parts = _convert_to_parts(
+        [{"thought": True, "text": "Thinking.", "thought_signature": b"raw_sig"}]
+    )
+
+    assert len(parts) == 1
+    assert parts[0].thought is True
+    assert parts[0].thought_signature == b"raw_sig"
+
+
+def test_convert_to_parts_typed_block_wins_over_thought_key() -> None:
+    """Honor an explicit block type before inspecting legacy shape keys."""
+    parts = _convert_to_parts(
+        [{"type": "text", "text": "Not a thought.", "thought": True}]
+    )
+
+    assert len(parts) == 1
+    assert parts[0].text == "Not a thought."
+    assert parts[0].thought is not True
+
+
+def test_convert_to_parts_empty_inline_data_is_not_a_file_part() -> None:
+    """Do not reinterpret present-but-empty inline data as file data."""
+    parts = _convert_to_parts([{"inline_data": {}}])
+
+    assert len(parts) == 1
+    assert parts[0].inline_data is not None
+    assert parts[0].file_data is None
+
+
+@pytest.mark.parametrize(
+    ("block", "attr"),
+    [
+        ({"inline_data": {"mime_type": None, "data": "aGk="}}, "inline_data"),
+        ({"file_data": {"mime_type": None, "file_uri": "gs://b/o"}}, "file_data"),
+        ({"executable_code": {"language": None, "code": "x=1"}}, "executable_code"),
+        (
+            {"code_execution_result": {"outcome": None, "output": "1"}},
+            "code_execution_result",
+        ),
+    ],
+)
+def test_convert_to_parts_v1beta_shapes_tolerate_none_valued_keys(
+    block: dict[str, Any], attr: str
+) -> None:
+    parts = _convert_to_parts([block])
+
+    assert len(parts) == 1
+    assert getattr(parts[0], attr) is not None
+
+
+def test_convert_to_parts_joins_multi_segment_summary() -> None:
+    parts = _convert_to_parts(
+        [
+            {
+                "type": "reasoning",
+                "summary": [
+                    {"type": "summary_text", "text": "First."},
+                    "not a dict",
+                    {"type": "summary_text", "text": "Second."},
+                ],
+            }
+        ]
+    )
+
+    assert len(parts) == 1
+    assert parts[0].text == "First. Second."
+    assert parts[0].thought is True
+
+
+def test_convert_from_v1_keeps_base64_media_undecoded() -> None:
+    """Leave base64 decoding to SDK validation to avoid double encoding."""
+    converted = _convert_from_v1_to_generativelanguage_v1beta(
+        [{"type": "image", "base64": "aGVsbG8=", "mime_type": "image/png"}],
+        "google_genai",
+    )
+
+    assert converted == [
+        {"inline_data": {"mime_type": "image/png", "data": "aGVsbG8="}}
+    ]
+    assert Blob(**converted[0]["inline_data"]).data == b"hello"
+
+
+@pytest.mark.parametrize(
+    ("content", "model_provider", "expected_fragment"),
+    [
+        (
+            [{"type": "brand_new_core_block"}],
+            "google_genai",
+            "no Gemini equivalent",
+        ),
+        (
+            [{"type": "non_standard", "value": {"type": "redacted_thinking"}}],
+            "anthropic",
+            "non-standard v1 content block",
+        ),
+        (["not a mapping"], "google_genai", "not a typed mapping"),
+    ],
+)
+def test_convert_from_v1_logs_dropped_blocks(
+    content: list[Any],
+    model_provider: str,
+    expected_fragment: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Keep every intentional v1 content drop diagnosable."""
+    with caplog.at_level(logging.WARNING):
+        result = _convert_from_v1_to_generativelanguage_v1beta(
+            cast("Any", content), model_provider
+        )
+
+    assert result == []
+    assert expected_fragment in caplog.text


### PR DESCRIPTION

Fixes #1706
Fixes #1964
Fixes #1603

Supersedes #1609

---

## Why

`_parse_chat_history` had a separate `AIMessage.tool_calls` branch that manually rebuilt Gemini parts and skipped the normal content converter. This caused three related failures:

- plain assistant text beside tool calls was silently dropped (#1706);
- v1 reasoning and its thought signature were lost after a `content_blocks` round trip (#1964);
- OpenAI-style reasoning summaries could raise `KeyError` instead of replaying safely (#1603).

## Approach

- Keep `message.tool_calls` as the authoritative source of function-call parts, so calls are emitted exactly once.
- Route all remaining AI-message content through one helper for both v0 and v1 histories.
- Classify source providers once as native, foreign, or unknown:
  - native Gemini/Vertex content converts strictly and keeps valid signatures;
  - foreign content drops unsupported provider-only blocks and signatures without losing compatible text/media;
  - provider-less checkpoints preserve potentially native metadata while converting unsupported blocks leniently.
- Preserve valid native blocks that LangChain core projects as `non_standard`, including Gemini media.
- Use the Google GenAI SDK's `Part` validation for v1beta dictionaries instead of manually reconstructing each SDK shape.
- Normalize multi-segment reasoning summaries with explicit spacing and filter genuinely empty parts.
- Continue pairing tool responses by tool-call ID and avoid empty Gemini `Content` messages.