### PR TITLE
fix(genai): drop foreign-provider reasoning blocks

### DIFF
--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -215,6 +215,16 @@ def _convert_from_v1_to_generativelanguage_v1beta(
 
         # ReasoningContentBlock -> thinking
         elif block_dict["type"] == "reasoning":
+            if provider_kind == "foreign":
+                # Another provider's chain-of-thought (for example AWS Bedrock or
+                # OpenAI summary blocks) is not a Gemini thought; sending it back
+                # would leak foreign reasoning text into Gemini requests.
+                logger.info(
+                    "Dropping v1 reasoning block from provider %r; foreign "
+                    "reasoning cannot be replayed as a Gemini thought part.",
+                    model_provider,
+                )
+                continue
             extras = block_dict.get("extras")
             signature = block_dict.get("thought_signature") or (
                 extras.get("signature") if isinstance(extras, dict) else None
@@ -236,13 +246,14 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                     and text.strip()
                 ]
                 reasoning_text = " ".join(summary_texts)
-            if not reasoning_text and not (signature and provider_kind != "foreign"):
+            # Past the early return above, provider_kind is native or unknown.
+            if not reasoning_text and not signature:
                 continue
             new_block = {
                 "thought": True,
                 "text": reasoning_text or "",
             }
-            if signature and provider_kind != "foreign":
+            if signature:
                 new_block["thought_signature"] = signature
             new_content.append(new_block)
 

--- a/libs/genai/langchain_google_genai/_compat.py
+++ b/libs/genai/langchain_google_genai/_compat.py
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 # Vertex and the Gemini Developer API share content and signature formats.
 _NATIVE_MODEL_PROVIDERS = frozenset({"google_genai", "google_vertexai"})
 _ModelProviderKind = Literal["native", "foreign", "unknown"]
+# Standardized `reasoning` plus the raw shapes providers emit before conversion.
+_REASONING_BLOCK_TYPES = frozenset({"reasoning", "thinking", "reasoning_content"})
 
 
 def _classify_model_provider(model_provider: str | None) -> _ModelProviderKind:
@@ -219,9 +221,9 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                 # Another provider's chain-of-thought (for example AWS Bedrock or
                 # OpenAI summary blocks) is not a Gemini thought; sending it back
                 # would leak foreign reasoning text into Gemini requests.
-                logger.info(
+                logger.warning(
                     "Dropping v1 reasoning block from provider %r; foreign "
-                    "reasoning cannot be replayed as a Gemini thought part.",
+                    "reasoning is not replayed as a Gemini thought part.",
                     model_provider,
                 )
                 continue
@@ -246,7 +248,8 @@ def _convert_from_v1_to_generativelanguage_v1beta(
                     and text.strip()
                 ]
                 reasoning_text = " ".join(summary_texts)
-            # Past the early return above, provider_kind is native or unknown.
+            # Foreign blocks already continued above, and native blocks with no
+            # signature were dropped, so an unsigned block here is provider-less.
             if not reasoning_text and not signature:
                 continue
             new_block = {

--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -129,6 +129,7 @@ from langchain_google_genai._common import (
     get_user_agent,
 )
 from langchain_google_genai._compat import (
+    _REASONING_BLOCK_TYPES,
     _classify_model_provider,
     _convert_from_v1_to_generativelanguage_v1beta,
     _is_file_uri_supported,
@@ -1171,9 +1172,8 @@ def _prepare_ai_message_content(
     Foreign messages use LangChain's standardized blocks. Native messages retain
     their raw blocks because core may wrap valid Gemini media as `non_standard`.
     """
-    provider_kind = _classify_model_provider(
-        message.response_metadata.get("model_provider")
-    )
+    model_provider = message.response_metadata.get("model_provider")
+    provider_kind = _classify_model_provider(model_provider)
     is_foreign = provider_kind == "foreign"
     # Core standardizes foreign blocks, but can wrap native Gemini blocks as
     # `non_standard`, so native and unstamped messages use their raw content.
@@ -1219,6 +1219,16 @@ def _prepare_ai_message_content(
             continue
         candidate: Mapping[str, Any] = block
         if is_foreign:
+            if block_type in _REASONING_BLOCK_TYPES:
+                # Mirrors the v1 conversion in `_compat.py`: stripping the foreign
+                # signature is not enough, because the reasoning text itself is
+                # another provider's chain-of-thought and is not a Gemini thought.
+                logger.warning(
+                    "Dropping reasoning block from provider %r; foreign reasoning "
+                    "is not replayed as a Gemini thought part.",
+                    model_provider,
+                )
+                continue
             if _is_unsupported_foreign_server_tool(block, code_interpreter_call_ids):
                 continue
             candidate = _strip_foreign_signature(block)

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -2912,6 +2912,7 @@ def test_thought_signature_conversion() -> None:
     expected = [{"text": "foo"}]
     assert result == expected
 
+    # Foreign reasoning blocks are dropped entirely (text and signature)
     reasoning_other_provider = {
         "type": "reasoning",
         "reasoning": "thinking...",
@@ -2921,7 +2922,7 @@ def test_thought_signature_conversion() -> None:
         [reasoning_other_provider],  # type: ignore[list-item]
         "other_provider",
     )
-    assert result == [{"thought": True, "text": "thinking..."}]
+    assert result == []
 
 
 def test_compat_image_url_block() -> None:
@@ -3919,14 +3920,8 @@ def test_parse_chat_history_tool_calls_drops_foreign_non_standard_media() -> Non
     assert parts[0].function_call is not None
 
 
-@pytest.mark.parametrize("output_version", [None, "v1"])
-def test_parse_chat_history_tool_calls_foreign_reasoning_block(
-    output_version: str | None,
-) -> None:
-    """Replay OpenAI summary reasoning safely (regression for #1603)."""
-    response_metadata = {"model_provider": "openai"}
-    if output_version:
-        response_metadata["output_version"] = output_version
+def test_parse_chat_history_tool_calls_foreign_reasoning_block() -> None:
+    """Drop foreign reasoning blocks rather than replaying them as thoughts."""
     message = AIMessage(
         content=[
             {
@@ -3935,18 +3930,57 @@ def test_parse_chat_history_tool_calls_foreign_reasoning_block(
             }
         ],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata=response_metadata,
+        response_metadata={"model_provider": "openai", "output_version": "v1"},
     )
 
     _, formatted_messages = _parse_chat_history([message])
 
     parts = formatted_messages[0].parts
     assert parts is not None
-    assert len(parts) == 2
-    assert parts[0].thought is True
-    assert parts[0].text == "I should search."
-    assert parts[0].thought_signature is None
-    assert parts[1].function_call is not None
+    assert len(parts) == 1
+    assert parts[0].function_call is not None
+
+
+def test_parse_chat_history_drops_bedrock_v1_reasoning_block() -> None:
+    """Bedrock chain-of-thought must not leak into Gemini requests."""
+    bedrock_reply = AIMessage(
+        content=[
+            {
+                "type": "reasoning_content",
+                "reasoning_content": {
+                    "text": "Considering Paris.",
+                    "signature": "bedrock-sig",
+                },
+            },
+            {"type": "text", "text": "Paris."},
+        ],
+        response_metadata={"model_provider": "bedrock_converse"},
+    )
+    for_gemini = bedrock_reply.model_copy(
+        update={
+            "content": bedrock_reply.content_blocks,
+            "response_metadata": {
+                **bedrock_reply.response_metadata,
+                "output_version": "v1",
+            },
+        }
+    )
+
+    _, contents = _parse_chat_history(
+        [
+            HumanMessage(content="Capital of France?"),
+            for_gemini,
+            HumanMessage(content="Of Italy?"),
+        ]
+    )
+
+    model = next(c for c in contents if c.role == "model")
+    parts = model.parts
+    assert parts is not None
+    assert all(part.thought is not True for part in parts)
+    assert [(part.thought, part.thought_signature, part.text) for part in parts] == [
+        (None, None, "Paris.")
+    ]
 
 
 def test_convert_to_parts_openai_summary_reasoning_without_metadata() -> None:

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -3920,8 +3920,18 @@ def test_parse_chat_history_tool_calls_drops_foreign_non_standard_media() -> Non
     assert parts[0].function_call is not None
 
 
-def test_parse_chat_history_tool_calls_foreign_reasoning_block() -> None:
-    """Drop foreign reasoning blocks rather than replaying them as thoughts."""
+@pytest.mark.parametrize("output_version", [None, "v1"])
+def test_parse_chat_history_tool_calls_foreign_reasoning_block(
+    output_version: str | None,
+) -> None:
+    """Drop foreign reasoning rather than replaying it as a thought (#1603).
+
+    Both the v1 and non-v1 conversions must drop it: `output_version` is stamped by
+    the producing integration, so it cannot decide whether foreign reasoning leaks.
+    """
+    response_metadata = {"model_provider": "openai"}
+    if output_version:
+        response_metadata["output_version"] = output_version
     message = AIMessage(
         content=[
             {
@@ -3930,7 +3940,7 @@ def test_parse_chat_history_tool_calls_foreign_reasoning_block() -> None:
             }
         ],
         tool_calls=[{"name": "search", "args": {}, "id": "call_1"}],
-        response_metadata={"model_provider": "openai", "output_version": "v1"},
+        response_metadata=response_metadata,
     )
 
     _, formatted_messages = _parse_chat_history([message])
@@ -3956,6 +3966,8 @@ def test_parse_chat_history_drops_bedrock_v1_reasoning_block() -> None:
         ],
         response_metadata={"model_provider": "bedrock_converse"},
     )
+    # Restamp as v1 content so replay goes through the v1 converter rather than
+    # the non-v1 path; both are covered, but this test pins the v1 one.
     for_gemini = bedrock_reply.model_copy(
         update={
             "content": bedrock_reply.content_blocks,
@@ -4230,9 +4242,10 @@ def test_parse_chat_history_handles_empty_thought_blocks(
             id="text",
         ),
         pytest.param(
+            # Foreign reasoning is dropped outright, not merely de-signatured.
             {"type": "reasoning", "reasoning": "I should search."},
-            "I should search.",
-            True,
+            None,
+            None,
             id="reasoning",
         ),
         pytest.param(

--- a/libs/genai/tests/unit_tests/test_content_conversion.py
+++ b/libs/genai/tests/unit_tests/test_content_conversion.py
@@ -119,12 +119,15 @@ def test_convert_from_v1_drops_foreign_reasoning_with_signature() -> None:
 def test_convert_from_v1_drops_foreign_reasoning_summary() -> None:
     """OpenAI-style summary blocks are dropped for foreign providers."""
     converted = _convert_from_v1_to_generativelanguage_v1beta(
-        [
-            {
-                "type": "reasoning",
-                "summary": [{"type": "summary_text", "text": "I should search."}],
-            }
-        ],
+        cast(
+            "Any",
+            [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "I should search."}],
+                }
+            ],
+        ),
         "openai",
     )
 

--- a/libs/genai/tests/unit_tests/test_content_conversion.py
+++ b/libs/genai/tests/unit_tests/test_content_conversion.py
@@ -99,6 +99,74 @@ def test_convert_to_parts_joins_multi_segment_summary() -> None:
     assert parts[0].thought is True
 
 
+def test_convert_from_v1_drops_foreign_reasoning_with_signature() -> None:
+    """Foreign reasoning blocks drop entirely; adjacent text still converts."""
+    converted = _convert_from_v1_to_generativelanguage_v1beta(
+        [
+            {
+                "type": "reasoning",
+                "reasoning": "Considering Paris.",
+                "extras": {"signature": "bedrock-sig"},
+            },
+            {"type": "text", "text": "Paris."},
+        ],
+        "bedrock_converse",
+    )
+
+    assert converted == [{"text": "Paris."}]
+
+
+def test_convert_from_v1_drops_foreign_reasoning_summary() -> None:
+    """OpenAI-style summary blocks are dropped for foreign providers."""
+    converted = _convert_from_v1_to_generativelanguage_v1beta(
+        [
+            {
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "I should search."}],
+            }
+        ],
+        "openai",
+    )
+
+    assert converted == []
+
+
+def test_convert_from_v1_keeps_native_reasoning_with_signature() -> None:
+    """Regression guard: native signed reasoning still becomes a thought part."""
+    converted = _convert_from_v1_to_generativelanguage_v1beta(
+        [
+            {
+                "type": "reasoning",
+                "reasoning": "Thinking.",
+                "extras": {"signature": "c2ln"},
+            }
+        ],
+        "google_genai",
+    )
+
+    assert converted == [
+        {"thought": True, "text": "Thinking.", "thought_signature": "c2ln"}
+    ]
+
+
+def test_convert_from_v1_keeps_unknown_provider_reasoning() -> None:
+    """Regression guard: provider-less checkpoints stay lenient."""
+    converted = _convert_from_v1_to_generativelanguage_v1beta(
+        [
+            {
+                "type": "reasoning",
+                "reasoning": "Thinking.",
+                "extras": {"signature": "c2ln"},
+            }
+        ],
+        None,
+    )
+
+    assert converted == [
+        {"thought": True, "text": "Thinking.", "thought_signature": "c2ln"}
+    ]
+
+
 def test_convert_from_v1_keeps_base64_media_undecoded() -> None:
     """Leave base64 decoding to SDK validation to avoid double encoding."""
     converted = _convert_from_v1_to_generativelanguage_v1beta(


### PR DESCRIPTION
## Problem

When alternating between another provider (e.g. `ChatBedrockConverse`, `ChatOpenAI`) and `ChatGoogleGenerativeAI`, foreign reasoning text leaked into Gemini requests: a `reasoning` block produced by another provider was converted into a Gemini thought part.

```python
from langchain_core.messages import AIMessage, HumanMessage
from langchain_google_genai.chat_models import _parse_chat_history

openai_reply = AIMessage(
    content=[
        {"type": "reasoning", "summary": [{"type": "summary_text", "text": "SECRET COT"}]},
        {"type": "text", "text": "Paris."},
    ],
    response_metadata={"model_provider": "openai"},
)
_, contents = _parse_chat_history(
    [HumanMessage("Capital of France?"), openai_reply, HumanMessage("Of Italy?")]
)
model = next(c for c in contents if c.role == "model")
print([(p.thought, p.text) for p in model.parts or []])
```

Before:

```
[(True, 'SECRET COT'), (None, 'Paris.')]   # OpenAI CoT sent back as a Gemini thought part
```

After:

```
[(None, 'Paris.')]
```

This is reached by any ordinary multi-model flow — `.with_fallbacks()`, a cost/capability router, or a LangGraph checkpoint resumed after the graph's model config changed.

## Fix

Foreign reasoning (source `model_provider` not `google_genai` / `google_vertexai`) is now dropped on **both** conversion paths:

- **v1** — `_convert_from_v1_to_generativelanguage_v1beta` (`_compat.py`). Previously the foreign signature was withheld but the text was still emitted as `{"thought": True, "text": ...}`; the empty-block guard only dropped foreign blocks with no text at all.
- **non-v1** — `_prepare_ai_message_content` (`chat_models.py`). Previously `_strip_foreign_signature` removed only the signature and kept the text, which `_convert_to_parts_lenient` then emitted as `Part(text=..., thought=True)`.

Covering only the v1 path would have left the leak open in the default case. `output_version` is stamped by the *producing* integration and is not a property of the content, so it cannot be what decides whether foreign reasoning leaks — the same message leaked or not depending on a setting on another provider's model object, and callers who have not opted into v1 output take the non-v1 path.

The v1 log was also raised from `info` to `warning`, matching every sibling drop site in `_compat.py` (`:44`, `:196`, `:233`, `:398`, `:408`). Python's root logger defaults to `WARNING`, so the drop was invisible under default configuration while the downstream empty-parts fallback (added in cc4cc80) still warned — users saw the symptom with no cause.

`native` and `unknown` (no `model_provider`, e.g. older checkpoints) behavior is unchanged; `unknown` stays lenient so same-provider round-trips without metadata keep working. Text blocks, tool calls, citations, media, and `non_standard` handling are untouched.

This mirrors the AWS-side fix in langchain-aws#1206 (langchain-aws 1.7.3) so behavior is symmetric across providers.
