### PR TITLE
fix(genai): select thinking param by model family when both are set

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -3058,7 +3058,8 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     !!! note "Replaces `thinking_budget`"
 
         `thinking_budget` is deprecated for Gemini 3+ models. If both parameters are
-        provided, this field takes precedence.
+        provided, the one matching the model family is used: `thinking_level` for
+        Gemini 3+ models and `thinking_budget` for Gemini 2.x models.
 
         If left unspecified, the model's default thinking level is used.
 
@@ -3082,8 +3083,10 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
     !!! note "Precedence"
 
         If `thinking_config` is provided together with flat thinking arguments,
-        the flat arguments take precedence for matching fields. After merging,
-        `thinking_level` takes precedence over `thinking_budget` for Gemini 3+ models.
+        the flat arguments take precedence for matching fields. After merging, if
+        both `thinking_level` and `thinking_budget` are present, the one matching
+        the model family is used: `thinking_level` for Gemini 3+ models and
+        `thinking_budget` for Gemini 2.x models.
     """
 
     cached_content: str | None = None
@@ -3521,16 +3524,31 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
         if include_thoughts is not None:
             config["include_thoughts"] = include_thoughts
 
-        # thinking_level takes precedence over thinking_budget for Gemini 3+ models
+        # `thinking_level` (Gemini 3+) and `thinking_budget` (Gemini 2.x) map to
+        # different, mutually exclusive API fields. When both are set, keep the one
+        # that matches the target model so a single configuration can drive both
+        # model families.
         if "thinking_level" in config and "thinking_budget" in config:
-            warnings.warn(
-                "Both 'thinking_level' and 'thinking_budget' were set after merging "
-                "thinking configuration values. 'thinking_level' takes precedence "
-                "for Gemini 3+ models; 'thinking_budget' will be ignored.",
-                UserWarning,
-                stacklevel=2,
-            )
-            config.pop("thinking_budget")
+            if _is_gemini_3_or_later(self.model):
+                warnings.warn(
+                    "Both 'thinking_level' and 'thinking_budget' were set after "
+                    "merging thinking configuration values. 'thinking_level' takes "
+                    "precedence for Gemini 3+ models; 'thinking_budget' will be "
+                    "ignored.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                config.pop("thinking_budget")
+            else:
+                warnings.warn(
+                    "Both 'thinking_level' and 'thinking_budget' were set after "
+                    "merging thinking configuration values. 'thinking_budget' takes "
+                    "precedence for Gemini 2.x models; 'thinking_level' will be "
+                    "ignored.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                config.pop("thinking_level")
 
         return ThinkingConfig(**config)
 

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -6219,6 +6219,39 @@ def test_thinking_level_takes_precedence_over_thinking_budget() -> None:
         assert config.thinking_config.thinking_budget is None
 
 
+def test_thinking_budget_takes_precedence_for_gemini_2x() -> None:
+    """Test `thinking_budget` wins over `thinking_level` for Gemini 2.x models.
+
+    Regression test for a bug where `thinking_level` was applied regardless of
+    model version, so a config carrying both parameters (to target 2.x and 3.x
+    interchangeably) silently dropped `thinking_budget` even on Gemini 2.x, where
+    `thinking_level` is not supported.
+    """
+    with warnings.catch_warnings(record=True) as warning_list:
+        warnings.simplefilter("always")
+
+        llm = ChatGoogleGenerativeAI(
+            model="gemini-2.5-flash",
+            google_api_key=SecretStr(FAKE_API_KEY),
+            thinking_level="low",
+            thinking_budget=128,
+        )
+
+        msg = HumanMessage(content="test")
+        request = llm._prepare_request([msg])
+        config = request["config"]
+
+        assert len(warning_list) == 1
+        assert issubclass(warning_list[0].category, UserWarning)
+        assert "thinking_budget' takes precedence" in str(warning_list[0].message)
+
+        # Check that thinking_budget is used and thinking_level is ignored
+        assert config.thinking_config is not None
+        assert config.thinking_config.thinking_budget == 128
+        # Pydantic models define all fields; check value is None rather than hasattr
+        assert config.thinking_config.thinking_level is None
+
+
 def test_thinking_budget_alone_still_works() -> None:
     """Test that `thinking_budget` still works when `thinking_level` is not provided."""
     llm = ChatGoogleGenerativeAI(


### PR DESCRIPTION
**Description:** When both `thinking_level` and `thinking_budget` are set, `_build_thinking_config` always dropped `thinking_budget`, regardless of the model version. The accompanying warning claims `thinking_level` takes precedence "for Gemini 3+ models", but the code applied that precedence to every model, including Gemini 2.x where `thinking_level` is not supported.

This breaks the documented pattern of building a single model configuration that carries both parameters so it can target either family: `thinking_budget` for Gemini 2.x and `thinking_level` for Gemini 3+. On a Gemini 2.x model, `thinking_budget` was silently discarded and the request went out with an unsupported `thinking_level` instead.

**Reproduction (no API key needed):**

```python
import warnings
from pydantic import SecretStr
from langchain_core.messages import HumanMessage
from langchain_google_genai import ChatGoogleGenerativeAI

for model in ("gemini-2.5-flash", "gemini-3.5-flash"):
    llm = ChatGoogleGenerativeAI(
        model=model,
        google_api_key=SecretStr("k"),
        thinking_level="low",
        thinking_budget=128,
    )
    with warnings.catch_warnings(record=True):
        warnings.simplefilter("always")
        cfg = llm._prepare_request([HumanMessage(content="hi")])["config"].thinking_config
    print(f"{model:20s} level={cfg.thinking_level} budget={cfg.thinking_budget}")
```

Before this PR:

```
gemini-2.5-flash     level=ThinkingLevel.LOW budget=None   # thinking_budget wrongly dropped
gemini-3.5-flash     level=ThinkingLevel.LOW budget=None
```

After this PR:

```
gemini-2.5-flash     level=None budget=128                 # thinking_budget kept for 2.x
gemini-3.5-flash     level=ThinkingLevel.LOW budget=None   # thinking_level kept for 3+
```

**Fix:** When both parameters survive merging, keep the one matching the target model family using the existing `_is_gemini_3_or_later(self.model)` helper: `thinking_level` for Gemini 3+, `thinking_budget` for Gemini 2.x. The warning now names the parameter that was dropped and the family it applies to. Docstrings for `reasoning_effort`/`thinking_level` and `thinking_config` are updated to describe the version-aware selection.

**Issue:** Fixes #1462

**Dependencies:** None

**Changes:**

- `libs/genai/langchain_google_genai/chat_models.py`: version-aware selection in `_build_thinking_config`, plus docstring updates.
- `libs/genai/tests/unit_tests/test_chat_models.py`: added `test_thinking_budget_takes_precedence_for_gemini_2x`.

Existing `thinking_level` precedence tests (which use a Gemini 3+ model) still pass unchanged. Full `tests/unit_tests/test_chat_models.py` run: 409 passed.
