### PR TITLE
fix(genai): disable SDK automatic function calling to silence AFC warning

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -31,6 +31,7 @@ import filetype  # type: ignore[import-untyped]
 from google.genai.client import Client
 from google.genai.errors import ClientError, ServerError
 from google.genai.types import (
+    AutomaticFunctionCallingConfig,
     Blob,
     Candidate,
     CodeExecutionResult,
@@ -3940,6 +3941,17 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
                 for parameter in ignored_parameters:
                     request_params.pop(parameter, None)
 
+        # LangChain runs its own tool-execution loop and only ever sends tool
+        # *declarations* (schemas) to the API, never Python callables. Disable
+        # the SDK's Automatic Function Calling by default so it does not run its
+        # AFC loop or emit the "Direct use of automatic function calling (AFC)
+        # in Models.generate_content is not recommended" warning. A caller may
+        # still override this by passing `automatic_function_calling` explicitly.
+        automatic_function_calling = kwargs.pop(
+            "automatic_function_calling",
+            AutomaticFunctionCallingConfig(disable=True),
+        )
+
         return GenerateContentConfig(
             tools=list(formatted_tools) if formatted_tools else None,
             tool_config=formatted_tool_config,
@@ -3949,6 +3961,7 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             http_options=http_options,
             image_config=image_config_obj,
             labels=labels,
+            automatic_function_calling=automatic_function_calling,
             **request_params,
             **kwargs,
         )

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -15,6 +15,7 @@ from unittest.mock import ANY, AsyncMock, Mock, patch
 import pytest
 from google.genai.errors import ClientError, ServerError
 from google.genai.types import (
+    AutomaticFunctionCallingConfig,
     Blob,
     Candidate,
     Content,
@@ -6312,6 +6313,60 @@ def test_thinking_config_object_is_propagated() -> None:
     assert config.thinking_config is not None
     assert config.thinking_config.include_thoughts is True
     assert config.thinking_config.thinking_budget == 512
+
+
+def test_automatic_function_calling_disabled_by_default() -> None:
+    """Test AFC is disabled on the request config.
+
+    LangChain runs its own tool-execution loop and only sends tool declarations
+    to the API, so the SDK's Automatic Function Calling must be disabled.
+    Leaving it enabled makes the SDK log the "Direct use of automatic function
+    calling (AFC) in Models.generate_content is not recommended" warning
+    (regression test for issue #1978).
+    """
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+
+    request = llm._prepare_request([HumanMessage(content="test")])
+    afc = request["config"].automatic_function_calling
+    assert afc is not None
+    assert afc.disable is True
+
+
+def test_automatic_function_calling_disabled_with_tools() -> None:
+    """Test AFC stays disabled when tools are bound (regression for #1978)."""
+
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+
+    request = llm._prepare_request([HumanMessage(content="test")], tools=[add])
+    afc = request["config"].automatic_function_calling
+    assert afc is not None
+    assert afc.disable is True
+
+
+def test_automatic_function_calling_caller_override_is_honored() -> None:
+    """Test an explicit `automatic_function_calling` overrides the default."""
+    llm = ChatGoogleGenerativeAI(
+        model=MODEL_NAME,
+        google_api_key=SecretStr(FAKE_API_KEY),
+    )
+
+    request = llm._prepare_request(
+        [HumanMessage(content="test")],
+        automatic_function_calling=AutomaticFunctionCallingConfig(disable=False),
+    )
+    afc = request["config"].automatic_function_calling
+    assert afc is not None
+    assert afc.disable is False
 
 
 @pytest.mark.parametrize(

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -74,6 +74,9 @@ from langchain_google_genai import (
 from langchain_google_genai._compat import (
     _convert_from_v1_to_generativelanguage_v1beta,
 )
+from langchain_google_genai._function_utils import (
+    convert_to_genai_function_declarations,
+)
 from langchain_google_genai.chat_models import (
     _FUNCTION_CALL_THOUGHT_SIGNATURES_MAP_KEY,
     DUMMY_THOUGHT_SIGNATURE,
@@ -6347,7 +6350,10 @@ def test_automatic_function_calling_disabled_with_tools() -> None:
         google_api_key=SecretStr(FAKE_API_KEY),
     )
 
-    request = llm._prepare_request([HumanMessage(content="test")], tools=[add])
+    request = llm._prepare_request(
+        [HumanMessage(content="test")],
+        tools=convert_to_genai_function_declarations([add]),
+    )
     afc = request["config"].automatic_function_calling
     assert afc is not None
     assert afc.disable is True


### PR DESCRIPTION
## Bug

Every request through `ChatGoogleGenerativeAI` makes the underlying `google-genai` SDK log:

```
Direct use of automatic function calling (AFC) in Models.generate_content is not recommended. Instead, we recommend to use AFC in Chat.send_message. Similarly, direct use of AFC in Models.generate_content_stream is not recommended.
```

This happens even with no tools bound (reproduction from #1978):

```python
from langchain_google_genai import ChatGoogleGenerativeAI

llm = ChatGoogleGenerativeAI(model="gemini-3.6-flash")
llm.invoke("Explain APIs in one sentence.")  # logs the AFC warning
```

Fixes #1978

## Root cause

`_build_request_config` never sets `automatic_function_calling` on the
`GenerateContentConfig`. The SDK defaults AFC to **enabled**, so
`google.genai` takes its AFC code path in `Models.generate_content` /
`generate_content_stream` and emits the "not recommended" warning
(`google/genai/models.py`, gated on `should_disable_afc`).

LangChain does not want the SDK's AFC loop at all: it runs its own
tool-execution loop and only ever sends tool *declarations* (schemas) to the
API, never Python callables. So AFC should be turned off on the request.

## Fix

Default `automatic_function_calling` to `AutomaticFunctionCallingConfig(disable=True)`
in `_build_request_config`, while still honoring an explicit
`automatic_function_calling` passed by the caller. With `disable=True` the SDK's
`should_disable_afc()` short-circuits before the warning is ever logged.

## Verification

Confirmed against the installed SDK without any API key:

- Before: `request["config"].automatic_function_calling is None` -> SDK runs AFC and logs the warning.
- After: `automatic_function_calling.disable is True`; `google.genai._extra_utils.should_disable_afc(config)` returns `True` and emits **no** warning.
- Caller override still works: passing `automatic_function_calling=AutomaticFunctionCallingConfig(disable=False)` is preserved.

## Tests

Added three regression tests in `test_chat_models.py`:

- `test_automatic_function_calling_disabled_by_default`
- `test_automatic_function_calling_disabled_with_tools`
- `test_automatic_function_calling_caller_override_is_honored`

Full `tests/unit_tests/test_chat_models.py` suite: **412 passed**. `ruff check` and `ruff format` clean.
