### PR TITLE
fix(genai): apply max_retries at client level so streaming honors it

### DIFF
--- a/libs/genai/langchain_google_genai/chat_models.py
+++ b/libs/genai/langchain_google_genai/chat_models.py
@@ -3250,6 +3250,18 @@ class ChatGoogleGenerativeAI(_BaseGoogleGenerativeAI, BaseChatModel):
             base_url=cast("str", base_url),
             api_version=self.api_version,
             headers=headers,
+            # Set client-level retries so all code paths honor `max_retries`.
+            # Per-request `HttpRetryOptions` only reach non-streaming calls;
+            # `async_request_streamed` in the SDK does not forward per-request
+            # `http_options`, so without a client-level default, streaming
+            # requests (used by `_astream` / agentic workloads) would get zero
+            # retries regardless of `max_retries`. `max_retries=0` is left as
+            # `None` so the SDK default applies (see the `max_retries` docstring).
+            retry_options=(
+                HttpRetryOptions(attempts=self.max_retries)
+                if self.max_retries
+                else None
+            ),
             client_args=self.client_args,
             async_client_args=self.client_args,
         )

--- a/libs/genai/tests/unit_tests/test_chat_models.py
+++ b/libs/genai/tests/unit_tests/test_chat_models.py
@@ -826,6 +826,52 @@ def test_api_version_forwarded_to_http_options_gemini() -> None:
         assert call_http_options.api_version == "v1"
 
 
+def test_max_retries_sets_client_level_retry_options() -> None:
+    """`max_retries` sets client-level `retry_options` (regression for #1652).
+
+    Per-request `HttpRetryOptions` only reach non-streaming calls; the SDK's
+    streaming path does not forward them, so `max_retries` must also be applied
+    at client construction or streaming requests get zero retries.
+    """
+    with patch("langchain_google_genai.chat_models.Client") as mock_client:
+        ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            google_api_key=SecretStr(FAKE_API_KEY),
+            max_retries=5,
+        )
+        call_http_options = mock_client.call_args_list[0].kwargs["http_options"]
+        assert call_http_options.retry_options is not None
+        assert call_http_options.retry_options.attempts == 5
+
+
+def test_max_retries_defaults_to_client_level_retry_options() -> None:
+    """The default `max_retries` is applied at client level (regression #1652)."""
+    with patch("langchain_google_genai.chat_models.Client") as mock_client:
+        ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            google_api_key=SecretStr(FAKE_API_KEY),
+        )
+        call_http_options = mock_client.call_args_list[0].kwargs["http_options"]
+        assert call_http_options.retry_options is not None
+        assert call_http_options.retry_options.attempts == 6
+
+
+def test_max_retries_zero_defers_to_sdk_default() -> None:
+    """`max_retries=0` leaves `retry_options` unset so the SDK default applies.
+
+    `max_retries=0` is documented to mean "use the Google SDK default", so no
+    client-level `retry_options` should be forced (regression for #1652).
+    """
+    with patch("langchain_google_genai.chat_models.Client") as mock_client:
+        ChatGoogleGenerativeAI(
+            model=MODEL_NAME,
+            google_api_key=SecretStr(FAKE_API_KEY),
+            max_retries=0,
+        )
+        call_http_options = mock_client.call_args_list[0].kwargs["http_options"]
+        assert call_http_options.retry_options is None
+
+
 def test_api_version_forwarded_to_http_options_vertex() -> None:
     """`api_version` is forwarded into `HttpOptions` for the Vertex backend.
 


### PR DESCRIPTION
## Bug

`max_retries` on `ChatGoogleGenerativeAI` is silently ignored for **streaming**
requests. A transient error (e.g. a 429 `RESOURCE_EXHAUSTED`) during a streaming
call fails immediately with no retries, even with `max_retries` set. Streaming is
the path used by `_astream` and by agentic workloads (LangGraph), so a single
transient 429 fails the whole turn.

Fixes #1652

## Root cause

`max_retries` was only attached as **per-request** `HttpRetryOptions` on the
`GenerateContentConfig`. That works for non-streaming calls, but the google-genai
SDK's streaming path, `async_request_streamed`, does not forward per-request
`http_options` to `_async_request`. Streaming therefore falls back to the
**client-level** retry, which `ChatGoogleGenerativeAI` never configured, so the
client defaulted to a single attempt (zero retries).

Reproduction (deterministic, no network call needed):

```python
from langchain_google_genai import ChatGoogleGenerativeAI

m = ChatGoogleGenerativeAI(model="gemini-2.5-flash", max_retries=5)
ac = m.client._api_client
print(ac._http_options.retry_options)              # None
print(ac._async_retry.stop.max_attempt_number)     # 1  (expected 5)
```

## Fix

Pass `retry_options` into the client-level `HttpOptions` used to construct the
`genai.Client`, so every code path (streaming included) honors `max_retries`.
`max_retries=0` is left unset so the SDK default applies, matching the documented
behavior in the `max_retries` field docstring (`0` means "use the SDK default").

After the fix:

| `max_retries` | client `retry_options.attempts` | client max attempts |
| --- | --- | --- |
| `5` | `5` | `5` |
| default (`6`) | `6` | `6` |
| `1` | `1` | `1` |
| `0` | `None` (SDK default) | SDK default |

The upstream SDK gap (`async_request_streamed` dropping per-request
`http_options`) is a separate issue for googleapis/python-genai; setting the
client-level default is the correct and complete fix on the LangChain side.

## Tests

Added three regression tests in `test_chat_models.py`:

- `test_max_retries_sets_client_level_retry_options`
- `test_max_retries_defaults_to_client_level_retry_options`
- `test_max_retries_zero_defers_to_sdk_default`

Full `tests/unit_tests/test_chat_models.py`: **414 passed**. `ruff check` and
`ruff format` clean.
