### PR TITLE
test(vertexai): cover cache tokens in Anthropic usage metadata

### DIFF
--- a/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
+++ b/libs/vertexai/tests/unit_tests/test_anthropic_utils.py
@@ -8,6 +8,7 @@ from anthropic.types import (
     RawContentBlockDeltaEvent,
     SignatureDelta,
     ThinkingDelta,
+    Usage,
 )
 from langchain_core.messages import (
     AIMessage,
@@ -20,6 +21,7 @@ from langchain_core.messages.content import create_image_block, create_text_bloc
 from langchain_core.messages.tool import tool_call as create_tool_call
 
 from langchain_google_vertexai._anthropic_utils import (
+    _create_usage_metadata,
     _documents_in_params,
     _format_image,
     _format_message_anthropic,
@@ -1696,3 +1698,45 @@ def test_format_messages_anthropic_preserves_trailing_thinking_block() -> None:
     ]
     _, formatted = _format_messages_anthropic(messages, project="test-project")
     assert formatted[-1]["content"][0]["thinking"] == "considering...  "
+
+
+def test_create_usage_metadata_reports_cache_tokens_in_input_token_details() -> None:
+    """Cache counts belong in ``input_token_details``, not at the top level."""
+    usage = Usage(
+        input_tokens=14,
+        output_tokens=10,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+    assert _create_usage_metadata(usage) == {
+        "input_tokens": 14,
+        "output_tokens": 10,
+        "total_tokens": 24,
+        "input_token_details": {"cache_read": 0, "cache_creation": 0},
+    }
+
+
+def test_create_usage_metadata_counts_cache_tokens_in_input_tokens() -> None:
+    """Anthropic reports ``input_tokens`` exclusive of cached tokens."""
+    usage = Usage(
+        input_tokens=5,
+        output_tokens=7,
+        cache_read_input_tokens=100,
+        cache_creation_input_tokens=50,
+    )
+    assert _create_usage_metadata(usage) == {
+        "input_tokens": 155,
+        "output_tokens": 7,
+        "total_tokens": 162,
+        "input_token_details": {"cache_read": 100, "cache_creation": 50},
+    }
+
+
+def test_create_usage_metadata_omits_details_without_cache_fields() -> None:
+    """No ``input_token_details`` key when the payload carries no cache counts."""
+    usage = Usage(input_tokens=3, output_tokens=4)
+    assert _create_usage_metadata(usage) == {
+        "input_tokens": 3,
+        "output_tokens": 4,
+        "total_tokens": 7,
+    }


### PR DESCRIPTION
Relates to #1011.

While looking at #1011 I found the reported behaviour is already correct on `main` — `_create_usage_metadata()` puts Anthropic cache counts in `input_token_details` and folds them into `input_tokens`. Running the issue's own repro gives exactly the output it asks for:

```python
{'input_tokens': 14, 'output_tokens': 10, 'total_tokens': 24,
 'input_token_details': {'cache_read': 0, 'cache_creation': 0}}
```

But nothing in `tests/unit_tests/` exercises that helper, so the fix isn't pinned. This PR adds three cases:

- cache fields present but zero → `input_token_details` still reported (the issue's repro; easy to regress by treating `0` as absent)
- non-zero cache counts → folded into `input_tokens` / `total_tokens`
- provider omits the cache fields → `input_token_details` omitted entirely

Tests only, no source changes. `#1011` can probably be closed once someone confirms the streaming side too — `message_start` routes through the same helper, and `message_delta` intentionally reports output tokens only, matching `langchain_anthropic`.

```
$ uv run pytest tests/unit_tests/test_anthropic_utils.py
65 passed in 1.44s

$ uv run ruff check tests/unit_tests/test_anthropic_utils.py
All checks passed!

$ uv run ruff format --check tests/unit_tests/test_anthropic_utils.py
1 file already formatted
```

---

AI disclaimer (per `AGENTS.md`): I used an AI coding assistant to help investigate the issue and draft these tests. I reviewed every line, confirmed the current behaviour by running the helper directly, and ran the checks above.